### PR TITLE
Add Travis badge and Fix Access of Resources in Tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,7 @@
 language: rust
-rust:
-  - stable
-  - nightly
 before_script:
+  - rustup install stable
+  - rustup install nightly
   - rustup component add rustfmt --toolchain nightly
   - rustup component add clippy
 script:

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 </p>
 
 # Mamba
+[![Travis Build Status](https://travis-ci.org/JSAbrahams/mamba.svg?branch=master)](https://travis-ci.org/JSAbrahams/mamba)
 
 This is the Mamba programming language. 
 The Documentation can be found [here](https://github.com/JSAbrahams/mamba_doc).

--- a/tests/util.rs
+++ b/tests/util.rs
@@ -15,7 +15,11 @@ macro_rules! assert_ok {
 pub fn resource_string_content(file: String) -> String {
     let mut content = String::new();
     let mut source_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-    source_path.push("tests\\resources\\".to_owned());
+    source_path.push(if cfg!(windows) {
+                         String::from("tests\\resources\\")
+                     } else {
+                         String::from("tests/resources/")
+                     });
     source_path.push(file);
 
     match source_path.to_str() {
@@ -31,4 +35,10 @@ pub fn resource_string_content(file: String) -> String {
     return content;
 }
 
-pub fn valid_resource(file: &str) -> String { resource_string_content("valid\\".to_owned() + file) }
+pub fn valid_resource(file: &str) -> String {
+    if cfg!(windows) {
+        resource_string_content(format!("{}{}", "valid\\", file))
+    } else {
+        resource_string_content(format!("{}{}", "valid/", file))
+    }
+}


### PR DESCRIPTION
### Relevant issues
...

### Summary
- Add Travis build status badge to README.
- Install cargo first in the Travis build.
- Access test resources using backslash on windows systems and forward slash on Unix systems.

### Added Tests
...