### PR TITLE
Add tests for lexer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,3 +48,4 @@ script:
   - rm -rf kcov-master
   - for file in target/debug/deps/smoke-*[^\.d]; do mkdir -p "target/cov/$(basename $file)"; kcov --exclude-pattern=/.cargo,/usr/lib --verify "target/cov/$(basename $file)" "$file"; done
   - for file in target/debug/deps/parser-*[^\.d]; do mkdir -p "target/cov/$(basename $file)"; kcov --exclude-pattern=/.cargo,/usr/lib --verify "target/cov/$(basename $file)" "$file"; done
+  - for file in target/debug/deps/lexer-*[^\.d]; do mkdir -p "target/cov/$(basename $file)"; kcov --exclude-pattern=/.cargo,/usr/lib --verify "target/cov/$(basename $file)" "$file"; done

--- a/src/desugarer/expression.rs
+++ b/src/desugarer/expression.rs
@@ -40,7 +40,10 @@ pub fn desugar_expression(node_pos: &ASTNodePos) -> Core {
 
         ASTNode::Int { lit } => Core::Int { int: lit.clone() },
         ASTNode::Real { lit } => Core::Float { float: lit.clone() },
-        ASTNode::ENum { num, exp } => Core::ENum { num: num.clone(), exp: exp.clone() },
+        ASTNode::ENum { num, exp } => Core::ENum {
+            num: num.clone(),
+            exp: if exp.is_empty() { String::from("0") } else { exp.clone() }
+        },
         ASTNode::Str { lit } => Core::Str { _str: lit.clone() },
 
         ASTNode::IdType { id, _type } => desugar_expression(id),
@@ -58,7 +61,6 @@ pub fn desugar_expression(node_pos: &ASTNodePos) -> Core {
         ASTNode::ReturnEmpty => Core::Return { expr: Box::from(Core::Empty) },
         ASTNode::Return { expr } => Core::Return { expr: Box::from(desugar_expression(expr)) },
         ASTNode::Print { expr } => Core::Print { expr: Box::from(desugar_expression(expr)) },
-        ASTNode::PrintLn { expr } => Core::Print { expr: Box::from(desugar_expression(expr)) },
 
         ASTNode::IfElse { cond, then, _else } => match _else {
             Some(_else) => Core::IfElse { cond:  desugar_vec(cond),

--- a/src/desugarer/expression.rs
+++ b/src/desugarer/expression.rs
@@ -40,10 +40,9 @@ pub fn desugar_expression(node_pos: &ASTNodePos) -> Core {
 
         ASTNode::Int { lit } => Core::Int { int: lit.clone() },
         ASTNode::Real { lit } => Core::Float { float: lit.clone() },
-        ASTNode::ENum { num, exp } => Core::ENum {
-            num: num.clone(),
-            exp: if exp.is_empty() { String::from("0") } else { exp.clone() }
-        },
+        ASTNode::ENum { num, exp } =>
+            Core::ENum { num: num.clone(),
+                         exp: if exp.is_empty() { String::from("0") } else { exp.clone() } },
         ASTNode::Str { lit } => Core::Str { _str: lit.clone() },
 
         ASTNode::IdType { id, _type } => desugar_expression(id),

--- a/src/lexer/mod.rs
+++ b/src/lexer/mod.rs
@@ -115,12 +115,16 @@ pub fn tokenize(input: &String) -> Result<Vec<TokenPos>, String> {
             '{' => next_pos_and_tp!(1, Token::LCBrack),
             '}' => next_pos_and_tp!(1, Token::RCBrack),
             '?' => match (it.next(), it.peek()) {
+                (_, Some('.')) => next_pos_and_tp!(1, Token::QuestCall),
                 (_, Some('o')) => match (it.next(), it.peek()) {
-                    (_, Some('r')) => next_pos_and_tp!(3, Token::QuestOr),
+                    (_, Some('r')) => {
+                        next_pos_and_tp!(2, Token::QuestOr);
+                        pos += 3
+                    }
                     (_, Some(other)) => return Err(format!("Expected `?or`. Was '{}'.", other)),
                     (_, None) => return Err("Expected `?or`.".to_string())
                 },
-                _ => next_pos!(1, Token::Quest)
+                _ => next_pos!(0, Token::Quest)
             },
             '|' => next_pos_and_tp!(1, Token::Ver),
             '\n' => next_line_and_tp!(),

--- a/src/lexer/mod.rs
+++ b/src/lexer/mod.rs
@@ -15,7 +15,7 @@ macro_rules! next_and {
 }
 
 #[allow(clippy::cyclomatic_complexity)]
-pub fn tokenize(input: &str) -> Result<Vec<TokenPos>, String> {
+pub fn tokenize(input: &String) -> Result<Vec<TokenPos>, String> {
     let mut it = input.chars().peekable();
     let mut tokens = Vec::new();
 
@@ -263,7 +263,6 @@ fn get_string(it: &mut Peekable<Chars>, pos: &mut i32) -> Token {
 
 fn get_id_or_op(it: &mut Peekable<Chars>, pos: &mut i32) -> Token {
     let mut result = String::new();
-    *pos += 1;
 
     while let Some(&c) = it.peek() {
         match c {

--- a/src/lexer/mod.rs
+++ b/src/lexer/mod.rs
@@ -15,7 +15,7 @@ macro_rules! next_and {
 }
 
 #[allow(clippy::cyclomatic_complexity)]
-pub fn tokenize(input: &String) -> Result<Vec<TokenPos>, String> {
+pub fn tokenize(input: &str) -> Result<Vec<TokenPos>, String> {
     let mut it = input.chars().peekable();
     let mut tokens = Vec::new();
 

--- a/src/lexer/mod.rs
+++ b/src/lexer/mod.rs
@@ -100,10 +100,7 @@ pub fn tokenize(input: &String) -> Result<Vec<TokenPos>, String> {
                 },
                 _ => next_pos!(1, Token::Point)
             },
-            ':' => match (it.next(), it.peek()) {
-                (_, Some(':')) => next_pos_and_tp!(2, Token::DDoublePoint),
-                _ => next_pos!(1, Token::DoublePoint)
-            },
+            ':' => next_pos_and_tp!(1, Token::DoublePoint),
             '_' => next_pos_and_tp!(1, Token::Underscore),
             ',' => next_pos_and_tp!(1, Token::Comma),
             '(' => next_pos_and_tp!(1, Token::LRBrack),
@@ -184,7 +181,7 @@ fn get_operator(it: &mut Peekable<Chars>, pos: &mut i32) -> Token {
             _ => Token::Sub
         },
         Some('/') => match it.peek() {
-            Some('=') => next_and!(it, pos, Token::Eq),
+            Some('=') => next_and!(it, pos, Token::Neq),
             _ => Token::Div
         },
         Some('\\') => Token::BSlash,

--- a/src/lexer/mod.rs
+++ b/src/lexer/mod.rs
@@ -106,7 +106,7 @@ pub fn tokenize(input: &String) -> Result<Vec<TokenPos>, String> {
                 _ => next_pos!(1, Token::Point)
             },
             ':' => next_pos_and_tp!(1, Token::DoublePoint),
-            '_' => next_pos_and_tp!(1, Token::Underscore),
+            '_' => next_pos!(get_id_or_op),
             ',' => next_pos_and_tp!(1, Token::Comma),
             '(' => next_pos_and_tp!(1, Token::LRBrack),
             ')' => next_pos_and_tp!(1, Token::RRBrack),
@@ -275,6 +275,8 @@ fn get_id_or_op(it: &mut Peekable<Chars>, pos: &mut i32) -> Token {
     }
 
     match result.as_ref() {
+        "_" => Token::Underscore,
+
         "from" => Token::From,
         "type" => Token::Type,
         "stateful" => Token::Stateful,

--- a/src/lexer/mod.rs
+++ b/src/lexer/mod.rs
@@ -41,15 +41,19 @@ pub fn tokenize(input: &String) -> Result<Vec<TokenPos>, String> {
 
     macro_rules! indentation {
         () => {{
+            let mut indent_pos = 1;
             for _ in cur_ind..line_ind {
-                tokens.push(TokenPos { line, pos, token: Token::Indent });
+                tokens.push(TokenPos { line, pos: indent_pos, token: Token::Indent });
+                indent_pos += 4;
             }
             for _ in line_ind..cur_ind {
                 tokens.push(TokenPos { line, pos, token: Token::Dedent });
             }
+
             for _ in 1..cons_nl {
                 tokens.push(TokenPos { line, pos, token: Token::NL });
             }
+
             cur_ind = line_ind;
             cons_nl = 0;
             last_nl = false;
@@ -70,14 +74,15 @@ pub fn tokenize(input: &String) -> Result<Vec<TokenPos>, String> {
 
     macro_rules! next_line_and_tp {
         () => {{
-            cons_nl += 1;
-            line += 1;
-            pos = 1;
-
             if !last_nl {
                 cur_ind = line_ind;
                 tokens.push(TokenPos { line, pos, token: Token::NL });
             }
+
+            cons_nl += 1;
+            line += 1;
+            pos = 1;
+
             line_ind = 0;
             last_nl = true;
             it.next();
@@ -255,6 +260,7 @@ fn get_string(it: &mut Peekable<Chars>, pos: &mut i32) -> Token {
         }
     }
 
+    *pos += 1; // for closing " character
     Token::Str(result)
 }
 
@@ -315,10 +321,9 @@ fn get_id_or_op(it: &mut Peekable<Chars>, pos: &mut i32) -> Token {
         "retry" => Token::Retry,
         "when" => Token::When,
 
-        "true" => Token::Bool(true),
-        "false" => Token::Bool(false),
+        "True" => Token::Bool(true),
+        "False" => Token::Bool(false),
         "print" => Token::Print,
-        "println" => Token::PrintLn,
 
         "undefined" => Token::Undefined,
 

--- a/src/lexer/token.rs
+++ b/src/lexer/token.rs
@@ -100,6 +100,7 @@ pub enum Token {
 
     Quest,
     QuestOr,
+    QuestCall,
     Handle,
 
     Print,
@@ -197,6 +198,8 @@ impl fmt::Display for Token {
 
             Token::Quest => "?".to_string(),
             Token::QuestOr => "?or".to_string(),
+            Token::QuestCall => "?.".to_string(),
+
             Token::Handle => "handle".to_string(),
             Token::Raises => "raises".to_string(),
             Token::Retry => "retry".to_string(),

--- a/src/lexer/token.rs
+++ b/src/lexer/token.rs
@@ -103,7 +103,6 @@ pub enum Token {
     Handle,
 
     Print,
-    PrintLn,
 
     Undefined
 }
@@ -204,8 +203,6 @@ impl fmt::Display for Token {
             Token::When => "when".to_string(),
 
             Token::Print => "print".to_string(),
-            Token::PrintLn => "println".to_string(),
-
             Token::Undefined => "undefined".to_string()
         };
 

--- a/src/lexer/token.rs
+++ b/src/lexer/token.rs
@@ -27,7 +27,6 @@ pub enum Token {
     Point,
     Comma,
     DoublePoint,
-    DDoublePoint,
     Vararg,
     BSlash,
 
@@ -130,7 +129,6 @@ impl fmt::Display for Token {
             Token::Point => ".".to_string(),
             Token::Comma => ",".to_string(),
             Token::DoublePoint => ":".to_string(),
-            Token::DDoublePoint => "::".to_string(),
             Token::Vararg => "vararg".to_string(),
             Token::BSlash => "\\".to_string(),
 

--- a/src/parser/ast_node.rs
+++ b/src/parser/ast_node.rs
@@ -324,8 +324,5 @@ pub enum ASTNode {
 
     Print {
         expr: Box<ASTNodePos>
-    },
-    PrintLn {
-        expr: Box<ASTNodePos>
     }
 }

--- a/src/parser/expr_or_stmt.rs
+++ b/src/parser/expr_or_stmt.rs
@@ -22,7 +22,6 @@ pub fn parse_expr_or_stmt(it: &mut TPIterator) -> ParseResult {
         Some(TokenPos { token: Token::Def, .. })
         | Some(TokenPos { token: Token::Mut, .. })
         | Some(TokenPos { token: Token::Print, .. })
-        | Some(TokenPos { token: Token::PrintLn, .. })
         | Some(TokenPos { token: Token::For, .. })
         | Some(TokenPos { token: Token::While, .. })
         | Some(TokenPos { token: Token::Retry, .. }) => parse_statement(it),

--- a/src/parser/expression.rs
+++ b/src/parser/expression.rs
@@ -88,7 +88,6 @@ fn parse_post_expr(pre: ASTNodePos, it: &mut TPIterator) -> ParseResult {
 
         // normal method or function call
         Some(TokenPos { token: Token::LRBrack, .. })
-        | Some(TokenPos { token: Token::DDoublePoint, .. })
         | Some(TokenPos { token: Token::Point, .. }) => parse_call(pre, it),
         Some(&tp) if is_start_expression_exclude_unary(tp) => parse_call(pre, it),
 

--- a/src/parser/statement.rs
+++ b/src/parser/statement.rs
@@ -25,14 +25,6 @@ pub fn parse_statement(it: &mut TPIterator) -> ParseResult {
             let node = ASTNode::Print { expr };
             Ok(ASTNodePos { st_line, st_pos, en_line, en_pos, node })
         }
-        Some(TokenPos { token: Token::PrintLn, .. }) => {
-            it.next();
-            let expr: Box<ASTNodePos> = get_or_err!(it, parse_expression, "print line");
-
-            let (en_line, en_pos) = (expr.en_line, expr.en_pos);
-            let node = ASTNode::PrintLn { expr };
-            Ok(ASTNodePos { st_line, st_pos, en_line, en_pos, node })
-        }
         Some(TokenPos { token: Token::Retry, .. }) => {
             let (en_line, en_pos) = end_pos(it);
             it.next();

--- a/tests/lexer.rs
+++ b/tests/lexer.rs
@@ -1,0 +1,13 @@
+use mamba::lexer::token::Token;
+use mamba::lexer::token::TokenPos;
+use mamba::lexer::tokenize;
+
+#[test]
+fn parse_from() {
+    let source = String::from("from i use b");
+    let tokens = tokenize(&source).unwrap();
+    assert_eq!(tokens, vec![TokenPos { line: 1, pos: 1, token: Token::From },
+                            TokenPos { line: 1, pos: 6, token: Token::Id(String::from("i")) },
+                            TokenPos { line: 1, pos: 8, token: Token::Use },
+                            TokenPos { line: 1, pos: 12, token: Token::Id(String::from("b")) }]);
+}

--- a/tests/lexer.rs
+++ b/tests/lexer.rs
@@ -3,7 +3,7 @@ use mamba::lexer::token::TokenPos;
 use mamba::lexer::tokenize;
 
 #[test]
-fn parse_from() {
+fn lex_from() {
     let source = String::from("from i use b");
     let tokens = tokenize(&source).unwrap();
     assert_eq!(tokens,
@@ -14,7 +14,7 @@ fn parse_from() {
 }
 
 #[test]
-fn parse_operators() {
+fn lex_operators() {
     let source = String::from("+ - * / ^ mod sqrt i");
     let tokens = tokenize(&source).unwrap();
     assert_eq!(tokens,
@@ -30,7 +30,7 @@ fn parse_operators() {
 }
 
 #[test]
-fn test_comparison() {
+fn lex_comparison() {
     let source = String::from("< > <= >= = /= is isnt i");
     let tokens = tokenize(&source).unwrap();
     assert_eq!(tokens,
@@ -43,5 +43,46 @@ fn test_comparison() {
                     TokenPos { line: 1, pos: 16, token: Token::Is },
                     TokenPos { line: 1, pos: 19, token: Token::IsN },
                     TokenPos { line: 1, pos: 24, token: Token::Id(String::from("i")) }
+               ]);
+}
+
+#[test]
+fn lex_if() {
+    let source = String::from("if a then\n    b\nelse\n    c");
+    let tokens = tokenize(&source).unwrap();
+    assert_eq!(tokens,
+               vec![TokenPos { line: 1, pos: 1, token: Token::If },
+                    TokenPos { line: 1, pos: 4, token: Token::Id(String::from("a")) },
+                    TokenPos { line: 1, pos: 6, token: Token::Then },
+                    TokenPos { line: 1, pos: 10, token: Token::NL },
+                    TokenPos { line: 2, pos: 1, token: Token::Indent },
+                    TokenPos { line: 2, pos: 5, token: Token::Id(String::from("b")) },
+                    TokenPos { line: 2, pos: 6, token: Token::NL },
+                    TokenPos { line: 3, pos: 1, token: Token::Dedent },
+                    TokenPos { line: 3, pos: 1, token: Token::Else },
+                    TokenPos { line: 3, pos: 5, token: Token::NL },
+                    TokenPos { line: 4, pos: 1, token: Token::Indent },
+                    TokenPos { line: 4, pos: 5, token: Token::Id(String::from("c")) }
+               ]);
+}
+
+#[test]
+fn lex_numbers_and_strings() {
+    let source = String::from("1 2.0 3e10 5e 2 \"hello\" True False i");
+    let tokens = tokenize(&source).unwrap();
+
+    println!("{}", source);
+    assert_eq!(tokens,
+               vec![TokenPos { line: 1, pos: 1, token: Token::Int(String::from("1")) },
+                    TokenPos { line: 1, pos: 3, token: Token::Real(String::from("2.0")) },
+                    TokenPos { line: 1, pos: 7, token: Token::ENum(String::from("3"),
+                                                                   String::from("10")) },
+                    TokenPos { line: 1, pos: 12, token: Token::ENum(String::from("5"),
+                                                                    String::new()) },
+                    TokenPos { line: 1, pos: 15, token: Token::Int(String::from("2")) },
+                    TokenPos { line: 1, pos: 17, token: Token::Str(String::from("hello")) },
+                    TokenPos { line: 1, pos: 25, token: Token::Bool(true) },
+                    TokenPos { line: 1, pos: 30, token: Token::Bool(false) },
+                    TokenPos { line: 1, pos: 36, token: Token::Id(String::from("i")) }
                ]);
 }

--- a/tests/lexer.rs
+++ b/tests/lexer.rs
@@ -70,19 +70,37 @@ fn lex_if() {
 fn lex_numbers_and_strings() {
     let source = String::from("1 2.0 3e10 5e 2 \"hello\" True False i");
     let tokens = tokenize(&source).unwrap();
-
-    println!("{}", source);
     assert_eq!(tokens,
                vec![TokenPos { line: 1, pos: 1, token: Token::Int(String::from("1")) },
                     TokenPos { line: 1, pos: 3, token: Token::Real(String::from("2.0")) },
-                    TokenPos { line: 1, pos: 7, token: Token::ENum(String::from("3"),
-                                                                   String::from("10")) },
-                    TokenPos { line: 1, pos: 12, token: Token::ENum(String::from("5"),
-                                                                    String::new()) },
+                    TokenPos {
+                        line: 1,
+                        pos: 7,
+                        token: Token::ENum(String::from("3"),
+                                           String::from("10")),
+                    },
+                    TokenPos {
+                        line: 1,
+                        pos: 12,
+                        token: Token::ENum(String::from("5"),
+                                           String::new()),
+                    },
                     TokenPos { line: 1, pos: 15, token: Token::Int(String::from("2")) },
                     TokenPos { line: 1, pos: 17, token: Token::Str(String::from("hello")) },
                     TokenPos { line: 1, pos: 25, token: Token::Bool(true) },
                     TokenPos { line: 1, pos: 30, token: Token::Bool(false) },
                     TokenPos { line: 1, pos: 36, token: Token::Id(String::from("i")) }
+               ]);
+}
+
+#[test]
+fn lex_identifiers() {
+    let source = String::from("i _i 3a");
+    let tokens = tokenize(&source).unwrap();
+    assert_eq!(tokens,
+               vec![TokenPos { line: 1, pos: 1, token: Token::Id(String::from("i")) },
+                    TokenPos { line: 1, pos: 3, token: Token::Id(String::from("_i")) },
+                    TokenPos { line: 1, pos: 6, token: Token::Int(String::from("3")) },
+                    TokenPos { line: 1, pos: 7, token: Token::Id(String::from("a")) },
                ]);
 }

--- a/tests/lexer.rs
+++ b/tests/lexer.rs
@@ -6,101 +6,100 @@ use mamba::lexer::tokenize;
 fn lex_from() {
     let source = String::from("from i use b");
     let tokens = tokenize(&source).unwrap();
-    assert_eq!(tokens,
-               vec![TokenPos { line: 1, pos: 1, token: Token::From },
-                    TokenPos { line: 1, pos: 6, token: Token::Id(String::from("i")) },
-                    TokenPos { line: 1, pos: 8, token: Token::Use },
-                    TokenPos { line: 1, pos: 12, token: Token::Id(String::from("b")) }]);
+    assert_eq!(tokens, vec![TokenPos { line: 1, pos: 1, token: Token::From },
+                            TokenPos { line: 1, pos: 6, token: Token::Id(String::from("i")) },
+                            TokenPos { line: 1, pos: 8, token: Token::Use },
+                            TokenPos { line: 1, pos: 12, token: Token::Id(String::from("b")) }]);
 }
 
 #[test]
 fn lex_operators() {
     let source = String::from("+ - * / ^ mod sqrt i");
     let tokens = tokenize(&source).unwrap();
-    assert_eq!(tokens,
-               vec![TokenPos { line: 1, pos: 1, token: Token::Add },
-                    TokenPos { line: 1, pos: 3, token: Token::Sub },
-                    TokenPos { line: 1, pos: 5, token: Token::Mul },
-                    TokenPos { line: 1, pos: 7, token: Token::Div },
-                    TokenPos { line: 1, pos: 9, token: Token::Pow },
-                    TokenPos { line: 1, pos: 11, token: Token::Mod },
-                    TokenPos { line: 1, pos: 15, token: Token::Sqrt },
-                    TokenPos { line: 1, pos: 20, token: Token::Id(String::from("i")) }
-               ]);
+    assert_eq!(tokens, vec![TokenPos { line: 1, pos: 1, token: Token::Add },
+                            TokenPos { line: 1, pos: 3, token: Token::Sub },
+                            TokenPos { line: 1, pos: 5, token: Token::Mul },
+                            TokenPos { line: 1, pos: 7, token: Token::Div },
+                            TokenPos { line: 1, pos: 9, token: Token::Pow },
+                            TokenPos { line: 1, pos: 11, token: Token::Mod },
+                            TokenPos { line: 1, pos: 15, token: Token::Sqrt },
+                            TokenPos { line: 1, pos: 20, token: Token::Id(String::from("i")) }]);
 }
 
 #[test]
 fn lex_comparison() {
     let source = String::from("< > <= >= = /= is isnt i");
     let tokens = tokenize(&source).unwrap();
-    assert_eq!(tokens,
-               vec![TokenPos { line: 1, pos: 1, token: Token::Le },
-                    TokenPos { line: 1, pos: 3, token: Token::Ge },
-                    TokenPos { line: 1, pos: 5, token: Token::Leq },
-                    TokenPos { line: 1, pos: 8, token: Token::Geq },
-                    TokenPos { line: 1, pos: 11, token: Token::Eq },
-                    TokenPos { line: 1, pos: 13, token: Token::Neq },
-                    TokenPos { line: 1, pos: 16, token: Token::Is },
-                    TokenPos { line: 1, pos: 19, token: Token::IsN },
-                    TokenPos { line: 1, pos: 24, token: Token::Id(String::from("i")) }
-               ]);
+    assert_eq!(tokens, vec![TokenPos { line: 1, pos: 1, token: Token::Le },
+                            TokenPos { line: 1, pos: 3, token: Token::Ge },
+                            TokenPos { line: 1, pos: 5, token: Token::Leq },
+                            TokenPos { line: 1, pos: 8, token: Token::Geq },
+                            TokenPos { line: 1, pos: 11, token: Token::Eq },
+                            TokenPos { line: 1, pos: 13, token: Token::Neq },
+                            TokenPos { line: 1, pos: 16, token: Token::Is },
+                            TokenPos { line: 1, pos: 19, token: Token::IsN },
+                            TokenPos { line: 1, pos: 24, token: Token::Id(String::from("i")) }]);
 }
 
 #[test]
 fn lex_if() {
     let source = String::from("if a then\n    b\nelse\n    c");
     let tokens = tokenize(&source).unwrap();
-    assert_eq!(tokens,
-               vec![TokenPos { line: 1, pos: 1, token: Token::If },
-                    TokenPos { line: 1, pos: 4, token: Token::Id(String::from("a")) },
-                    TokenPos { line: 1, pos: 6, token: Token::Then },
-                    TokenPos { line: 1, pos: 10, token: Token::NL },
-                    TokenPos { line: 2, pos: 1, token: Token::Indent },
-                    TokenPos { line: 2, pos: 5, token: Token::Id(String::from("b")) },
-                    TokenPos { line: 2, pos: 6, token: Token::NL },
-                    TokenPos { line: 3, pos: 1, token: Token::Dedent },
-                    TokenPos { line: 3, pos: 1, token: Token::Else },
-                    TokenPos { line: 3, pos: 5, token: Token::NL },
-                    TokenPos { line: 4, pos: 1, token: Token::Indent },
-                    TokenPos { line: 4, pos: 5, token: Token::Id(String::from("c")) }
-               ]);
+    assert_eq!(tokens, vec![TokenPos { line: 1, pos: 1, token: Token::If },
+                            TokenPos { line: 1, pos: 4, token: Token::Id(String::from("a")) },
+                            TokenPos { line: 1, pos: 6, token: Token::Then },
+                            TokenPos { line: 1, pos: 10, token: Token::NL },
+                            TokenPos { line: 2, pos: 1, token: Token::Indent },
+                            TokenPos { line: 2, pos: 5, token: Token::Id(String::from("b")) },
+                            TokenPos { line: 2, pos: 6, token: Token::NL },
+                            TokenPos { line: 3, pos: 1, token: Token::Dedent },
+                            TokenPos { line: 3, pos: 1, token: Token::Else },
+                            TokenPos { line: 3, pos: 5, token: Token::NL },
+                            TokenPos { line: 4, pos: 1, token: Token::Indent },
+                            TokenPos { line: 4, pos: 5, token: Token::Id(String::from("c")) }]);
 }
 
 #[test]
 fn lex_numbers_and_strings() {
     let source = String::from("1 2.0 3e10 5e 2 \"hello\" True False i");
     let tokens = tokenize(&source).unwrap();
-    assert_eq!(tokens,
-               vec![TokenPos { line: 1, pos: 1, token: Token::Int(String::from("1")) },
-                    TokenPos { line: 1, pos: 3, token: Token::Real(String::from("2.0")) },
-                    TokenPos {
-                        line: 1,
-                        pos: 7,
-                        token: Token::ENum(String::from("3"),
-                                           String::from("10")),
-                    },
-                    TokenPos {
-                        line: 1,
-                        pos: 12,
-                        token: Token::ENum(String::from("5"),
-                                           String::new()),
-                    },
-                    TokenPos { line: 1, pos: 15, token: Token::Int(String::from("2")) },
-                    TokenPos { line: 1, pos: 17, token: Token::Str(String::from("hello")) },
-                    TokenPos { line: 1, pos: 25, token: Token::Bool(true) },
-                    TokenPos { line: 1, pos: 30, token: Token::Bool(false) },
-                    TokenPos { line: 1, pos: 36, token: Token::Id(String::from("i")) }
-               ]);
+    assert_eq!(tokens, vec![TokenPos { line: 1, pos: 1, token: Token::Int(String::from("1")) },
+                            TokenPos { line:  1,
+                                       pos:   3,
+                                       token: Token::Real(String::from("2.0")) },
+                            TokenPos { line:  1,
+                                       pos:   7,
+                                       token: Token::ENum(String::from("3"), String::from("10")) },
+                            TokenPos { line:  1,
+                                       pos:   12,
+                                       token: Token::ENum(String::from("5"), String::new()) },
+                            TokenPos { line:  1,
+                                       pos:   15,
+                                       token: Token::Int(String::from("2")) },
+                            TokenPos { line:  1,
+                                       pos:   17,
+                                       token: Token::Str(String::from("hello")) },
+                            TokenPos { line: 1, pos: 25, token: Token::Bool(true) },
+                            TokenPos { line: 1, pos: 30, token: Token::Bool(false) },
+                            TokenPos { line: 1, pos: 36, token: Token::Id(String::from("i")) }]);
 }
 
 #[test]
 fn lex_identifiers() {
     let source = String::from("i _i 3a");
     let tokens = tokenize(&source).unwrap();
-    assert_eq!(tokens,
-               vec![TokenPos { line: 1, pos: 1, token: Token::Id(String::from("i")) },
-                    TokenPos { line: 1, pos: 3, token: Token::Id(String::from("_i")) },
-                    TokenPos { line: 1, pos: 6, token: Token::Int(String::from("3")) },
-                    TokenPos { line: 1, pos: 7, token: Token::Id(String::from("a")) },
-               ]);
+    assert_eq!(tokens, vec![TokenPos { line: 1, pos: 1, token: Token::Id(String::from("i")) },
+                            TokenPos { line: 1, pos: 3, token: Token::Id(String::from("_i")) },
+                            TokenPos { line: 1, pos: 6, token: Token::Int(String::from("3")) },
+                            TokenPos { line: 1, pos: 7, token: Token::Id(String::from("a")) },]);
+}
+
+#[test]
+fn lex_question() {
+    let source = String::from("? ?. ?or i");
+    let tokens = tokenize(&source).unwrap();
+    assert_eq!(tokens, vec![TokenPos { line: 1, pos: 1, token: Token::Quest },
+                            TokenPos { line: 1, pos: 3, token: Token::QuestCall },
+                            TokenPos { line: 1, pos: 6, token: Token::QuestOr },
+                            TokenPos { line: 1, pos: 10, token: Token::Id(String::from("i")) }]);
 }

--- a/tests/lexer.rs
+++ b/tests/lexer.rs
@@ -6,8 +6,42 @@ use mamba::lexer::tokenize;
 fn parse_from() {
     let source = String::from("from i use b");
     let tokens = tokenize(&source).unwrap();
-    assert_eq!(tokens, vec![TokenPos { line: 1, pos: 1, token: Token::From },
-                            TokenPos { line: 1, pos: 6, token: Token::Id(String::from("i")) },
-                            TokenPos { line: 1, pos: 8, token: Token::Use },
-                            TokenPos { line: 1, pos: 12, token: Token::Id(String::from("b")) }]);
+    assert_eq!(tokens,
+               vec![TokenPos { line: 1, pos: 1, token: Token::From },
+                    TokenPos { line: 1, pos: 6, token: Token::Id(String::from("i")) },
+                    TokenPos { line: 1, pos: 8, token: Token::Use },
+                    TokenPos { line: 1, pos: 12, token: Token::Id(String::from("b")) }]);
+}
+
+#[test]
+fn parse_operators() {
+    let source = String::from("+ - * / ^ mod sqrt i");
+    let tokens = tokenize(&source).unwrap();
+    assert_eq!(tokens,
+               vec![TokenPos { line: 1, pos: 1, token: Token::Add },
+                    TokenPos { line: 1, pos: 3, token: Token::Sub },
+                    TokenPos { line: 1, pos: 5, token: Token::Mul },
+                    TokenPos { line: 1, pos: 7, token: Token::Div },
+                    TokenPos { line: 1, pos: 9, token: Token::Pow },
+                    TokenPos { line: 1, pos: 11, token: Token::Mod },
+                    TokenPos { line: 1, pos: 15, token: Token::Sqrt },
+                    TokenPos { line: 1, pos: 20, token: Token::Id(String::from("i")) }
+               ]);
+}
+
+#[test]
+fn test_comparison() {
+    let source = String::from("< > <= >= = /= is isnt i");
+    let tokens = tokenize(&source).unwrap();
+    assert_eq!(tokens,
+               vec![TokenPos { line: 1, pos: 1, token: Token::Le },
+                    TokenPos { line: 1, pos: 3, token: Token::Ge },
+                    TokenPos { line: 1, pos: 5, token: Token::Leq },
+                    TokenPos { line: 1, pos: 8, token: Token::Geq },
+                    TokenPos { line: 1, pos: 11, token: Token::Eq },
+                    TokenPos { line: 1, pos: 13, token: Token::Neq },
+                    TokenPos { line: 1, pos: 16, token: Token::Is },
+                    TokenPos { line: 1, pos: 19, token: Token::IsN },
+                    TokenPos { line: 1, pos: 24, token: Token::Id(String::from("i")) }
+               ]);
 }


### PR DESCRIPTION
### Relevant issues
...

### Summary
There were little to no tests for the lexer. This meant that certain incorrect implementations of the specification might've gone undetected. Thanks to the added tests, we:

- Now correctly identify the positions of `TokenPos` following a string or a `?or`.
- Identifiers can now start with an underscore `_` character, instead of the lexer recognizing this as a separate character.
- Indentation now has a position which reflects their position in the source, instead of the position of multiple consecutive indentations being equal to the first encountered character.
- We also add the `QuestCall` token, which should later be fully implemented in the parser.
- We also add a rule in the desugarer that if an `Enum` has no exponent, it's exponent becomes 0.
- `True` and `False` are now correctly lexed as booleans, as opposed to `true` and `false`
- Remove `println` and `::`, which is no longer in the specification of the language.
- Correctly lex `/=` as negative equality instead of equality.

### Added Tests
Each test checks that we lex the expected operator, and that their positions are what we expect them to be.

- Test lexing the from operator
- Test lexing mathematical operators
- Test lexing comparison operators
- Test lexing an if statement and the accompanying indentation
- Test lexing numbers and strings
- Test lexing identifier, including if they start with an underscore
- Test lexing question mark operators

### Additional Remarks
It is clear that the lexer should be refactored at some point. It is rather unwieldy and difficult to read. Thanks to these test it will be easier to refactor and check for any potential regression.
