### PR TITLE
Re-add links to badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
     <img src="/image/logo_medium.png" height="250">
 </p>
 
-![Travis (.org)](https://img.shields.io/travis/JSAbrahams/mamba.svg?style=for-the-badge&logo=travis)
- ![AppVeyor](https://img.shields.io/appveyor/ci/JSAbrahams/mamba.svg?style=for-the-badge&logo=appveyor)
- ![Codecov](https://img.shields.io/codecov/c/github/JSAbrahams/mamba.svg?style=for-the-badge&logo=codecov)
- ![GitHub](https://img.shields.io/github/license/JSAbrahams/mamba.svg?style=for-the-badge)
- ![Love](https://img.shields.io/badge/Built%20with-%E2%99%A5-red.svg?style=for-the-badge)
+[![Travis (.org)](https://img.shields.io/travis/JSAbrahams/mamba.svg?style=for-the-badge&logo=travis)](https://travis-ci.org/JSAbrahams/mamba)
+ [![AppVeyor](https://img.shields.io/appveyor/ci/JSAbrahams/mamba.svg?style=for-the-badge&logo=appveyor)](https://ci.appveyor.com/project/JSAbrahams/mamba)
+ [![Codecov](https://img.shields.io/codecov/c/github/JSAbrahams/mamba.svg?style=for-the-badge&logo=codecov)](https://codecov.io/gh/JSAbrahams/mamba)
+ [![GitHub](https://img.shields.io/github/license/JSAbrahams/mamba.svg?style=for-the-badge)](https://github.com/JSAbrahams/mamba/blob/master/LICENSE)
+ [![Love](https://img.shields.io/badge/Built%20with-%E2%99%A5-red.svg?style=for-the-badge)](https://github.com/JSAbrahams/mamba)
 
 
 # Mamba


### PR DESCRIPTION
### Relevant issues
The hyperlinks were removed from the badges. When we click on say the Travis badge we expect to go to the Travis build page.

### Summary
Re-add links.

### Added Tests
Clicked every link to check that they work.
