### PR TITLE
Fix code of conduct link in README

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Contributions are encouraged!
 
 A good place to start is by looking at [good first issues](https://github.com/JSAbrahams/mamba/labels/good%20first%20issue).
 
-Please read our [code of conduct](https://github.com/JSAbrahams/mamba/blob/master/CODE_OF_CONDUCT.md) before contributing.
+Please read our [code of conduct](/CODE_OF_CONDUCT.md) before contributing.
 
 ## 📝 Procedures
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,8 +4,7 @@ Contributions are encouraged!
 
 A good place to start is by looking at [good first issues](https://github.com/JSAbrahams/mamba/labels/good%20first%20issue).
 
-Please read our [code of conduct](https://github.com/JSAbrahams/mamba/blob/code-of-conduct/CODE_OF_CONDUCT.md) before contributing.
-
+Please read our [code of conduct](https://github.com/JSAbrahams/mamba/blob/master/CODE_OF_CONDUCT.md) before contributing.
 
 ## 📝 Procedures
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Functions written in Python can be called in Mamba and vice versa.
 
 ## 👥 Contributing
 
-Before submitting your first issue or pull request, please take the time to read both our [contribution guidelines](/CONTRIBUTING.md) and our [code of conduct](https://github.com/JSAbrahams/mamba/blob/master/CODE_OF_CONDUCT.md).
+Before submitting your first issue or pull request, please take the time to read both our [contribution guidelines](/CONTRIBUTING.md) and our [code of conduct](/CODE_OF_CONDUCT.md).
 
 ## 🔨 Tooling
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Functions written in Python can be called in Mamba and vice versa.
 
 ## 👥 Contributing
 
-Before submitting your first issue or pull request, please take the time to read both our [contribution guidelines](/CONTRIBUTING.md) and our [code of conduct](https://github.com/JSAbrahams/mamba/blob/code-of-conduct/CODE_OF_CONDUCT.md).
+Before submitting your first issue or pull request, please take the time to read both our [contribution guidelines](/CONTRIBUTING.md) and our [code of conduct](https://github.com/JSAbrahams/mamba/blob/master/CODE_OF_CONDUCT.md).
 
 ## 🔨 Tooling
 


### PR DESCRIPTION
### Relevant issues
Code of conduct link was broken in README and CONTRIBUTING.

### Summary
Fixed code of conduct link in README and CONTRIBUTING.
Use a relative path instead of an absolute path, which is fragile.

### Added Tests
Clicked on the links to make sure they work.

### Additional Context
...
