### PR TITLE
Wrap pipeline

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,4 +1,146 @@
 [[package]]
+name = "assert_cmd"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "escargot 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "predicates 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "predicates-core 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "predicates-tree 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "difference"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "escargot"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "serde 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "itoa"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "mamba"
 version = "0.1.0"
+dependencies = [
+ "assert_cmd 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
+[[package]]
+name = "predicates"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "difference 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "predicates-core 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "predicates-core"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "predicates-tree"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "predicates-core 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "treeline 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "proc-macro2"
+version = "0.4.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "quote"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "ryu"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "serde"
+version = "1.0.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "serde_derive 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.29 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.39"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "itoa 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ryu 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "syn"
+version = "0.15.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "treeline"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "unicode-xid"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[metadata]
+"checksum assert_cmd 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)" = "b7ac5c260f75e4e4ba87b7342be6edcecbcb3eb6741a0507fda7ad115845cc65"
+"checksum difference 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "524cbf6897b527295dff137cec09ecf3a05f4fddffd7dfcd1585403449e74198"
+"checksum escargot 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "19db1f7e74438642a5018cdf263bb1325b2e792f02dd0a3ca6d6c0f0d7b1d5a5"
+"checksum itoa 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "1306f3464951f30e30d12373d31c79fbd52d236e5e896fd92f96ec7babbbe60b"
+"checksum predicates 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fa984b7cd021a0bf5315bcce4c4ae61d2a535db2a8d288fc7578638690a7b7c3"
+"checksum predicates-core 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "06075c3a3e92559ff8929e7a280684489ea27fe44805174c3ebd9328dcb37178"
+"checksum predicates-tree 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8e63c4859013b38a76eca2414c64911fba30def9e3202ac461a2d22831220124"
+"checksum proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)" = "4d317f9caece796be1980837fd5cb3dfec5613ebdb04ad0956deea83ce168915"
+"checksum quote 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)" = "cdd8e04bd9c52e0342b406469d494fcb033be4bdbe5c606016defbb1681411e1"
+"checksum ryu 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "eb9e9b8cde282a9fe6a42dd4681319bfb63f121b8a8ee9439c6f4107e58a46f7"
+"checksum serde 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)" = "92514fb95f900c9b5126e32d020f5c6d40564c27a5ea6d1d7d9f157a96623560"
+"checksum serde_derive 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)" = "bb6eabf4b5914e88e24eea240bb7c9f9a2cbc1bbbe8d961d381975ec3c6b806c"
+"checksum serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)" = "5a23aa71d4a4d43fdbfaac00eff68ba8a06a51759a89ac3304323e800c4dd40d"
+"checksum syn 0.15.29 (registry+https://github.com/rust-lang/crates.io-index)" = "1825685f977249735d510a242a6727b46efe914bb67e38d30c071b1b72b1d5c2"
+"checksum treeline 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a7f741b240f1a48843f9b8e0444fb55fb2a4ff67293b50a9179dfd5ea67f8d41"
+"checksum unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,3 +5,4 @@ authors = ["Joel Abrahams <abrahamsjo@gmail.com>"]
 edition = "2018"
 
 [dependencies]
+assert_cmd = "0.10"

--- a/src/command/mod.rs
+++ b/src/command/mod.rs
@@ -1,0 +1,66 @@
+use crate::core::to_py_source;
+use crate::desugarer::desugar;
+use crate::lexer::tokenize;
+use crate::parser::parse;
+use std::fs::File;
+use std::io::Read;
+use std::io::Write;
+use std::path::Path;
+
+pub fn quick_transpile(path: &Path) -> File {
+    let new_file_path = format!("{}.py", match path.parent() {
+        Some(parent) => parent,
+        None => panic!()
+    }.join(match path.file_stem() {
+        Some(path) => path,
+        None => panic!()
+    }).to_string_lossy());
+
+    println!("{}", new_file_path);
+
+    let mut output_file = match File::create(new_file_path) {
+        Ok(file) => file,
+        Err(err) => panic!("{}", err)
+    };
+
+    let mut input_file = match File::open(path) {
+        Ok(file) => file,
+        Err(err) => panic!("{}", err)
+    };
+
+    transpile_file(&mut input_file, &mut output_file);
+    output_file
+}
+
+pub fn transpile_file(input: &mut File, output: &mut File) {
+    let mut input_string = String::new();
+    match input.read_to_string(&mut input_string) {
+        Ok(_) => (),
+        Err(err) => panic!("{}", err)
+    }
+
+    let output_string = match transpile(&input_string) {
+        Ok(python) => python,
+        Err(err) => panic!("{}", err)
+    };
+
+    match output.write(output_string.as_ref()) {
+        Ok(_) => (),
+        Err(err) => panic!("{}", err)
+    }
+}
+
+fn transpile(input: &str) -> Result<String, String> {
+    let tokens = match tokenize(input) {
+        Ok(tokens) => tokens,
+        Err(err) => return Err(err)
+    };
+
+    let ast_tree = match parse(&tokens) {
+        Ok(ast_tree) => ast_tree,
+        Err(err) => return Err(format!("{}", err))
+    };
+
+    let core_tree = desugar(&ast_tree);
+    Ok(to_py_source(&core_tree))
+}

--- a/src/command/mod.rs
+++ b/src/command/mod.rs
@@ -2,47 +2,58 @@ use crate::core::to_py_source;
 use crate::desugarer::desugar;
 use crate::lexer::tokenize;
 use crate::parser::parse;
-use std::fs::File;
+use std::fs::OpenOptions;
 use std::io::Read;
 use std::io::Write;
 use std::path::Path;
 use std::path::PathBuf;
 
 pub fn mamba_to_python_direct(input_path: &Path) -> Result<PathBuf, String> {
-    let file_path = match input_path.parent() {
-        Some(parent) => parent,
-        None => return Err(format!("Not in a directory: {}", input_path.to_string_lossy()))
-    }.join(match input_path.file_stem() {
-        Some(path) => path,
-        None => return Err(format!("File does not have name: {}", input_path.to_string_lossy())),
-    });
+    let file_path =
+        match input_path.parent() {
+            Some(parent) => parent,
+            None => return Err(format!("Not in a directory: {}", input_path.to_string_lossy()))
+        }.join(match input_path.file_stem() {
+            Some(path) => path,
+            None =>
+                return Err(format!("File does not have name: {}",
+                                   input_path.to_string_lossy())),
+        });
 
     let output_path_string = format!("{}.py", file_path.to_string_lossy());
     let output_path = Path::new(&output_path_string);
-    match mamba_to_python(input_path,  output_path) {
+    match mamba_to_python(input_path, output_path) {
         Ok(output_path) => Ok(output_path),
         Err(err) => Err(err)
     }
 }
 
 pub fn mamba_to_python(input: &Path, output: &Path) -> Result<PathBuf, String> {
-    let mut input_string = String::new();
     let res_output = output.to_owned();
 
-    let (mut input_file, mut output_file) = match (File::open(input), File::open(output)) {
+    let input_file_option = OpenOptions::new()
+        .read(true)
+        .open(input);
+    let output_file_options = OpenOptions::new()
+        .write(true)
+        .create(true)
+        .open(output);
+
+    let (mut input_file, mut output_file) = match (input_file_option, output_file_options) {
         (Ok(input_file), Ok(output_file)) => (input_file, output_file),
         (Err(err), _) => return Err(err.to_string()),
         (_, Err(err)) => return Err(err.to_string())
     };
 
+    let mut input_string = String::new();
     match input_file.read_to_string(&mut input_string) {
         Ok(_) => (),
-        Err(err) => return Err(format!("{}", err))
+        Err(err) => return Err(err.to_string())
     }
 
     let output_string = match transpile(&input_string) {
         Ok(python) => python,
-        Err(err) => return Err(format!("{}", err))
+        Err(err) => return Err(err.to_string())
     };
 
     match output_file.write(output_string.as_ref()) {

--- a/src/command/mod.rs
+++ b/src/command/mod.rs
@@ -7,46 +7,50 @@ use std::io::Read;
 use std::io::Write;
 use std::path::Path;
 
-pub fn quick_transpile(path: &Path) -> File {
-    let new_file_path = format!("{}.py",
-                                match path.parent() {
-                                    Some(parent) => parent,
-                                    None => panic!()
-                                }.join(match path.file_stem() {
-                                           Some(path) => path,
-                                           None => panic!()
-                                       })
-                                 .to_string_lossy());
+pub fn mamba_to_python_direct(path: &Path) -> Result<File, String> {
+    let file_path =
+        match path.parent() {
+            Some(parent) => parent,
+            None => return Err(format!("Not in a directory: {}", path.to_string_lossy()))
+        }.join(match path.file_stem() {
+                   Some(path) => path,
+                   None =>
+                       return Err(format!("File does not have name: {}", path.to_string_lossy())),
+               });
+
+    let new_file_path = format!("{}.py", file_path.to_string_lossy());
 
     let mut output_file = match File::create(new_file_path) {
         Ok(file) => file,
-        Err(err) => panic!("{}", err)
+        Err(err) => return Err(format!("{}", err))
     };
 
     let mut input_file = match File::open(path) {
         Ok(file) => file,
-        Err(err) => panic!("{}", err)
+        Err(err) => return Err(format!("{}", err))
     };
 
-    transpile_file(&mut input_file, &mut output_file);
-    output_file
+    match mamba_to_python(&mut input_file, &mut output_file) {
+        Ok(_) => Ok(output_file),
+        Err(err) => Err(err)
+    }
 }
 
-pub fn transpile_file(input: &mut File, output: &mut File) {
+pub fn mamba_to_python(input: &mut File, output: &mut File) -> Result<(), String> {
     let mut input_string = String::new();
     match input.read_to_string(&mut input_string) {
         Ok(_) => (),
-        Err(err) => panic!("{}", err)
+        Err(err) => return Err(format!("{}", err))
     }
 
     let output_string = match transpile(&input_string) {
         Ok(python) => python,
-        Err(err) => panic!("{}", err)
+        Err(err) => return Err(format!("{}", err))
     };
 
     match output.write(output_string.as_ref()) {
-        Ok(_) => (),
-        Err(err) => panic!("{}", err)
+        Ok(_) => Ok(()),
+        Err(err) => Err(format!("{}", err))
     }
 }
 

--- a/src/command/mod.rs
+++ b/src/command/mod.rs
@@ -8,15 +8,15 @@ use std::io::Write;
 use std::path::Path;
 
 pub fn quick_transpile(path: &Path) -> File {
-    let new_file_path = format!("{}.py", match path.parent() {
-        Some(parent) => parent,
-        None => panic!()
-    }.join(match path.file_stem() {
-        Some(path) => path,
-        None => panic!()
-    }).to_string_lossy());
-
-    println!("{}", new_file_path);
+    let new_file_path = format!("{}.py",
+                                match path.parent() {
+                                    Some(parent) => parent,
+                                    None => panic!()
+                                }.join(match path.file_stem() {
+                                           Some(path) => path,
+                                           None => panic!()
+                                       })
+                                 .to_string_lossy());
 
     let mut output_file = match File::create(new_file_path) {
         Ok(file) => file,

--- a/src/command/mod.rs
+++ b/src/command/mod.rs
@@ -9,16 +9,17 @@ use std::path::Path;
 use std::path::PathBuf;
 
 pub fn mamba_to_python_direct(input_path: &Path) -> Result<PathBuf, String> {
-    let file_path =
-        match input_path.parent() {
-            Some(parent) => parent,
-            None => return Err(format!("Not in a directory: {}", input_path.to_string_lossy()))
-        }.join(match input_path.file_stem() {
-                   Some(path) => path,
-                   None =>
-                       return Err(format!("File does not have name: {}",
-                                          input_path.to_string_lossy())),
-               });
+    let file_path = match input_path.parent() {
+                        Some(parent) => parent,
+                        None =>
+                            return Err(format!("Input was not in a directory: {}",
+                                               input_path.to_string_lossy())),
+                    }.join(match input_path.file_stem() {
+                               Some(path) => path,
+                               None =>
+                                   return Err(format!("Input file did not have a name: {}",
+                                                      input_path.to_string_lossy())),
+                           });
 
     let output_path_string = format!("{}.py", file_path.to_string_lossy());
     let output_path = Path::new(&output_path_string);

--- a/src/command/mod.rs
+++ b/src/command/mod.rs
@@ -14,11 +14,11 @@ pub fn mamba_to_python_direct(input_path: &Path) -> Result<PathBuf, String> {
             Some(parent) => parent,
             None => return Err(format!("Not in a directory: {}", input_path.to_string_lossy()))
         }.join(match input_path.file_stem() {
-            Some(path) => path,
-            None =>
-                return Err(format!("File does not have name: {}",
-                                   input_path.to_string_lossy())),
-        });
+                   Some(path) => path,
+                   None =>
+                       return Err(format!("File does not have name: {}",
+                                          input_path.to_string_lossy())),
+               });
 
     let output_path_string = format!("{}.py", file_path.to_string_lossy());
     let output_path = Path::new(&output_path_string);
@@ -31,13 +31,8 @@ pub fn mamba_to_python_direct(input_path: &Path) -> Result<PathBuf, String> {
 pub fn mamba_to_python(input: &Path, output: &Path) -> Result<PathBuf, String> {
     let res_output = output.to_owned();
 
-    let input_file_option = OpenOptions::new()
-        .read(true)
-        .open(input);
-    let output_file_options = OpenOptions::new()
-        .write(true)
-        .create(true)
-        .open(output);
+    let input_file_option = OpenOptions::new().read(true).open(input);
+    let output_file_options = OpenOptions::new().write(true).create(true).open(output);
 
     let (mut input_file, mut output_file) = match (input_file_option, output_file_options) {
         (Ok(input_file), Ok(output_file)) => (input_file, output_file),

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -42,7 +42,11 @@ fn to_py(core: &Core, ind: usize) -> String {
                 _ => panic!()
             };
 
-            format!("{}({}): {}", name, comma_delimited(args, ind), to_py(body.as_ref(), ind + 1))
+            format!("\n{}{}({}): {}",
+                    indent(ind),
+                    name,
+                    comma_delimited(args, ind),
+                    to_py(body.as_ref(), ind + 1))
         }
 
         Core::Assign { left, right } =>

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -126,7 +126,7 @@ fn to_py(core: &Core, ind: usize) -> String {
         Core::Continue => String::from("continue"),
         Core::Break => String::from("break"),
 
-        Core::ClassDef { name, parents, definitions, .. } => format!("class {}({}): {}\n",
+        Core::ClassDef { name, parents, definitions, .. } => format!("class {}({}):\n{}\n",
                     to_py(name, ind),
                     comma_delimited(parents, ind),
                     newline_delimited(definitions, ind + 1)),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,3 +2,5 @@ pub mod core;
 pub mod desugarer;
 pub mod lexer;
 pub mod parser;
+
+pub mod command;

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,3 +4,7 @@ pub mod desugarer;
 pub mod lexer;
 pub mod parser;
 pub mod type_checker;
+
+fn main() {
+    println!("hello world.");
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,6 +15,8 @@ fn main() -> Result<(), String> {
     let mut output: Option<String> = None;
 
     let mut args = std::env::args();
+    args.next(); // skip program name
+
     while let Some(arg) = args.next() {
         match arg.as_str() {
             INPUT_FLAG => input = Option::from(args.next().expect("Expected input file path.")),
@@ -25,12 +27,11 @@ fn main() -> Result<(), String> {
     }
 
     match (input, output) {
-        (Some(input), Some(output)) => match command::mamba_to_python(
-            Path::new(&input),
-            Path::new(&output)) {
-            Ok(_) => Ok(()),
-            Err(err) => Err(err)
-        },
+        (Some(input), Some(output)) =>
+            match command::mamba_to_python(Path::new(&input), Path::new(&output)) {
+                Ok(_) => Ok(()),
+                Err(err) => Err(err)
+            },
         (Some(input), None) => match command::mamba_to_python_direct(Path::new(&input)) {
             Ok(_) => Ok(()),
             Err(err) => Err(err)

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,5 @@
+use std::path::Path;
+
 pub mod command;
 pub mod core;
 pub mod desugarer;
@@ -5,6 +7,34 @@ pub mod lexer;
 pub mod parser;
 pub mod type_checker;
 
-fn main() {
-    println!("hello world.");
+const INPUT_FLAG: &str = "-i";
+const OUTPUT_FLAG: &str = "-o";
+
+fn main() -> Result<(), String> {
+    let mut input: Option<String> = None;
+    let mut output: Option<String> = None;
+
+    let mut args = std::env::args();
+    while let Some(arg) = args.next() {
+        match arg.as_str() {
+            INPUT_FLAG => input = Option::from(args.next().expect("Expected input file path.")),
+            OUTPUT_FLAG => output = Option::from(args.next().expect("Expected output file path.")),
+
+            other => return Err(format!("Flag not recognized: {}", other))
+        }
+    }
+
+    match (input, output) {
+        (Some(input), Some(output)) => match command::mamba_to_python(
+            Path::new(&input),
+            Path::new(&output)) {
+            Ok(_) => Ok(()),
+            Err(err) => Err(err)
+        },
+        (Some(input), None) => match command::mamba_to_python_direct(Path::new(&input)) {
+            Ok(_) => Ok(()),
+            Err(err) => Err(err)
+        },
+        _ => Err(String::from("No input file path given."))
+    }
 }

--- a/src/type_checker/mod.rs
+++ b/src/type_checker/mod.rs
@@ -1,6 +1,4 @@
-use crate::parser::ASTNode;
-use crate::parser::ASTNodePos;
+use crate::parser::ast_node::ASTNode;
+use crate::parser::ast_node::ASTNodePos;
 
-pub fn type_check(input: &ASTNodePos) -> ASTNode {
-    return input.node
-}
+pub fn type_check(input: ASTNodePos) -> ASTNode { input.node }

--- a/tests/command.rs
+++ b/tests/command.rs
@@ -7,5 +7,5 @@ mod util;
 #[test]
 fn test_output_class() {
     let source = valid_resource_path(&String::from("class.txt"));
-    let output = quick_transpile(Path::new(&source));
+    quick_transpile(Path::new(&source));
 }

--- a/tests/command.rs
+++ b/tests/command.rs
@@ -1,0 +1,11 @@
+use crate::util::valid_resource_path;
+use mamba::command::quick_transpile;
+use std::path::Path;
+
+mod util;
+
+#[test]
+fn test_output_class() {
+    let source = valid_resource_path(&String::from("class.txt"));
+    let output = quick_transpile(Path::new(&source));
+}

--- a/tests/command.rs
+++ b/tests/command.rs
@@ -7,5 +7,7 @@ mod util;
 #[test]
 fn test_output_class() {
     let source = valid_resource_path(&String::from("class.txt"));
-    mamba_to_python_direct(Path::new(&source));
+    let path = &mut Path::new(&source);
+
+    mamba_to_python_direct(path);
 }

--- a/tests/command.rs
+++ b/tests/command.rs
@@ -1,13 +1,55 @@
+use crate::util::check_valid_resource_exists_and_delete;
+use crate::util::invalid_resource_path;
 use crate::util::valid_resource_path;
+use mamba::command::mamba_to_python;
 use mamba::command::mamba_to_python_direct;
+use std::fs::OpenOptions;
 use std::path::Path;
 
 mod util;
 
 #[test]
-fn test_output_class() {
+fn output_class_direct() {
     let source = valid_resource_path(&String::from("class.txt"));
     let path = &mut Path::new(&source);
 
     mamba_to_python_direct(path);
+
+    check_valid_resource_exists_and_delete("class.py");
+}
+
+#[test]
+fn output_class_output_non_existent() {
+    let source = valid_resource_path(&String::from("class.txt"));
+    let output = valid_resource_path(&String::from("class-other.py"));
+
+    let path = &mut Path::new(&source);
+    let out_path = &mut Path::new(&output);
+    mamba_to_python(path, out_path);
+
+    check_valid_resource_exists_and_delete("class-other.py");
+}
+
+#[test]
+fn output_class_output_exists() {
+    let source = valid_resource_path(&String::from("class.txt"));
+    let output = valid_resource_path(&String::from("class-already-exists.py"));
+
+    let path = &mut Path::new(&source);
+    let out_path = &mut Path::new(&output);
+
+    OpenOptions::new().write(true).create(true).open(&output); // Create file beforehand
+    assert_eq!(true, Path::new(&out_path).exists());
+
+    mamba_to_python(path, out_path);
+    check_valid_resource_exists_and_delete("class-already-exists.py");
+}
+
+#[test]
+fn test_empty_file_direct() {
+    let source = valid_resource_path(&String::from("empty_file.txt"));
+    let path = &mut Path::new(&source);
+
+    mamba_to_python_direct(path);
+    check_valid_resource_exists_and_delete("empty_file.py");
 }

--- a/tests/command.rs
+++ b/tests/command.rs
@@ -1,5 +1,5 @@
 use crate::util::valid_resource_path;
-use mamba::command::quick_transpile;
+use mamba::command::mamba_to_python_direct;
 use std::path::Path;
 
 mod util;
@@ -7,5 +7,5 @@ mod util;
 #[test]
 fn test_output_class() {
     let source = valid_resource_path(&String::from("class.txt"));
-    quick_transpile(Path::new(&source));
+    mamba_to_python_direct(Path::new(&source));
 }

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -1,6 +1,6 @@
 use crate::util::check_valid_resource_exists_and_delete;
-use assert_cmd::prelude::*;
 use crate::util::valid_resource_path;
+use assert_cmd::prelude::*;
 use std::process::Command;
 
 mod util;

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -1,0 +1,40 @@
+use assert_cmd::prelude::*;
+use crate::util::valid_resource_exists;
+// Run programs
+use crate::util::valid_resource_path;
+use std::process::Command;
+// Add methods on commands
+
+mod util;
+
+#[test]
+fn command_line_class() -> Result<(), Box<std::error::Error>> {
+    let mut cmd = Command::main_binary()?;
+    cmd.arg("mambac")
+        .arg("-i")
+        .arg(valid_resource_path("class"));
+
+    cmd.output().unwrap();
+    if valid_resource_exists("class") {
+        Ok(())
+    } else {
+        panic!("no output file found.")
+    }
+}
+
+#[test]
+fn command_line_class_with_output() -> Result<(), Box<std::error::Error>> {
+    let mut cmd = Command::main_binary()?;
+    cmd.arg("mambac")
+        .arg("-i")
+        .arg(valid_resource_path("class"))
+        .arg("-o")
+        .arg(format!("{}.py", valid_resource_path("class")));
+
+    cmd.output().unwrap();
+    if valid_resource_exists("class") {
+        Ok(())
+    } else {
+        panic!("no output file found.")
+    }
+}

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -1,5 +1,5 @@
+use crate::util::valid_resource_exists_and_delete;
 use assert_cmd::prelude::*;
-use crate::util::valid_resource_exists;
 // Run programs
 use crate::util::valid_resource_path;
 use std::process::Command;
@@ -10,31 +10,29 @@ mod util;
 #[test]
 fn command_line_class() -> Result<(), Box<std::error::Error>> {
     let mut cmd = Command::main_binary()?;
-    cmd.arg("mambac")
-        .arg("-i")
-        .arg(valid_resource_path("class"));
+    cmd.arg("-i").arg(valid_resource_path("class"));
 
     cmd.output().unwrap();
-    if valid_resource_exists("class") {
+    if valid_resource_exists_and_delete("class.py") {
         Ok(())
     } else {
-        panic!("no output file found.")
+        let output = format!("{}.py", valid_resource_path("class"));
+        panic!("no output file found. {}", output)
     }
 }
 
 #[test]
 fn command_line_class_with_output() -> Result<(), Box<std::error::Error>> {
     let mut cmd = Command::main_binary()?;
-    cmd.arg("mambac")
-        .arg("-i")
-        .arg(valid_resource_path("class"))
-        .arg("-o")
-        .arg(format!("{}.py", valid_resource_path("class")));
+    println!("{:?}", cmd);
+
+    let output = format!("{}.py", valid_resource_path("class"));
+    cmd.arg("-i").arg(valid_resource_path("class.txt")).arg("-o").arg(output.clone());
 
     cmd.output().unwrap();
-    if valid_resource_exists("class") {
+    if valid_resource_exists_and_delete("class.py") {
         Ok(())
     } else {
-        panic!("no output file found.")
+        panic!("no output file found: {}", output)
     }
 }

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -1,9 +1,7 @@
 use crate::util::check_valid_resource_exists_and_delete;
 use assert_cmd::prelude::*;
-// Run programs
 use crate::util::valid_resource_path;
 use std::process::Command;
-// Add methods on commands
 
 mod util;
 

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -1,4 +1,4 @@
-use crate::util::valid_resource_exists_and_delete;
+use crate::util::check_valid_resource_exists_and_delete;
 use assert_cmd::prelude::*;
 // Run programs
 use crate::util::valid_resource_path;
@@ -13,7 +13,7 @@ fn command_line_class() -> Result<(), Box<std::error::Error>> {
     cmd.arg("-i").arg(valid_resource_path("class"));
 
     cmd.output().unwrap();
-    if valid_resource_exists_and_delete("class.py") {
+    if check_valid_resource_exists_and_delete("class.py") {
         Ok(())
     } else {
         let output = format!("{}.py", valid_resource_path("class"));
@@ -30,7 +30,7 @@ fn command_line_class_with_output() -> Result<(), Box<std::error::Error>> {
     cmd.arg("-i").arg(valid_resource_path("class.txt")).arg("-o").arg(output.clone());
 
     cmd.output().unwrap();
-    if valid_resource_exists_and_delete("class.py") {
+    if check_valid_resource_exists_and_delete("class.py") {
         Ok(())
     } else {
         panic!("no output file found: {}", output)

--- a/tests/parser.rs
+++ b/tests/parser.rs
@@ -1,4 +1,4 @@
-use crate::util::valid_resource_contents;
+use crate::util::valid_resource_content;
 use mamba::lexer::tokenize;
 use mamba::parser::parse;
 
@@ -6,72 +6,72 @@ mod util;
 
 #[test]
 fn parse_assigns_and_while() {
-    let source = valid_resource_contents("assign_and_while.txt");
+    let source = valid_resource_content("assign_and_while.txt");
     assert_ok!(parse(&tokenize(&source).unwrap()));
 }
 
 #[test]
 fn parse_class() {
-    let source = valid_resource_contents("class.txt");
+    let source = valid_resource_content("class.txt");
     assert_ok!(parse(&tokenize(&source).unwrap()));
 }
 
 #[test]
 fn parse_collections() {
-    let source = valid_resource_contents("collections.txt");
+    let source = valid_resource_content("collections.txt");
     assert_ok!(parse(&tokenize(&source).unwrap()));
 }
 
 #[test]
 fn parse_empty_file() {
-    let source = valid_resource_contents("empty_file.txt");
+    let source = valid_resource_content("empty_file.txt");
     assert_ok!(parse(&tokenize(&source).unwrap()));
 }
 
 #[test]
 fn parse_for_statements() {
-    let source = valid_resource_contents("for_statements.txt");
+    let source = valid_resource_content("for_statements.txt");
     assert_ok!(parse(&tokenize(&source).unwrap()));
 }
 
 #[test]
 fn parse_if() {
-    let source = valid_resource_contents("if.txt");
+    let source = valid_resource_content("if.txt");
     assert_ok!(parse(&tokenize(&source).unwrap()));
 }
 
 #[test]
 fn parse_tuples() {
-    let source = valid_resource_contents("tuples.txt");
+    let source = valid_resource_content("tuples.txt");
     assert_ok!(parse(&tokenize(&source).unwrap()));
 }
 
 #[test]
 fn parse_when_statements() {
-    let source = valid_resource_contents("when_statements.txt");
+    let source = valid_resource_content("when_statements.txt");
     assert_ok!(parse(&tokenize(&source).unwrap()));
 }
 
 #[test]
 fn parse_while_statements() {
-    let source = valid_resource_contents("while_statements.txt");
+    let source = valid_resource_content("while_statements.txt");
     assert_ok!(parse(&tokenize(&source).unwrap()));
 }
 
 #[test]
 fn parse_function_definitions() {
-    let source = valid_resource_contents("function_definitions.txt");
+    let source = valid_resource_content("function_definitions.txt");
     assert_ok!(parse(&tokenize(&source).unwrap()));
 }
 
 #[test]
 fn parse_function_calling() {
-    let source = valid_resource_contents("function_calling.txt");
+    let source = valid_resource_content("function_calling.txt");
     assert_ok!(parse(&tokenize(&source).unwrap()));
 }
 
 #[test]
 fn parse_infix_function_calling() {
-    let source = valid_resource_contents("infix_function_calling.txt");
+    let source = valid_resource_content("infix_function_calling.txt");
     assert_ok!(parse(&tokenize(&source).unwrap()));
 }

--- a/tests/parser.rs
+++ b/tests/parser.rs
@@ -1,4 +1,4 @@
-use crate::util::valid_resource;
+use crate::util::valid_resource_contents;
 use mamba::lexer::tokenize;
 use mamba::parser::parse;
 
@@ -6,72 +6,72 @@ mod util;
 
 #[test]
 fn parse_assigns_and_while() {
-    let source = valid_resource("assign_and_while.txt");
+    let source = valid_resource_contents("assign_and_while.txt");
     assert_ok!(parse(&tokenize(&source).unwrap()));
 }
 
 #[test]
 fn parse_class() {
-    let source = valid_resource("class.txt");
+    let source = valid_resource_contents("class.txt");
     assert_ok!(parse(&tokenize(&source).unwrap()));
 }
 
 #[test]
 fn parse_collections() {
-    let source = valid_resource("collections.txt");
+    let source = valid_resource_contents("collections.txt");
     assert_ok!(parse(&tokenize(&source).unwrap()));
 }
 
 #[test]
 fn parse_empty_file() {
-    let source = valid_resource("empty_file.txt");
+    let source = valid_resource_contents("empty_file.txt");
     assert_ok!(parse(&tokenize(&source).unwrap()));
 }
 
 #[test]
 fn parse_for_statements() {
-    let source = valid_resource("for_statements.txt");
+    let source = valid_resource_contents("for_statements.txt");
     assert_ok!(parse(&tokenize(&source).unwrap()));
 }
 
 #[test]
 fn parse_if() {
-    let source = valid_resource("if.txt");
+    let source = valid_resource_contents("if.txt");
     assert_ok!(parse(&tokenize(&source).unwrap()));
 }
 
 #[test]
 fn parse_tuples() {
-    let source = valid_resource("tuples.txt");
+    let source = valid_resource_contents("tuples.txt");
     assert_ok!(parse(&tokenize(&source).unwrap()));
 }
 
 #[test]
 fn parse_when_statements() {
-    let source = valid_resource("when_statements.txt");
+    let source = valid_resource_contents("when_statements.txt");
     assert_ok!(parse(&tokenize(&source).unwrap()));
 }
 
 #[test]
 fn parse_while_statements() {
-    let source = valid_resource("while_statements.txt");
+    let source = valid_resource_contents("while_statements.txt");
     assert_ok!(parse(&tokenize(&source).unwrap()));
 }
 
 #[test]
 fn parse_function_definitions() {
-    let source = valid_resource("function_definitions.txt");
+    let source = valid_resource_contents("function_definitions.txt");
     assert_ok!(parse(&tokenize(&source).unwrap()));
 }
 
 #[test]
 fn parse_function_calling() {
-    let source = valid_resource("function_calling.txt");
+    let source = valid_resource_contents("function_calling.txt");
     assert_ok!(parse(&tokenize(&source).unwrap()));
 }
 
 #[test]
 fn parse_infix_function_calling() {
-    let source = valid_resource("infix_function_calling.txt");
+    let source = valid_resource_contents("infix_function_calling.txt");
     assert_ok!(parse(&tokenize(&source).unwrap()));
 }

--- a/tests/resources/invalid/syntax/assign_and_while.txt
+++ b/tests/resources/invalid/syntax/assign_and_while.txt
@@ -1,0 +1,10 @@
+def a <- 10
+def b <- 4.6
+def c <- 4.2E2
+
+def d <- 0
+while e < f, b do
+    def g <- h * i
+    j - k mod 2 + "300"
+
+while l < m do print n

--- a/tests/resources/invalid/syntax/assign_and_while.txt
+++ b/tests/resources/invalid/syntax/assign_and_while.txt
@@ -1,10 +1,11 @@
 def a <- 10
 def b <- 4.6
 def c <- 4.2E2
+def illegal <- e * def other
 
 def d <- 0
 while e < f, b do
     def g <- h * i
-    j - k mod 2 + "300"
+    j <- k mod 2 + "300"
 
 while l < m do print n

--- a/tests/smoke.rs
+++ b/tests/smoke.rs
@@ -1,4 +1,4 @@
-use crate::util::valid_resource_contents;
+use crate::util::valid_resource_content;
 use mamba::core::to_py_source;
 use mamba::desugarer::desugar;
 use mamba::lexer::tokenize;
@@ -8,7 +8,7 @@ mod util;
 
 #[test]
 fn class_to_python() {
-    let source = valid_resource_contents("class.txt");
+    let source = valid_resource_content("class.txt");
 
     let tokens = tokenize(&source).unwrap();
     let ast_tree = parse(&tokens).unwrap();

--- a/tests/smoke.rs
+++ b/tests/smoke.rs
@@ -1,5 +1,4 @@
-use crate::util::valid_resource;
-
+use crate::util::valid_resource_contents;
 use mamba::core::to_py_source;
 use mamba::desugarer::desugar;
 use mamba::lexer::tokenize;
@@ -9,7 +8,7 @@ mod util;
 
 #[test]
 fn class_to_python() {
-    let source = valid_resource("class.txt");
+    let source = valid_resource_contents("class.txt");
 
     let tokens = tokenize(&source).unwrap();
     let ast_tree = parse(&tokens).unwrap();

--- a/tests/util.rs
+++ b/tests/util.rs
@@ -1,7 +1,8 @@
+use std::fs;
 use std::fs::File;
 use std::io::Read;
 use std::path::Path;
-use std::path::PathBuf;use std::fs;
+use std::path::PathBuf;
 
 #[macro_export]
 macro_rules! assert_ok {
@@ -58,5 +59,7 @@ pub fn valid_resource_exists_and_delete(file: &str) -> bool {
     if path.exists() {
         fs::remove_file(path);
         true
-    } else { false }
+    } else {
+        false
+    }
 }

--- a/tests/util.rs
+++ b/tests/util.rs
@@ -24,6 +24,7 @@ fn resource_path(file: &String) -> String {
     String::from(source_path.to_string_lossy())
 }
 
+#[ignore(unused_must_use)]
 fn resource_string_content(file: &String) -> String {
     let mut content = String::new();
 

--- a/tests/util.rs
+++ b/tests/util.rs
@@ -12,8 +12,7 @@ macro_rules! assert_ok {
     }};
 }
 
-pub fn resource_string_content(file: String) -> String {
-    let mut content = String::new();
+fn resource_path(file: &String) -> String {
     let mut source_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     source_path.push(if cfg!(windows) {
                          String::from("tests\\resources\\")
@@ -22,23 +21,30 @@ pub fn resource_string_content(file: String) -> String {
                      });
     source_path.push(file);
 
-    match source_path.to_str() {
-        Some(path) => match File::open(path) {
-            Ok(mut file) => {
-                file.read_to_string(&mut content).unwrap();
-            }
-            Err(error) => panic!("Error opening file {}: {}", path, error)
-        },
-        None => panic!("Error opening file: path can't be converted to string.")
-    }
-
-    return content;
+    String::from(source_path.to_string_lossy())
 }
 
-pub fn valid_resource(file: &str) -> String {
+fn resource_string_content(file: &String) -> String {
+    let mut content = String::new();
+
+    let path = valid_resource_path(file);
+    File::open(path).unwrap().read_to_string(&mut content);
+
+    content
+}
+
+pub fn valid_resource_contents(file: &str) -> String {
     if cfg!(windows) {
-        resource_string_content(format!("{}{}", "valid\\", file))
+        resource_string_content(&format!("{}{}", "valid\\", file))
     } else {
-        resource_string_content(format!("{}{}", "valid/", file))
+        resource_string_content(&format!("{}{}", "valid/", file))
+    }
+}
+
+pub fn valid_resource_path(file: &str) -> String {
+    if cfg!(windows) {
+        resource_path(&format!("{}{}", "valid\\", file))
+    } else {
+        resource_path(&format!("{}{}", "valid/", file))
     }
 }

--- a/tests/util.rs
+++ b/tests/util.rs
@@ -1,5 +1,6 @@
 use std::fs::File;
 use std::io::Read;
+use std::path::Path;
 use std::path::PathBuf;
 
 #[macro_export]
@@ -15,10 +16,10 @@ macro_rules! assert_ok {
 fn resource_path(file: &String) -> String {
     let mut source_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     source_path.push(if cfg!(windows) {
-                         String::from("tests\\resources\\")
-                     } else {
-                         String::from("tests/resources/")
-                     });
+        String::from("tests\\resources\\")
+    } else {
+        String::from("tests/resources/")
+    });
     source_path.push(file);
 
     String::from(source_path.to_string_lossy())
@@ -48,4 +49,8 @@ pub fn valid_resource_path(file: &str) -> String {
     } else {
         resource_path(&format!("{}{}", "valid/", file))
     }
+}
+
+pub fn valid_resource_exists(file: &str) -> bool {
+    Path::exists(file.as_ref())
 }

--- a/tests/util.rs
+++ b/tests/util.rs
@@ -1,7 +1,7 @@
 use std::fs::File;
 use std::io::Read;
 use std::path::Path;
-use std::path::PathBuf;
+use std::path::PathBuf;use std::fs;
 
 #[macro_export]
 macro_rules! assert_ok {
@@ -16,10 +16,10 @@ macro_rules! assert_ok {
 fn resource_path(file: &String) -> String {
     let mut source_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     source_path.push(if cfg!(windows) {
-        String::from("tests\\resources\\")
-    } else {
-        String::from("tests/resources/")
-    });
+                         String::from("tests\\resources\\")
+                     } else {
+                         String::from("tests/resources/")
+                     });
     source_path.push(file);
 
     String::from(source_path.to_string_lossy())
@@ -51,6 +51,12 @@ pub fn valid_resource_path(file: &str) -> String {
     }
 }
 
-pub fn valid_resource_exists(file: &str) -> bool {
-    Path::exists(file.as_ref())
+/// Checks if a resource exists and then immediately deletes it if it does.
+pub fn valid_resource_exists_and_delete(file: &str) -> bool {
+    let path_string = valid_resource_path(file);
+    let path = Path::new(&path_string);
+    if path.exists() {
+        fs::remove_file(path);
+        true
+    } else { false }
 }

--- a/tests/util.rs
+++ b/tests/util.rs
@@ -14,47 +14,44 @@ macro_rules! assert_ok {
     }};
 }
 
-fn resource_path(file: &String) -> String {
-    let mut source_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-    source_path.push(if cfg!(windows) {
-                         String::from("tests\\resources\\")
-                     } else {
-                         String::from("tests/resources/")
-                     });
-    source_path.push(file);
+pub fn valid_resource_content(file: &str) -> String { resource_content("valid", file) }
 
-    String::from(source_path.to_string_lossy())
-}
+pub fn valid_resource_path(file: &str) -> String { resource_path("valid", file) }
 
-#[clippy::ignore(unused_must_use)]
-fn resource_string_content(file: &String) -> String {
+pub fn invalid_resource_content(file: &str) -> String { resource_content("invalid", file) }
+
+pub fn invalid_resource_path(file: &str) -> String { resource_path("invalid", file) }
+
+fn resource_content(subdir: &str, file: &str) -> String {
     let mut content = String::new();
-
-    let path = resource_path(file);
+    let path = resource_path(subdir, file);
     File::open(path).unwrap().read_to_string(&mut content);
 
     content
 }
 
-pub fn valid_resource_contents(file: &str) -> String {
-    if cfg!(windows) {
-        resource_string_content(&format!("{}{}", "valid\\", file))
-    } else {
-        resource_string_content(&format!("{}{}", "valid/", file))
-    }
+fn resource_path(subdir: &str, file: &str) -> String {
+    let mut source_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    source_path.push(if cfg!(windows) {
+                         format!("tests\\resources\\{}\\{}", subdir, file)
+                     } else {
+                         format!("tests/resources/{}/{}", subdir, file)
+                     });
+
+    String::from(source_path.to_string_lossy())
 }
 
-pub fn valid_resource_path(file: &str) -> String {
-    if cfg!(windows) {
-        resource_path(&format!("{}{}", "valid\\", file))
-    } else {
-        resource_path(&format!("{}{}", "valid/", file))
-    }
-}
-
-/// Checks if a resource exists and then immediately deletes it if it does.
-pub fn valid_resource_exists_and_delete(file: &str) -> bool {
+pub fn check_valid_resource_exists_and_delete(file: &str) -> bool {
     let path_string = valid_resource_path(file);
+    remove(&path_string)
+}
+
+pub fn check_invalid_resource_exists_and_delete(file: &str) -> bool {
+    let path_string = invalid_resource_path(file);
+    remove(&path_string)
+}
+
+fn remove(path_string: &String) -> bool {
     let path = Path::new(&path_string);
     if path.exists() {
         fs::remove_file(path);

--- a/tests/util.rs
+++ b/tests/util.rs
@@ -24,7 +24,7 @@ fn resource_path(file: &String) -> String {
     String::from(source_path.to_string_lossy())
 }
 
-#[ignore(unused_must_use)]
+#[clippy::ignore(unused_must_use)]
 fn resource_string_content(file: &String) -> String {
     let mut content = String::new();
 

--- a/tests/util.rs
+++ b/tests/util.rs
@@ -27,7 +27,7 @@ fn resource_path(file: &String) -> String {
 fn resource_string_content(file: &String) -> String {
     let mut content = String::new();
 
-    let path = valid_resource_path(file);
+    let path = resource_path(file);
     File::open(path).unwrap().read_to_string(&mut content);
 
     content


### PR DESCRIPTION
### Relevant issues
Implements #17. Should also make it easier to test outputted python files, as stated in #32. 
A next step would also be to finally create a command line interface.

### Summary
Wraps the pipeline, and allows us to specify mamba files which should be converted to python files.
We can:
- Use the default location, meaning a python file is stored alongside the mamba input.
- We can specify an output directory.

In future, we should extend this functionality so we can recursively iterate over a directory, and output each file elsewhere.
The directory structure of the output should then mirror the directory structure of the input.

### Added Tests
Tests added to check that reading and writing files work and that the pipeline behaves.

### Additional Context
...
