### PR TITLE
update mamba doc link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 # Mamba
 
 This is the Mamba programming language. 
-The Documentation can be found [here](https://github.com/JSAbrahams/mamba_doc).
+The Documentation can be found [here](https://joelabrahams.nl/mamba_doc/).
 This documentation outlines the different language features, and also contains a formal specification of the language.
 
 In short, Mamba is like Python, but with a few key features:


### PR DESCRIPTION
### Relevant issues
The link pointed to the repo, which is not as navigable.

### Summary
The link now points to the documentation, currently at http://joelabrahams.nl/mamba_doc/

### Added Tests
Clicked on the link to make sure it works.

### Additional Context
...
