### PR TITLE
Add tests for parser

### DIFF
--- a/src/desugarer/expression.rs
+++ b/src/desugarer/expression.rs
@@ -244,7 +244,7 @@ pub fn desugar_node(node_pos: &ASTNodePos) -> Core {
             method: String::from("range_incl"),
             args:   vec![desugar_node(to)]
         },
-        ASTNode::UnderScore => Core::UnderScore,
+        ASTNode::Underscore => Core::UnderScore,
         ASTNode::QuestOr { _do, _default } => Core::Block {
             statements: vec![
                 Core::VarDef {

--- a/src/desugarer/expression.rs
+++ b/src/desugarer/expression.rs
@@ -85,10 +85,8 @@ pub fn desugar_node(node_pos: &ASTNodePos) -> Core {
         },
         ASTNode::Match { cond, cases } =>
             Core::When { cond: desugar_vec(cond), cases: desugar_vec(cases) },
-        ASTNode::Case { cond, expr_or_stmt } => Core::Case {
-            cond: Box::from(desugar_node(cond)),
-            then: Box::from(desugar_node(expr_or_stmt))
-        },
+        ASTNode::Case { cond, expr } =>
+            Core::Case { cond: Box::from(desugar_node(cond)), then: Box::from(desugar_node(expr)) },
         ASTNode::While { cond, body } =>
             Core::While { cond: desugar_vec(cond), body: Box::from(desugar_node(body)) },
         ASTNode::For { expr, collection, body } => Core::For {

--- a/src/parser/ast.rs
+++ b/src/parser/ast.rs
@@ -1,4 +1,4 @@
-#[derive(PartialEq, Eq, Hash, Debug)]
+#[derive(PartialEq, Eq, Hash, Debug, Clone)]
 /// Wrapper of ASTNode, and its start end end position in the source code.
 /// The start and end positions can be used to generate useful error messages.
 pub struct ASTNodePos {
@@ -9,7 +9,7 @@ pub struct ASTNodePos {
     pub node:    ASTNode
 }
 
-#[derive(PartialEq, Eq, Hash, Debug)]
+#[derive(PartialEq, Eq, Hash, Debug, Clone)]
 pub enum ASTNode {
     File {
         imports:   Vec<ASTNodePos>,

--- a/src/parser/ast.rs
+++ b/src/parser/ast.rs
@@ -296,8 +296,8 @@ pub enum ASTNode {
         cases: Vec<ASTNodePos>
     },
     Case {
-        cond:         Box<ASTNodePos>,
-        expr_or_stmt: Box<ASTNodePos>
+        cond: Box<ASTNodePos>,
+        expr: Box<ASTNodePos>
     },
     For {
         expr:       Vec<ASTNodePos>,

--- a/src/parser/ast.rs
+++ b/src/parser/ast.rs
@@ -315,7 +315,7 @@ pub enum ASTNode {
         expr: Box<ASTNodePos>
     },
     ReturnEmpty,
-    UnderScore,
+    Underscore,
 
     QuestOr {
         _do:      Box<ASTNodePos>,

--- a/src/parser/ast.rs
+++ b/src/parser/ast.rs
@@ -84,12 +84,7 @@ pub enum ASTNode {
     },
     Retry,
 
-    FunctionCall {
-        namespace: Box<ASTNodePos>,
-        name:      Box<ASTNodePos>,
-        args:      Vec<ASTNodePos>
-    },
-    FunctionCallDirect {
+    DirectCall {
         name: Box<ASTNodePos>,
         args: Vec<ASTNodePos>
     },
@@ -99,8 +94,8 @@ pub enum ASTNode {
         args:     Vec<ASTNodePos>
     },
     Call {
-        instance_or_met: Box<ASTNodePos>,
-        met_or_arg:      Box<ASTNodePos>
+        left:  Box<ASTNodePos>,
+        right: Box<ASTNodePos>
     },
 
     Id {

--- a/src/parser/control_flow_expr.rs
+++ b/src/parser/control_flow_expr.rs
@@ -103,6 +103,6 @@ fn parse_match_case(it: &mut TPIterator) -> ParseResult {
         st_pos,
         en_line: expr_or_stmt.en_line,
         en_pos: expr_or_stmt.en_pos,
-        node: ASTNode::Case { cond, expr_or_stmt }
+        node: ASTNode::Case { cond, expr: expr_or_stmt }
     })
 }

--- a/src/parser/expression.rs
+++ b/src/parser/expression.rs
@@ -39,6 +39,7 @@ pub fn parse_expression(it: &mut TPIterator) -> ParseResult {
         | Some(TokenPos { token: Token::Str(_), .. })
         | Some(TokenPos { token: Token::Bool(_), .. })
         | Some(TokenPos { token: Token::Not, .. })
+        | Some(TokenPos { token: Token::Sqrt, .. })
         | Some(TokenPos { token: Token::Add, .. })
         | Some(TokenPos { token: Token::Id(_), .. })
         | Some(TokenPos { token: Token::Sub, .. }) => parse_operation(it),

--- a/src/parser/expression.rs
+++ b/src/parser/expression.rs
@@ -29,7 +29,7 @@ pub fn parse_expression(it: &mut TPIterator) -> ParseResult {
         Some(TokenPos { token: Token::Underscore, .. }) => {
             let (en_line, en_pos) = end_pos(it);
             it.next();
-            Ok(ASTNodePos { st_line, st_pos, en_line, en_pos, node: ASTNode::UnderScore })
+            Ok(ASTNodePos { st_line, st_pos, en_line, en_pos, node: ASTNode::Underscore })
         }
 
         Some(TokenPos { token: Token::_Self, .. })
@@ -70,7 +70,7 @@ fn parse_post_expr(pre: ASTNodePos, it: &mut TPIterator) -> ParseResult {
         }
         Some(TokenPos { token: Token::Range, .. }) => {
             it.next();
-            let to: Box<ASTNodePos> = get_or_err!(it, parse_expression, "?or");
+            let to: Box<ASTNodePos> = get_or_err!(it, parse_expression, "..");
 
             let (en_line, en_pos) = (to.en_line, to.en_pos);
             let node = ASTNode::Range { from: Box::from(pre), to };
@@ -78,7 +78,7 @@ fn parse_post_expr(pre: ASTNodePos, it: &mut TPIterator) -> ParseResult {
         }
         Some(TokenPos { token: Token::RangeIncl, .. }) => {
             it.next();
-            let to: Box<ASTNodePos> = get_or_err!(it, parse_expression, "?or");
+            let to: Box<ASTNodePos> = get_or_err!(it, parse_expression, "..=");
 
             let (en_line, en_pos) = (to.en_line, to.en_pos);
             let node = ASTNode::RangeIncl { from: Box::from(pre), to };

--- a/src/parser/operation.rs
+++ b/src/parser/operation.rs
@@ -59,7 +59,7 @@ fn parse_relation(it: &mut TPIterator) -> ParseResult {
     }
 
     match it.peek() {
-        Some(TokenPos { token: Token::Ge, .. }) => bin_op!(parse_relation, IsA, "greater than"),
+        Some(TokenPos { token: Token::Ge, .. }) => bin_op!(parse_relation, Ge, "greater than"),
         Some(TokenPos { token: Token::Geq, .. }) =>
             bin_op!(parse_relation, Geq, "greater or equal than"),
         Some(TokenPos { token: Token::Le, .. }) => bin_op!(parse_relation, Le, "less than"),

--- a/src/parser/statement.rs
+++ b/src/parser/statement.rs
@@ -5,8 +5,6 @@ use crate::parser::ast::ASTNodePos;
 use crate::parser::control_flow_stmt::parse_cntrl_flow_stmt;
 use crate::parser::definition::parse_definition;
 use crate::parser::end_pos;
-use crate::parser::expr_or_stmt::parse_handle;
-use crate::parser::expr_or_stmt::parse_raise;
 use crate::parser::expression::parse_expression;
 use crate::parser::parse_result::ParseErr::*;
 use crate::parser::parse_result::ParseResult;
@@ -15,8 +13,7 @@ use crate::parser::TPIterator;
 
 pub fn parse_statement(it: &mut TPIterator) -> ParseResult {
     let (st_line, st_pos) = start_pos(it);
-
-    let result = match it.peek() {
+    match it.peek() {
         Some(TokenPos { token: Token::Print, .. }) => {
             it.next();
             let expr: Box<ASTNodePos> = get_or_err!(it, parse_expression, "print");
@@ -37,11 +34,5 @@ pub fn parse_statement(it: &mut TPIterator) -> ParseResult {
 
         Some(&next) => Err(CustomErr { expected: "statement".to_string(), actual: next.clone() }),
         None => Err(CustomEOFErr { expected: "statement".to_string() })
-    };
-
-    match (result, it.peek()) {
-        (Ok(pre), Some(TokenPos { token: Token::Raises, .. })) => parse_raise(pre, it),
-        (Ok(pre), Some(TokenPos { token: Token::Handle, .. })) => parse_handle(pre, it),
-        (result, _) => result
     }
 }

--- a/tests/parser/call.rs
+++ b/tests/parser/call.rs
@@ -1,0 +1,138 @@
+use mamba::lexer::tokenize;
+use mamba::parser::ast::ASTNode;
+use mamba::parser::ast::ASTNodePos;
+use mamba::parser::parse_direct;
+
+#[test]
+fn anon_fun_no_args_verify() {
+    let source = String::from("\\ => c");
+    let ast_tree = parse_direct(&tokenize(&source).unwrap()).unwrap();
+
+    let (args, body) = match ast_tree.node {
+        ASTNode::Script { statements, .. } =>
+            match &statements.first().expect("script empty.").node {
+                ASTNode::AnonFun { args, body } => (args.clone(), body.clone()),
+                _ => panic!("first element script was anon fun.")
+            },
+        _ => panic!("ast_tree was not script.")
+    };
+
+    assert_eq!(args.len(), 0);
+    assert_eq!(body.node, ASTNode::Id { lit: String::from("c") });
+}
+
+#[test]
+fn anon_fun_verify() {
+    let source = String::from("\\a,b => c");
+    let ast_tree = parse_direct(&tokenize(&source).unwrap()).unwrap();
+
+    let (args, body) = match ast_tree.node {
+        ASTNode::Script { statements, .. } =>
+            match &statements.first().expect("script empty.").node {
+                ASTNode::AnonFun { args, body } => (args.clone(), body.clone()),
+                _ => panic!("first element script was anon fun.")
+            },
+        _ => panic!("ast_tree was not script.")
+    };
+
+    assert_eq!(args.len(), 2);
+    let (id1, id2) = match (&args[0], &args[1]) {
+        (
+            ASTNodePos { node: ASTNode::IdType { id: id1, _type: None }, .. },
+            ASTNodePos { node: ASTNode::IdType { id: id2, _type: None }, .. }
+        ) => (id1.clone(), id2.clone()),
+        other => panic!("Id's of anon fun not id maybe type: {:?}", other)
+    };
+
+    assert_eq!(id1.node, ASTNode::Id { lit: String::from("a") });
+    assert_eq!(id2.node, ASTNode::Id { lit: String::from("b") });
+
+    assert_eq!(body.node, ASTNode::Id { lit: String::from("c") });
+}
+
+#[test]
+fn direct_call_verify() {
+    let source = String::from("a(b, c)");
+    let ast_tree = parse_direct(&tokenize(&source).unwrap()).unwrap();
+
+    let (name, args) = match ast_tree.node {
+        ASTNode::Script { statements, .. } =>
+            match &statements.first().expect("script empty.").node {
+                ASTNode::DirectCall { name, args } => (name.clone(), args.clone()),
+                _ => panic!("first element script was anon fun.")
+            },
+        _ => panic!("ast_tree was not script.")
+    };
+
+    assert_eq!(name.node, ASTNode::Id { lit: String::from("a") });
+    assert_eq!(args.len(), 2);
+    assert_eq!(args[0].node, ASTNode::Id { lit: String::from("b") });
+    assert_eq!(args[1].node, ASTNode::Id { lit: String::from("c") });
+}
+
+#[test]
+fn method_call_verify() {
+    let source = String::from("instance.a(b, c)");
+    let ast_tree = parse_direct(&tokenize(&source).unwrap()).unwrap();
+
+    let (instance, name, args) = match ast_tree.node {
+        ASTNode::Script { statements, .. } =>
+            match &statements.first().expect("script empty.").node {
+                ASTNode::MethodCall { instance, name, args } =>
+                    (instance.clone(), name.clone(), args.clone()),
+                _ => panic!("first element script was anon fun.")
+            },
+        _ => panic!("ast_tree was not script.")
+    };
+
+    assert_eq!(instance.node, ASTNode::Id { lit: String::from("instance") });
+
+    assert_eq!(name.node, ASTNode::Id { lit: String::from("a") });
+
+    assert_eq!(args.len(), 2);
+    assert_eq!(args[0].node, ASTNode::Id { lit: String::from("b") });
+    assert_eq!(args[1].node, ASTNode::Id { lit: String::from("c") });
+}
+
+#[test]
+fn call_verify() {
+    let source = String::from("a b");
+    let ast_tree = parse_direct(&tokenize(&source).unwrap()).unwrap();
+
+    let (left, right) = match ast_tree.node {
+        ASTNode::Script { statements, .. } =>
+            match &statements.first().expect("script empty.").node {
+                ASTNode::Call { left, right } => (left.clone(), right.clone()),
+                _ => panic!("first element script was anon fun.")
+            },
+        _ => panic!("ast_tree was not script.")
+    };
+
+    assert_eq!(left.node, ASTNode::Id { lit: String::from("a") });
+    assert_eq!(right.node, ASTNode::Id { lit: String::from("b") });
+}
+
+#[test]
+fn call_right_associative_verify() {
+    let source = String::from("a b c");
+    let ast_tree = parse_direct(&tokenize(&source).unwrap()).unwrap();
+
+    let (left, right) = match ast_tree.node {
+        ASTNode::Script { statements, .. } =>
+            match &statements.first().expect("script empty.").node {
+                ASTNode::Call { left, right } => (left.clone(), right.node.clone()),
+                _ => panic!("first element script was anon fun.")
+            },
+        _ => panic!("ast_tree was not script.")
+    };
+
+    assert_eq!(left.node, ASTNode::Id { lit: String::from("a") });
+
+    let (right_left, right_right) = match right {
+        ASTNode::Call { left, right } => (left.clone(), right.clone()),
+        other => panic!("Expected nested call but was {:?}.", other)
+    };
+
+    assert_eq!(right_left.node, ASTNode::Id { lit: String::from("b") });
+    assert_eq!(right_right.node, ASTNode::Id { lit: String::from("c") });
+}

--- a/tests/parser/collection.rs
+++ b/tests/parser/collection.rs
@@ -1,7 +1,6 @@
 use crate::util::*;
 use mamba::lexer::tokenize;
 use mamba::parser::ast::ASTNode;
-use mamba::parser::ast::ASTNodePos;
 use mamba::parser::parse_direct;
 
 use mamba::parser::parse;
@@ -152,12 +151,12 @@ fn tuple_single_verify() {
     };
 
     assert_eq!(elements.len(), 1);
-    assert_eq!(elements[0].node, ASTNode::Id {lit: String::from("a")});
+    assert_eq!(elements[0].node, ASTNode::Id { lit: String::from("a") });
 }
 
 #[test]
 fn tuple_multiple_verify() {
-    let source = String::from("(a, b)");
+    let source = String::from("(d, c)");
     let ast_tree = parse_direct(&tokenize(&source).unwrap()).unwrap();
 
     let _statements;
@@ -173,6 +172,6 @@ fn tuple_multiple_verify() {
     };
 
     assert_eq!(elements.len(), 2);
-    assert_eq!(elements[0].node, ASTNode::Id {lit: String::from("a")});
-    assert_eq!(elements[0].node, ASTNode::Id {lit: String::from("b")});
+    assert_eq!(elements[0].node, ASTNode::Id { lit: String::from("d") });
+    assert_eq!(elements[1].node, ASTNode::Id { lit: String::from("c") });
 }

--- a/tests/parser/collection.rs
+++ b/tests/parser/collection.rs
@@ -1,11 +1,60 @@
 use crate::util::*;
 use mamba::lexer::tokenize;
+use mamba::parser::ast::ASTNode;
+use mamba::parser::ast::ASTNodePos;
+use mamba::parser::parse_direct;
+
 use mamba::parser::parse;
 
 #[test]
-fn parse_list() {
+fn list_expression() {
     let source = valid_resource_content(&["collection"], "tuple.mamba");
     assert_ok!(parse(&tokenize(&source).unwrap()));
+}
+
+#[test]
+fn list_verify() {
+    let source = String::from("[a, b]");
+    let ast_tree = parse_direct(&tokenize(&source).unwrap()).unwrap();
+
+    let _statements;
+    let elements = match ast_tree.node {
+        ASTNode::Script { statements, .. } => {
+            _statements = statements;
+            match &_statements.first().expect("script empty.").node {
+                ASTNode::List { elements } => elements,
+                _ => panic!("first element script was not list.")
+            }
+        }
+        _ => panic!("ast_tree was not script.")
+    };
+
+    assert_eq!(elements[0].node, ASTNode::Id { lit: String::from("a") });
+    assert_eq!(elements[1].node, ASTNode::Id { lit: String::from("b") });
+}
+
+#[test]
+fn list_builder_verify() {
+    let source = String::from("[a | c, d]");
+    let ast_tree = parse_direct(&tokenize(&source).unwrap()).unwrap();
+
+    let _statements;
+    let (items, conditions) = match ast_tree.node {
+        ASTNode::Script { statements, .. } => {
+            _statements = statements;
+            match &_statements.first().expect("script empty.").node {
+                ASTNode::ListBuilder { items, conditions } => (items, conditions),
+                _ => panic!("first element script was not list builder.")
+            }
+        }
+        _ => panic!("ast_tree was not script.")
+    };
+
+    assert_eq!(items.node, ASTNode::Id { lit: String::from("a") });
+
+    assert_eq!(conditions.len(), 2);
+    assert_eq!(conditions[0].node, ASTNode::Id { lit: String::from("c") });
+    assert_eq!(conditions[1].node, ASTNode::Id { lit: String::from("d") });
 }
 
 #[test]
@@ -15,13 +64,115 @@ fn parse_map() {
 }
 
 #[test]
-fn parse_set() {
-    let source = valid_resource_content(&["collection"], "set.mamba");
-    assert_ok!(parse(&tokenize(&source).unwrap()));
+fn set_verify() {
+    let source = String::from("{a, b}");
+    let ast_tree = parse_direct(&tokenize(&source).unwrap()).unwrap();
+
+    let _statements;
+    let elements = match ast_tree.node {
+        ASTNode::Script { statements, .. } => {
+            _statements = statements;
+            match &_statements.first().expect("script empty.").node {
+                ASTNode::Set { elements } => elements,
+                _ => panic!("first element script was not set.")
+            }
+        }
+        _ => panic!("ast_tree was not script.")
+    };
+
+    assert_eq!(elements[0].node, ASTNode::Id { lit: String::from("a") });
+    assert_eq!(elements[1].node, ASTNode::Id { lit: String::from("b") });
+}
+
+#[test]
+fn set_builder_verify() {
+    let source = String::from("{a | c, d}");
+    let ast_tree = parse_direct(&tokenize(&source).unwrap()).unwrap();
+
+    let _statements;
+    let (items, conditions) = match ast_tree.node {
+        ASTNode::Script { statements, .. } => {
+            _statements = statements;
+            match &_statements.first().expect("script empty.").node {
+                ASTNode::SetBuilder { items, conditions } => (items, conditions),
+                _ => panic!("first element script was not set builder.")
+            }
+        }
+        _ => panic!("ast_tree was not script.")
+    };
+
+    assert_eq!(items.node, ASTNode::Id { lit: String::from("a") });
+
+    assert_eq!(conditions.len(), 2);
+    assert_eq!(conditions[0].node, ASTNode::Id { lit: String::from("c") });
+    assert_eq!(conditions[1].node, ASTNode::Id { lit: String::from("d") });
 }
 
 #[test]
 fn parse_tuple() {
     let source = valid_resource_content(&["collection"], "tuple.mamba");
     assert_ok!(parse(&tokenize(&source).unwrap()));
+}
+
+#[test]
+fn tuple_empty_verify() {
+    let source = String::from("()");
+    let ast_tree = parse_direct(&tokenize(&source).unwrap()).unwrap();
+
+    let _statements;
+    let elements = match ast_tree.node {
+        ASTNode::Script { statements, .. } => {
+            _statements = statements;
+            match &_statements.first().expect("script empty.").node {
+                ASTNode::Tuple { elements } => elements,
+                _ => panic!("first element script was not tuple.")
+            }
+        }
+        _ => panic!("ast_tree was not script.")
+    };
+
+    assert_eq!(elements.len(), 0);
+}
+
+#[test]
+fn tuple_single_verify() {
+    let source = String::from("(a)");
+    let ast_tree = parse_direct(&tokenize(&source).unwrap()).unwrap();
+
+    let _statements;
+    let elements = match ast_tree.node {
+        ASTNode::Script { statements, .. } => {
+            _statements = statements;
+            match &_statements.first().expect("script empty.").node {
+                ASTNode::Tuple { elements } => elements,
+                _ => panic!("first element script was not tuple.")
+            }
+        }
+        _ => panic!("ast_tree was not script.")
+    };
+
+    assert_eq!(elements.len(), 1);
+    assert_eq!(elements[0].node, ASTNode::Id {lit: String::from("a")});
+}
+
+#[test]
+fn tuple_multiple_verify() {
+    let source = String::from("(a, b)");
+    let ast_tree = parse_direct(&tokenize(&source).unwrap()).unwrap();
+
+    let _statements;
+    let elements = match ast_tree.node {
+        ASTNode::Script { statements, .. } => {
+            _statements = statements;
+            match &_statements.first().expect("script empty.").node {
+                ASTNode::Tuple { elements } => elements,
+                _ => panic!("first element script was not tuple.")
+            }
+        }
+        _ => panic!("ast_tree was not script.")
+    };
+
+    assert_eq!(elements.len(), 2);
+    assert_eq!(elements[0].node, ASTNode::Id {lit: String::from("a")});
+    assert_eq!(elements[0].node, ASTNode::Id {lit: String::from("b")});
 }

--- a/tests/parser/control_flow.rs
+++ b/tests/parser/control_flow.rs
@@ -22,7 +22,7 @@ fn foreach_statement_verify() {
             _statements = statements;
             match &_statements.first().expect("script empty.").node {
                 ASTNode::For { expr, collection, body } => (expr, collection, body),
-                _ => panic!("first element script was not for loop.")
+                _ => panic!("first element script was not foreach.")
             }
         }
         _ => panic!("ast_tree was not script.")
@@ -44,7 +44,7 @@ fn foreach_tuple_statement_verify() {
             _statements = statements;
             match &_statements.first().expect("script empty.").node {
                 ASTNode::For { expr, collection, body } => (expr, collection, body),
-                _ => panic!("first element script was not for loop.")
+                _ => panic!("first element script was not foreach.")
             }
         }
         _ => panic!("ast_tree was not script.")
@@ -73,7 +73,7 @@ fn if_verify() {
             _statements = statements;
             match &_statements.first().expect("script empty.").node {
                 ASTNode::IfElse { cond, then, _else } => (cond, then, _else),
-                _ => panic!("first element script was not for loop.")
+                _ => panic!("first element script was not if.")
             }
         }
         _ => panic!("ast_tree was not script.")
@@ -96,7 +96,7 @@ fn if_else_verify() {
             _statements = statements;
             match &_statements.first().expect("script empty.").node {
                 ASTNode::IfElse { cond, then, _else } => (cond, then, _else),
-                _ => panic!("first element script was not for loop.")
+                _ => panic!("first element script was not if.")
             }
         }
         _ => panic!("ast_tree was not script.")
@@ -119,7 +119,7 @@ fn if_tuple_verify() {
             _statements = statements;
             match &_statements.first().expect("script empty.").node {
                 ASTNode::IfElse { cond, then, _else } => (cond, then, _else),
-                _ => panic!("first element script was not for loop.")
+                _ => panic!("first element script was not if.")
             }
         }
         _ => panic!("ast_tree was not script.")
@@ -149,7 +149,7 @@ fn match_verify() {
             _statements = statements;
             match &_statements.first().expect("script empty.").node {
                 ASTNode::Match { cond, cases } => (cond, cases),
-                _ => panic!("first element script was not for loop.")
+                _ => panic!("first element script was not match.")
             }
         }
         _ => panic!("ast_tree was not script.")
@@ -184,7 +184,7 @@ fn match_tuple_verify() {
             _statements = statements;
             match &_statements.first().expect("script empty.").node {
                 ASTNode::Match { cond, cases } => (cond, cases),
-                _ => panic!("first element script was not for loop.")
+                _ => panic!("first element script was not match.")
             }
         }
         _ => panic!("ast_tree was not script.")
@@ -212,7 +212,7 @@ fn while_verify() {
             _statements = statements;
             match &_statements.first().expect("script empty.").node {
                 ASTNode::While { cond, body } => (cond, body),
-                _ => panic!("first element script was not for loop.")
+                _ => panic!("first element script was not while.")
             }
         }
         _ => panic!("ast_tree was not script.")
@@ -234,7 +234,7 @@ fn while_tuple_verify() {
             _statements = statements;
             match &_statements.first().expect("script empty.").node {
                 ASTNode::While { cond, body } => (cond, body),
-                _ => panic!("first element script was not for loop.")
+                _ => panic!("first element script was not while.")
             }
         }
         _ => panic!("ast_tree was not script.")

--- a/tests/parser/control_flow.rs
+++ b/tests/parser/control_flow.rs
@@ -86,6 +86,35 @@ fn if_verify() {
 }
 
 #[test]
+fn if_with_block_verify() {
+    let source = String::from("if a then\n    c\n    d");
+    let ast_tree = parse_direct(&tokenize(&source).unwrap()).unwrap();
+
+    let (cond, then, _else) = match ast_tree.node {
+        ASTNode::Script { statements, .. } =>
+            match &statements.first().expect("script empty.").node {
+                ASTNode::IfElse { cond, then, _else } =>
+                    (cond.clone(), then.clone(), _else.clone()),
+                _ => panic!("first element script was not if.")
+            },
+        _ => panic!("ast_tree was not script.")
+    };
+
+    assert_eq!(cond.len(), 1);
+    assert_eq!(cond[0].node, ASTNode::Id { lit: String::from("a") });
+    assert_eq!(_else.is_none(), true);
+
+    let block = match then.node {
+        ASTNode::Block { statements } => statements,
+        other => panic!("then of if was not block, was: {:?}", other)
+    };
+
+    assert_eq!(block.len(), 2);
+    assert_eq!(block[0].node, ASTNode::Id { lit: String::from("c") });
+    assert_eq!(block[1].node, ASTNode::Id { lit: String::from("d") });
+}
+
+#[test]
 fn if_else_verify() {
     let source = String::from("if a then c else d");
     let ast_tree = parse_direct(&tokenize(&source).unwrap()).unwrap();

--- a/tests/parser/control_flow.rs
+++ b/tests/parser/control_flow.rs
@@ -1,68 +1,247 @@
 use crate::util::*;
 use mamba::lexer::tokenize;
 use mamba::parser::ast::ASTNode;
+use mamba::parser::ast::ASTNodePos;
 use mamba::parser::parse;
 use mamba::parser::parse_direct;
 
 #[test]
-fn parse_for_statement_check() {
-    let source = String::from("foreach a in c do d");
-    let ast_tree = parse_direct(&tokenize(&source).unwrap()).unwrap();
-
-    match ast_tree.node {
-        ASTNode::Script { statements, .. } =>
-            match &statements.first().expect("script empty.").node {
-                ASTNode::For { expr, collection, body } => {
-                    assert_eq!(expr[0].node, ASTNode::Id { lit: String::from("a") });
-                    assert_eq!(collection.node, ASTNode::Id { lit: String::from("c") });
-                    assert_eq!(body.node, ASTNode::Id { lit: String::from("d") });
-                }
-                _ => panic!("first element script was not for loop.")
-            },
-        _ => panic!("ast_tree was not script.")
-    };
-}
-
-#[test]
-fn parse_for_statement_multiple_expr_check() {
-    let source = String::from("foreach a,b in c do d");
-    let ast_tree = parse_direct(&tokenize(&source).unwrap()).unwrap();
-
-    match ast_tree.node {
-        ASTNode::Script { statements, .. } =>
-            match &statements.first().expect("script empty.").node {
-                ASTNode::For { expr, collection, body } => {
-                    assert_eq!(expr[0].node, ASTNode::Id { lit: String::from("a") });
-                    assert_eq!(expr[1].node, ASTNode::Id { lit: String::from("b") });
-                    assert_eq!(collection.node, ASTNode::Id { lit: String::from("c") });
-                    assert_eq!(body.node, ASTNode::Id { lit: String::from("d") });
-                }
-                _ => panic!("first element script was not for loop.")
-            },
-        _ => panic!("ast_tree was not script.")
-    };
-}
-
-#[test]
-fn parse_for_statements() {
+fn foreach_statements() {
     let source = valid_resource_content(&["control_flow"], "for_statements.mamba");
     assert_ok!(parse(&tokenize(&source).unwrap()));
 }
 
 #[test]
-fn parse_if() {
+fn foreach_statement_verify() {
+    let source = String::from("foreach a in c do d");
+    let ast_tree = parse_direct(&tokenize(&source).unwrap()).unwrap();
+
+    let _statements;
+    let (expr, collection, body) = match ast_tree.node {
+        ASTNode::Script { statements, .. } => {
+            _statements = statements;
+            match &_statements.first().expect("script empty.").node {
+                ASTNode::For { expr, collection, body } => (expr, collection, body),
+                _ => panic!("first element script was not for loop.")
+            }
+        }
+        _ => panic!("ast_tree was not script.")
+    };
+
+    assert_eq!(expr[0].node, ASTNode::Id { lit: String::from("a") });
+    assert_eq!(collection.node, ASTNode::Id { lit: String::from("c") });
+    assert_eq!(body.node, ASTNode::Id { lit: String::from("d") });
+}
+
+#[test]
+fn foreach_tuple_statement_verify() {
+    let source = String::from("foreach a,b in c do d");
+    let ast_tree = parse_direct(&tokenize(&source).unwrap()).unwrap();
+
+    let _statements;
+    let (expr, collection, body) = match ast_tree.node {
+        ASTNode::Script { statements, .. } => {
+            _statements = statements;
+            match &_statements.first().expect("script empty.").node {
+                ASTNode::For { expr, collection, body } => (expr, collection, body),
+                _ => panic!("first element script was not for loop.")
+            }
+        }
+        _ => panic!("ast_tree was not script.")
+    };
+
+    assert_eq!(expr[0].node, ASTNode::Id { lit: String::from("a") });
+    assert_eq!(expr[1].node, ASTNode::Id { lit: String::from("b") });
+    assert_eq!(collection.node, ASTNode::Id { lit: String::from("c") });
+    assert_eq!(body.node, ASTNode::Id { lit: String::from("d") });
+}
+
+#[test]
+fn if_stmt() {
     let source = valid_resource_content(&["control_flow"], "if.mamba");
     assert_ok!(parse(&tokenize(&source).unwrap()));
 }
 
 #[test]
-fn parse_match_statements() {
+fn if_verify() {
+    let source = String::from("if a then c");
+    let ast_tree = parse_direct(&tokenize(&source).unwrap()).unwrap();
+
+    let _statements;
+    let (cond, then, _else) = match ast_tree.node {
+        ASTNode::Script { statements, .. } => {
+            _statements = statements;
+            match &_statements.first().expect("script empty.").node {
+                ASTNode::IfElse { cond, then, _else } => (cond, then, _else),
+                _ => panic!("first element script was not for loop.")
+            }
+        }
+        _ => panic!("ast_tree was not script.")
+    };
+
+    assert_eq!(cond.len(), 1);
+    assert_eq!(cond[0].node, ASTNode::Id { lit: String::from("a") });
+    assert_eq!(then.node, ASTNode::Id { lit: String::from("c") });
+    assert_eq!(_else.is_none(), true);
+}
+
+#[test]
+fn if_else_verify() {
+    let source = String::from("if a then c else d");
+    let ast_tree = parse_direct(&tokenize(&source).unwrap()).unwrap();
+
+    let _statements;
+    let (cond, then, _else) = match ast_tree.node {
+        ASTNode::Script { statements, .. } => {
+            _statements = statements;
+            match &_statements.first().expect("script empty.").node {
+                ASTNode::IfElse { cond, then, _else } => (cond, then, _else),
+                _ => panic!("first element script was not for loop.")
+            }
+        }
+        _ => panic!("ast_tree was not script.")
+    };
+
+    assert_eq!(cond.len(), 1);
+    assert_eq!(cond[0].node, ASTNode::Id { lit: String::from("a") });
+    assert_eq!(then.node, ASTNode::Id { lit: String::from("c") });
+    assert_eq!(_else.as_ref().unwrap().node, ASTNode::Id { lit: String::from("d") });
+}
+
+#[test]
+fn if_tuple_verify() {
+    let source = String::from("if a,b then c");
+    let ast_tree = parse_direct(&tokenize(&source).unwrap()).unwrap();
+
+    let _statements;
+    let (cond, then, _else) = match ast_tree.node {
+        ASTNode::Script { statements, .. } => {
+            _statements = statements;
+            match &_statements.first().expect("script empty.").node {
+                ASTNode::IfElse { cond, then, _else } => (cond, then, _else),
+                _ => panic!("first element script was not for loop.")
+            }
+        }
+        _ => panic!("ast_tree was not script.")
+    };
+
+    assert_eq!(cond.len(), 2);
+    assert_eq!(cond[0].node, ASTNode::Id { lit: String::from("a") });
+    assert_eq!(cond[1].node, ASTNode::Id { lit: String::from("b") });
+    assert_eq!(then.node, ASTNode::Id { lit: String::from("c") });
+    assert_eq!(_else.is_none(), true);
+}
+
+#[test]
+fn match_statements() {
     let source = valid_resource_content(&["control_flow"], "match_statements.mamba");
     assert_ok!(parse(&tokenize(&source).unwrap()));
 }
 
 #[test]
-fn parse_while_statements() {
+fn match_verify() {
+    let source = String::from("match a with\n    a => b\n    c => d");
+    let ast_tree = parse_direct(&tokenize(&source).unwrap()).unwrap();
+
+    let _statements;
+    let (cond, cases) = match ast_tree.node {
+        ASTNode::Script { statements, .. } => {
+            _statements = statements;
+            match &_statements.first().expect("script empty.").node {
+                ASTNode::Match { cond, cases } => (cond, cases),
+                _ => panic!("first element script was not for loop.")
+            }
+        }
+        _ => panic!("ast_tree was not script.")
+    };
+
+    assert_eq!(cond.len(), 1);
+    assert_eq!(cond[0].node, ASTNode::Id { lit: String::from("a") });
+
+    assert_eq!(cases.len(), 2);
+    let (cond1, expr1, cond2, expr2) = match (&cases[0], &cases[1]) {
+        (
+            ASTNodePos { node: ASTNode::Case { cond: cond1, expr: expr1 }, .. },
+            ASTNodePos { node: ASTNode::Case { cond: cond2, expr: expr2 }, .. }
+        ) => (cond1, expr1, cond2, expr2),
+        _ => panic!("Cases incorrect.")
+    };
+
+    assert_eq!(cond1.node, ASTNode::Id { lit: String::from("a") });
+    assert_eq!(expr1.node, ASTNode::Id { lit: String::from("b") });
+    assert_eq!(cond2.node, ASTNode::Id { lit: String::from("c") });
+    assert_eq!(expr2.node, ASTNode::Id { lit: String::from("d") });
+}
+
+#[test]
+fn match_tuple_verify() {
+    let source = String::from("match a,b with\n    c => d");
+    let ast_tree = parse_direct(&tokenize(&source).unwrap()).unwrap();
+
+    let _statements;
+    let (cond, _) = match ast_tree.node {
+        ASTNode::Script { statements, .. } => {
+            _statements = statements;
+            match &_statements.first().expect("script empty.").node {
+                ASTNode::Match { cond, cases } => (cond, cases),
+                _ => panic!("first element script was not for loop.")
+            }
+        }
+        _ => panic!("ast_tree was not script.")
+    };
+
+    assert_eq!(cond.len(), 2);
+    assert_eq!(cond[0].node, ASTNode::Id { lit: String::from("a") });
+    assert_eq!(cond[1].node, ASTNode::Id { lit: String::from("b") });
+}
+
+#[test]
+fn while_statements() {
     let source = valid_resource_content(&["control_flow"], "while_statements.mamba");
     assert_ok!(parse(&tokenize(&source).unwrap()));
+}
+
+#[test]
+fn while_verify() {
+    let source = String::from("while a do d");
+    let ast_tree = parse_direct(&tokenize(&source).unwrap()).unwrap();
+
+    let _statements;
+    let (cond, body) = match ast_tree.node {
+        ASTNode::Script { statements, .. } => {
+            _statements = statements;
+            match &_statements.first().expect("script empty.").node {
+                ASTNode::While { cond, body } => (cond, body),
+                _ => panic!("first element script was not for loop.")
+            }
+        }
+        _ => panic!("ast_tree was not script.")
+    };
+
+    assert_eq!(cond.len(), 1);
+    assert_eq!(cond[0].node, ASTNode::Id { lit: String::from("a") });
+    assert_eq!(body.node, ASTNode::Id { lit: String::from("d") });
+}
+
+#[test]
+fn while_tuple_verify() {
+    let source = String::from("while a,b do d");
+    let ast_tree = parse_direct(&tokenize(&source).unwrap()).unwrap();
+
+    let _statements;
+    let (cond, body) = match ast_tree.node {
+        ASTNode::Script { statements, .. } => {
+            _statements = statements;
+            match &_statements.first().expect("script empty.").node {
+                ASTNode::While { cond, body } => (cond, body),
+                _ => panic!("first element script was not for loop.")
+            }
+        }
+        _ => panic!("ast_tree was not script.")
+    };
+
+    assert_eq!(cond.len(), 2);
+    assert_eq!(cond[0].node, ASTNode::Id { lit: String::from("a") });
+    assert_eq!(cond[1].node, ASTNode::Id { lit: String::from("b") });
+    assert_eq!(body.node, ASTNode::Id { lit: String::from("d") });
 }

--- a/tests/parser/expression_and_statement.rs
+++ b/tests/parser/expression_and_statement.rs
@@ -1,0 +1,135 @@
+use mamba::lexer::tokenize;
+use mamba::parser::ast::ASTNode;
+use mamba::parser::parse_direct;
+
+#[test]
+fn quest_or_verify() {
+    let source = String::from("a ?or b");
+    let ast_tree = parse_direct(&tokenize(&source).unwrap()).unwrap();
+
+    let (_do, _default) = match ast_tree.node {
+        ASTNode::Script { statements, .. } =>
+            match &statements.first().expect("script empty.").node {
+                ASTNode::QuestOr { _do, _default } => (_do.clone(), _default.clone()),
+                _ => panic!("first element script was not list.")
+            },
+        _ => panic!("ast_tree was not script.")
+    };
+
+    assert_eq!(_do.node, ASTNode::Id { lit: String::from("a") });
+    assert_eq!(_default.node, ASTNode::Id { lit: String::from("b") });
+}
+
+#[test]
+fn range_verify() {
+    let source = String::from("hello .. world");
+    let ast_tree = parse_direct(&tokenize(&source).unwrap()).unwrap();
+
+    let (from, to) = match ast_tree.node {
+        ASTNode::Script { statements, .. } =>
+            match &statements.first().expect("script empty.").node {
+                ASTNode::Range { from, to } => (from.clone(), to.clone()),
+                _ => panic!("first element script was not range.")
+            },
+        _ => panic!("ast_tree was not script.")
+    };
+
+    assert_eq!(from.node, ASTNode::Id { lit: String::from("hello") });
+    assert_eq!(to.node, ASTNode::Id { lit: String::from("world") });
+}
+
+#[test]
+fn range_incl_verify() {
+    let source = String::from("foo ..= bar");
+    let ast_tree = parse_direct(&tokenize(&source).unwrap()).unwrap();
+
+    let (from, to) = match ast_tree.node {
+        ASTNode::Script { statements, .. } =>
+            match &statements.first().expect("script empty.").node {
+                ASTNode::RangeIncl { from, to } => (from.clone(), to.clone()),
+                _ => panic!("first element script was not range inclusive.")
+            },
+        _ => panic!("ast_tree was not script.")
+    };
+
+    assert_eq!(from.node, ASTNode::Id { lit: String::from("foo") });
+    assert_eq!(to.node, ASTNode::Id { lit: String::from("bar") });
+}
+
+#[test]
+fn reassign_verify() {
+    let source = String::from("id <- new_value");
+    let ast_tree = parse_direct(&tokenize(&source).unwrap()).unwrap();
+
+    let (left, right) = match ast_tree.node {
+        ASTNode::Script { statements, .. } =>
+            match &statements.first().expect("script empty.").node {
+                ASTNode::ReAssign { left, right } => (left.clone(), right.clone()),
+                _ => panic!("first element script was not reassign.")
+            },
+        _ => panic!("ast_tree was not script.")
+    };
+
+    assert_eq!(left.node, ASTNode::Id { lit: String::from("id") });
+    assert_eq!(right.node, ASTNode::Id { lit: String::from("new_value") });
+}
+
+#[test]
+fn print_verify() {
+    let source = String::from("print some_value");
+    let ast_tree = parse_direct(&tokenize(&source).unwrap()).unwrap();
+
+    let expr = match ast_tree.node {
+        ASTNode::Script { statements, .. } =>
+            match &statements.first().expect("script empty.").node {
+                ASTNode::Print { expr } => expr.clone(),
+                _ => panic!("first element script was not reassign.")
+            },
+        _ => panic!("ast_tree was not script.")
+    };
+
+    assert_eq!(expr.node, ASTNode::Id { lit: String::from("some_value") });
+}
+
+#[test]
+fn return_verify() {
+    let source = String::from("return some_value");
+    let ast_tree = parse_direct(&tokenize(&source).unwrap()).unwrap();
+
+    let expr = match ast_tree.node {
+        ASTNode::Script { statements, .. } =>
+            match &statements.first().expect("script empty.").node {
+                ASTNode::Return { expr } => expr.clone(),
+                _ => panic!("first element script was not reassign.")
+            },
+        _ => panic!("ast_tree was not script.")
+    };
+
+    assert_eq!(expr.node, ASTNode::Id { lit: String::from("some_value") });
+}
+
+#[test]
+fn retry_verify() {
+    let source = String::from("retry");
+    let ast_tree = parse_direct(&tokenize(&source).unwrap()).unwrap();
+
+    let node_pos = match ast_tree.node {
+        ASTNode::Script { statements, .. } => statements.first().expect("script empty.").clone(),
+        _ => panic!("ast_tree was not script.")
+    };
+
+    assert_eq!(node_pos.node, ASTNode::Retry);
+}
+
+#[test]
+fn underscore_verify() {
+    let source = String::from("_");
+    let ast_tree = parse_direct(&tokenize(&source).unwrap()).unwrap();
+
+    let node_pos = match ast_tree.node {
+        ASTNode::Script { statements, .. } => statements.first().expect("script empty.").clone(),
+        _ => panic!("ast_tree was not script.")
+    };
+
+    assert_eq!(node_pos.node, ASTNode::Underscore);
+}

--- a/tests/parser/function.rs
+++ b/tests/parser/function.rs
@@ -3,19 +3,19 @@ use mamba::lexer::tokenize;
 use mamba::parser::parse;
 
 #[test]
-fn parse_function_definitions() {
+fn function_definitions() {
     let source = valid_resource_content(&["function"], "definition.mamba");
     assert_ok!(parse(&tokenize(&source).unwrap()));
 }
 
 #[test]
-fn parse_function_calling() {
+fn function_calling() {
     let source = valid_resource_content(&["function"], "calls.mamba");
     assert_ok!(parse(&tokenize(&source).unwrap()));
 }
 
 #[test]
-fn parse_infix_function_calling() {
+fn infix_function_calling() {
     let source = valid_resource_content(&["function"], "infix_calls.mamba");
     assert_ok!(parse(&tokenize(&source).unwrap()));
 }

--- a/tests/parser/mod.rs
+++ b/tests/parser/mod.rs
@@ -2,6 +2,7 @@ use crate::util::*;
 use mamba::lexer::tokenize;
 use mamba::parser::parse;
 
+pub mod call;
 pub mod class;
 pub mod collection;
 pub mod compound;

--- a/tests/parser/mod.rs
+++ b/tests/parser/mod.rs
@@ -6,6 +6,7 @@ pub mod class;
 pub mod collection;
 pub mod compound;
 pub mod control_flow;
+pub mod expression_and_statement;
 pub mod function;
 pub mod operation;
 

--- a/tests/parser/mod.rs
+++ b/tests/parser/mod.rs
@@ -7,6 +7,7 @@ pub mod collection;
 pub mod compound;
 pub mod control_flow;
 pub mod function;
+pub mod operation;
 
 #[test]
 fn parse_empty_file() {

--- a/tests/parser/operation.rs
+++ b/tests/parser/operation.rs
@@ -23,7 +23,7 @@ macro_rules! verify_is_un_operation {
         match $ast_tree.node {
             ASTNode::Script { statements, .. } =>
                 match &statements.first().expect("script empty.").node {
-                    ASTNode::$op { expr } => expr,
+                    ASTNode::$op { expr } => expr.clone(),
                     _ => panic!("first element script was not tuple.")
                 },
             _ => panic!("ast_tree was not script.")
@@ -201,4 +201,22 @@ fn or_verify() {
     let (left, right) = verify_is_operation!(Or, ast_tree);
     assert_eq!(left.node, ASTNode::Id { lit: String::from("one") });
     assert_eq!(right.node, ASTNode::Str { lit: String::from("asdf") });
+}
+
+#[test]
+fn not_verify() {
+    let source = String::from("not some_cond");
+    let ast_tree = parse_direct(&tokenize(&source).unwrap()).unwrap();
+
+    let expr = verify_is_un_operation!(Not, ast_tree);
+    assert_eq!(expr.node, ASTNode::Id { lit: String::from("some_cond") });
+}
+
+#[test]
+fn sqrt_verify() {
+    let source = String::from("sqrt some_num");
+    let ast_tree = parse_direct(&tokenize(&source).unwrap()).unwrap();
+
+    let expr = verify_is_un_operation!(Sqrt, ast_tree);
+    assert_eq!(expr.node, ASTNode::Id { lit: String::from("some_num") });
 }

--- a/tests/parser/operation.rs
+++ b/tests/parser/operation.rs
@@ -42,6 +42,15 @@ fn addition_verify() {
 }
 
 #[test]
+fn addition_unary_verify() {
+    let source = String::from("+ b");
+    let ast_tree = parse_direct(&tokenize(&source).unwrap()).unwrap();
+
+    let expr = verify_is_un_operation!(AddU, ast_tree);
+    assert_eq!(expr.node, ASTNode::Id { lit: String::from("b") });
+}
+
+#[test]
 fn subtraction_verify() {
     let source = String::from("a - False");
     let ast_tree = parse_direct(&tokenize(&source).unwrap()).unwrap();
@@ -49,6 +58,15 @@ fn subtraction_verify() {
     let (left, right) = verify_is_operation!(Sub, ast_tree);
     assert_eq!(left.node, ASTNode::Id { lit: String::from("a") });
     assert_eq!(right.node, ASTNode::Bool { lit: false });
+}
+
+#[test]
+fn subtraction_unary_verify() {
+    let source = String::from("- c");
+    let ast_tree = parse_direct(&tokenize(&source).unwrap()).unwrap();
+
+    let expr = verify_is_un_operation!(SubU, ast_tree);
+    assert_eq!(expr.node, ASTNode::Id { lit: String::from("c") });
 }
 
 #[test]

--- a/tests/parser/operation.rs
+++ b/tests/parser/operation.rs
@@ -1,0 +1,204 @@
+use mamba::lexer::token::Token::*;
+use mamba::lexer::tokenize;
+use mamba::parser::ast::ASTNode;
+use mamba::parser::parse_direct;
+
+macro_rules! verify_is_operation {
+    ($op:ident, $ast_tree:expr) => {{
+        match $ast_tree.node {
+            ASTNode::Script { statements, .. } => {
+                match &statements.first().expect("script empty.").node {
+                    ASTNode::$op { left, right } => (left.clone(), right.clone()),
+                    other =>
+                        panic!("first element script was not op: {}, but was: {:?}", $op, other),
+                }
+            }
+            _ => panic!("ast_tree was not script.")
+        }
+    }};
+}
+
+macro_rules! verify_is_un_operation {
+    ($op:ident, $ast_tree:expr) => {{
+        match $ast_tree.node {
+            ASTNode::Script { statements, .. } =>
+                match &statements.first().expect("script empty.").node {
+                    ASTNode::$op { expr } => expr,
+                    _ => panic!("first element script was not tuple.")
+                },
+            _ => panic!("ast_tree was not script.")
+        }
+    }};
+}
+
+#[test]
+fn addition_verify() {
+    let source = String::from("a + b");
+    let ast_tree = parse_direct(&tokenize(&source).unwrap()).unwrap();
+
+    let (left, right) = verify_is_operation!(Add, ast_tree);
+    assert_eq!(left.node, ASTNode::Id { lit: String::from("a") });
+    assert_eq!(right.node, ASTNode::Id { lit: String::from("b") });
+}
+
+#[test]
+fn subtraction_verify() {
+    let source = String::from("a - b");
+    let ast_tree = parse_direct(&tokenize(&source).unwrap()).unwrap();
+
+    let (left, right) = verify_is_operation!(Sub, ast_tree);
+    assert_eq!(left.node, ASTNode::Id { lit: String::from("a") });
+    assert_eq!(right.node, ASTNode::Id { lit: String::from("b") });
+}
+
+#[test]
+fn multiplcation_verify() {
+    let source = String::from("c * b");
+    let ast_tree = parse_direct(&tokenize(&source).unwrap()).unwrap();
+
+    let (left, right) = verify_is_operation!(Mul, ast_tree);
+    assert_eq!(left.node, ASTNode::Id { lit: String::from("c") });
+    assert_eq!(right.node, ASTNode::Id { lit: String::from("b") });
+}
+
+#[test]
+fn division_verify() {
+    let source = String::from("asd / fgh");
+    let ast_tree = parse_direct(&tokenize(&source).unwrap()).unwrap();
+
+    let (left, right) = verify_is_operation!(Div, ast_tree);
+    assert_eq!(left.node, ASTNode::Id { lit: String::from("asd") });
+    assert_eq!(right.node, ASTNode::Id { lit: String::from("fgh") });
+}
+
+#[test]
+fn power_verify() {
+    let source = String::from("chopin ^ liszt");
+    let ast_tree = parse_direct(&tokenize(&source).unwrap()).unwrap();
+
+    let (left, right) = verify_is_operation!(Pow, ast_tree);
+    assert_eq!(left.node, ASTNode::Id { lit: String::from("chopin") });
+    assert_eq!(right.node, ASTNode::Id { lit: String::from("liszt") });
+}
+
+#[test]
+fn mod_verify() {
+    let source = String::from("chopin mod liszt");
+    let ast_tree = parse_direct(&tokenize(&source).unwrap()).unwrap();
+
+    let (left, right) = verify_is_operation!(Mod, ast_tree);
+    assert_eq!(left.node, ASTNode::Id { lit: String::from("chopin") });
+    assert_eq!(right.node, ASTNode::Id { lit: String::from("liszt") });
+}
+
+#[test]
+fn is_verify() {
+    let source = String::from("p is q");
+    let ast_tree = parse_direct(&tokenize(&source).unwrap()).unwrap();
+
+    let (left, right) = verify_is_operation!(Is, ast_tree);
+    assert_eq!(left.node, ASTNode::Id { lit: String::from("p") });
+    assert_eq!(right.node, ASTNode::Id { lit: String::from("q") });
+}
+
+#[test]
+fn isnt_verify() {
+    let source = String::from("p isnt q");
+    let ast_tree = parse_direct(&tokenize(&source).unwrap()).unwrap();
+
+    let (left, right) = verify_is_operation!(IsN, ast_tree);
+    assert_eq!(left.node, ASTNode::Id { lit: String::from("p") });
+    assert_eq!(right.node, ASTNode::Id { lit: String::from("q") });
+}
+
+#[test]
+fn isa_verify() {
+    let source = String::from("lizard isa animal");
+    let ast_tree = parse_direct(&tokenize(&source).unwrap()).unwrap();
+
+    let (left, right) = verify_is_operation!(IsA, ast_tree);
+    assert_eq!(left.node, ASTNode::Id { lit: String::from("lizard") });
+    assert_eq!(right.node, ASTNode::Id { lit: String::from("animal") });
+}
+
+#[test]
+fn isnta_verify() {
+    let source = String::from("i isnta natural");
+    let ast_tree = parse_direct(&tokenize(&source).unwrap()).unwrap();
+
+    let (left, right) = verify_is_operation!(IsNA, ast_tree);
+    assert_eq!(left.node, ASTNode::Id { lit: String::from("i") });
+    assert_eq!(right.node, ASTNode::Id { lit: String::from("natural") });
+}
+
+#[test]
+fn equality_verify() {
+    let source = String::from("i = s");
+    let ast_tree = parse_direct(&tokenize(&source).unwrap()).unwrap();
+
+    let (left, right) = verify_is_operation!(Eq, ast_tree);
+    assert_eq!(left.node, ASTNode::Id { lit: String::from("i") });
+    assert_eq!(right.node, ASTNode::Id { lit: String::from("s") });
+}
+
+#[test]
+fn le_verify() {
+    let source = String::from("one < two");
+    let ast_tree = parse_direct(&tokenize(&source).unwrap()).unwrap();
+
+    let (left, right) = verify_is_operation!(Le, ast_tree);
+    assert_eq!(left.node, ASTNode::Id { lit: String::from("one") });
+    assert_eq!(right.node, ASTNode::Id { lit: String::from("two") });
+}
+
+#[test]
+fn leq_verify() {
+    let source = String::from("two_hundred <= three");
+    let ast_tree = parse_direct(&tokenize(&source).unwrap()).unwrap();
+
+    let (left, right) = verify_is_operation!(Leq, ast_tree);
+    assert_eq!(left.node, ASTNode::Id { lit: String::from("two_hundred") });
+    assert_eq!(right.node, ASTNode::Id { lit: String::from("three") });
+}
+
+#[test]
+fn ge_verify() {
+    let source = String::from("r > 10");
+    println!("{:?}", &tokenize(&source).unwrap());
+    let ast_tree = parse_direct(&tokenize(&source).unwrap()).unwrap();
+    println!("{:?}", ast_tree);
+
+    let (left, right) = verify_is_operation!(Ge, ast_tree);
+    assert_eq!(left.node, ASTNode::Id { lit: String::from("r") });
+    assert_eq!(right.node, ASTNode::Int { lit: String::from("10") });
+}
+
+#[test]
+fn geq_verify() {
+    let source = String::from("4 >= 10");
+    let ast_tree = parse_direct(&tokenize(&source).unwrap()).unwrap();
+
+    let (left, right) = verify_is_operation!(Geq, ast_tree);
+    assert_eq!(left.node, ASTNode::Int { lit: String::from("4") });
+    assert_eq!(right.node, ASTNode::Int { lit: String::from("10") });
+}
+
+#[test]
+fn and_verify() {
+    let source = String::from("one and three");
+    let ast_tree = parse_direct(&tokenize(&source).unwrap()).unwrap();
+
+    let (left, right) = verify_is_operation!(And, ast_tree);
+    assert_eq!(left.node, ASTNode::Id { lit: String::from("one") });
+    assert_eq!(right.node, ASTNode::Id { lit: String::from("three") });
+}
+
+#[test]
+fn or_verify() {
+    let source = String::from("one or \"asdf\"");
+    let ast_tree = parse_direct(&tokenize(&source).unwrap()).unwrap();
+
+    let (left, right) = verify_is_operation!(Or, ast_tree);
+    assert_eq!(left.node, ASTNode::Id { lit: String::from("one") });
+    assert_eq!(right.node, ASTNode::Str { lit: String::from("asdf") });
+}

--- a/tests/parser/operation.rs
+++ b/tests/parser/operation.rs
@@ -43,31 +43,31 @@ fn addition_verify() {
 
 #[test]
 fn subtraction_verify() {
-    let source = String::from("a - b");
+    let source = String::from("a - False");
     let ast_tree = parse_direct(&tokenize(&source).unwrap()).unwrap();
 
     let (left, right) = verify_is_operation!(Sub, ast_tree);
     assert_eq!(left.node, ASTNode::Id { lit: String::from("a") });
-    assert_eq!(right.node, ASTNode::Id { lit: String::from("b") });
+    assert_eq!(right.node, ASTNode::Bool { lit: false });
 }
 
 #[test]
-fn multiplcation_verify() {
-    let source = String::from("c * b");
+fn multiplication_verify() {
+    let source = String::from("True * b");
     let ast_tree = parse_direct(&tokenize(&source).unwrap()).unwrap();
 
     let (left, right) = verify_is_operation!(Mul, ast_tree);
-    assert_eq!(left.node, ASTNode::Id { lit: String::from("c") });
+    assert_eq!(left.node, ASTNode::Bool { lit: true });
     assert_eq!(right.node, ASTNode::Id { lit: String::from("b") });
 }
 
 #[test]
 fn division_verify() {
-    let source = String::from("asd / fgh");
+    let source = String::from("10.0 / fgh");
     let ast_tree = parse_direct(&tokenize(&source).unwrap()).unwrap();
 
     let (left, right) = verify_is_operation!(Div, ast_tree);
-    assert_eq!(left.node, ASTNode::Id { lit: String::from("asd") });
+    assert_eq!(left.node, ASTNode::Real { lit: String::from("10.0") });
     assert_eq!(right.node, ASTNode::Id { lit: String::from("fgh") });
 }
 
@@ -83,12 +83,12 @@ fn power_verify() {
 
 #[test]
 fn mod_verify() {
-    let source = String::from("chopin mod liszt");
+    let source = String::from("chopin mod 3e10");
     let ast_tree = parse_direct(&tokenize(&source).unwrap()).unwrap();
 
     let (left, right) = verify_is_operation!(Mod, ast_tree);
     assert_eq!(left.node, ASTNode::Id { lit: String::from("chopin") });
-    assert_eq!(right.node, ASTNode::Id { lit: String::from("liszt") });
+    assert_eq!(right.node, ASTNode::ENum { num: String::from("3"), exp: String::from("10") });
 }
 
 #[test]
@@ -219,4 +219,13 @@ fn sqrt_verify() {
 
     let expr = verify_is_un_operation!(Sqrt, ast_tree);
     assert_eq!(expr.node, ASTNode::Id { lit: String::from("some_num") });
+}
+
+#[test]
+fn print() {
+    let source = String::from("print my_name");
+    let ast_tree = parse_direct(&tokenize(&source).unwrap()).unwrap();
+
+    let expr = verify_is_un_operation!(Print, ast_tree);
+    assert_eq!(expr.node, ASTNode::Id { lit: String::from("my_name") });
 }


### PR DESCRIPTION
### Relevant issues
A lot of the parser remained untested. Namely, we did check that files were parsable but we didn't verify the output.

### Summary
We verify parts of the output of the parser. Fix some bugs as well, namely:
- `<` is now correctly parsed (before it was parsed as a `isa` comparison)
- `sqrt` is now correctly identified as the start of an operation

### Added Tests
Verification tests for:
- Operations
- Collections
- Control Flows

### Additional Context
...
