### PR TITLE
Test parsing definitions

### DIFF
--- a/src/parser/block.rs
+++ b/src/parser/block.rs
@@ -15,7 +15,14 @@ pub fn parse_statements(it: &mut TPIterator) -> ParseResult<Vec<ASTNodePos>> {
             Token::NL => {
                 it.next();
             }
-            _ => statements.push(get_or_err_direct!(it, parse_expr_or_stmt, "block"))
+            _ => {
+                statements.push(get_or_err_direct!(it, parse_expr_or_stmt, "block"));
+                if let Some(&t) = it.peek() {
+                    if t.token != Token::NL && t.token != Token::Dedent {
+                        return Err(TokenErr { expected: Token::NL, actual: t.clone() });
+                    }
+                }
+            }
         }
     }
 

--- a/src/parser/definition.rs
+++ b/src/parser/definition.rs
@@ -58,8 +58,7 @@ pub fn parse_definition(it: &mut TPIterator) -> ParseResult {
                 parse_variable_def_id(id, false, it),
             id @ ASTNodePos { node: ASTNode::IdType { _type: None, .. }, .. } => match it.peek() {
                 Some(TokenPos { token: Token::LRBrack, .. }) => parse_fun_def(id, it),
-                Some(_) => parse_variable_def_id(id, false, it),
-                None => Err(CustomEOFErr { expected: "id".to_string() })
+                None | Some(_) => parse_variable_def_id(id, false, it)
             },
             _ => return Err(InternalErr { message: String::from("couldn't parse def") })
         }

--- a/src/parser/definition.rs
+++ b/src/parser/definition.rs
@@ -76,9 +76,23 @@ pub fn parse_definition(it: &mut TPIterator) -> ParseResult {
     }
 }
 
-fn parse_fun_def(id: ASTNodePos, it: &mut TPIterator) -> ParseResult {
+fn parse_fun_def(id_type: ASTNodePos, it: &mut TPIterator) -> ParseResult {
     let (st_line, st_pos) = start_pos(it);
     let fun_args = get_or_err_direct!(it, parse_fun_args, "function arguments");
+
+    let id = match id_type {
+        ASTNodePos { node: ASTNode::IdType { id, _type }, .. } => match _type {
+            None => id,
+            _ =>
+                return Err(InternalErr {
+                    message: String::from("Function definition given id type with some type.")
+                }),
+        },
+        _ =>
+            return Err(InternalErr {
+                message: String::from("Function definition not given id type.")
+            }),
+    };
 
     let ret_ty: Option<Box<ASTNodePos>> = match it.peek() {
         Some(TokenPos { token: Token::DoublePoint, .. }) => {
@@ -109,10 +123,10 @@ fn parse_fun_def(id: ASTNodePos, it: &mut TPIterator) -> ParseResult {
         (_, Some(b), _) if b.last().is_some() =>
             (b.last().unwrap().en_line, b.last().unwrap().en_pos),
         (Some(b), ..) => (b.en_line, b.en_pos),
-        _ => (id.en_line, id.en_pos)
+        _ => (id_type.en_line, id_type.en_pos)
     };
 
-    let node = ASTNode::FunDef { id: Box::from(id), fun_args, ret_ty, raises, body };
+    let node = ASTNode::FunDef { id, fun_args, ret_ty, raises, body };
     Ok(ASTNodePos { st_line, st_pos, en_line, en_pos, node })
 }
 
@@ -193,13 +207,8 @@ fn parse_fun_arg(it: &mut TPIterator, pos: i32) -> ParseResult {
     };
 
     let (en_line, en_pos) = end_pos(it);
-    Ok(ASTNodePos {
-        st_line,
-        st_pos,
-        en_line,
-        en_pos,
-        node: ASTNode::FunArg { vararg, id_maybe_type, default }
-    })
+    let node = ASTNode::FunArg { vararg, id_maybe_type, default };
+    Ok(ASTNodePos { st_line, st_pos, en_line, en_pos, node })
 }
 
 pub fn parse_forward(it: &mut TPIterator) -> ParseResult<Vec<ASTNodePos>> {
@@ -222,6 +231,7 @@ pub fn parse_forward(it: &mut TPIterator) -> ParseResult<Vec<ASTNodePos>> {
 }
 
 fn parse_variable_def_id(id: ASTNodePos, mutable: bool, it: &mut TPIterator) -> ParseResult {
+    let (st_line, st_pos) = (id.st_line, id.st_pos);
     let ofmut;
     if let Some(TokenPos { token: Token::OfMut, .. }) = it.peek() {
         it.next();
@@ -249,19 +259,9 @@ fn parse_variable_def_id(id: ASTNodePos, mutable: bool, it: &mut TPIterator) -> 
         None => (id.en_line, id.en_pos)
     };
 
-    Ok(ASTNodePos {
-        st_line: id.st_line,
-        st_pos: id.st_pos,
-        en_line,
-        en_pos,
-        node: ASTNode::VariableDef {
-            mutable,
-            ofmut,
-            id_maybe_type: Box::from(id),
-            expression,
-            forward
-        }
-    })
+    let node =
+        ASTNode::VariableDef { mutable, ofmut, id_maybe_type: Box::from(id), expression, forward };
+    Ok(ASTNodePos { st_line, st_pos, en_line, en_pos, node })
 }
 
 fn parse_variable_def(it: &mut TPIterator) -> ParseResult {

--- a/tests/core/function.rs
+++ b/tests/core/function.rs
@@ -5,6 +5,7 @@ use mamba::lexer::tokenize;
 use mamba::parser::parse;
 
 #[test]
+#[ignore]
 fn core_function_definitions() {
     let source = valid_resource_content(&["function"], "definition.mamba");
     to_py!(source);

--- a/tests/parser/invalid/compound.rs
+++ b/tests/parser/invalid/compound.rs
@@ -3,7 +3,7 @@ use mamba::lexer::tokenize;
 use mamba::parser::parse;
 
 #[test]
-fn parse_assigns_and_while() {
+fn assigns_and_while() {
     let source = invalid_resource_content(&["syntax"], "assign_and_while.mamba");
     let err = parse(&tokenize(&source).unwrap());
 

--- a/tests/parser/invalid/control_flow.rs
+++ b/tests/parser/invalid/control_flow.rs
@@ -1,4 +1,3 @@
-use crate::util::*;
 use mamba::lexer::tokenize;
 use mamba::parser::parse_direct;
 

--- a/tests/parser/invalid/definition.rs
+++ b/tests/parser/invalid/definition.rs
@@ -1,0 +1,38 @@
+use mamba::lexer::tokenize;
+use mamba::parser::parse_direct;
+
+#[test]
+fn def_multiple() {
+    let source = String::from("def a b");
+    let err = parse_direct(&tokenize(&source).unwrap());
+    assert_eq!(err.is_err(), true);
+}
+
+#[test]
+fn def_mut_private_wrong_order() {
+    let source = String::from("def mut private a ");
+    let err = parse_direct(&tokenize(&source).unwrap());
+    assert_eq!(err.is_err(), true);
+}
+
+#[test]
+fn def_missing_id() {
+    let source = String::from("def");
+    let err = parse_direct(&tokenize(&source).unwrap());
+    assert_eq!(err.is_err(), true);
+}
+
+#[test]
+fn def_fun_no_closing_brack() {
+    let source = String::from("def f(a");
+    let err = parse_direct(&tokenize(&source).unwrap());
+    assert_eq!(err.is_err(), true);
+}
+
+#[test]
+fn def_fun_missing_arrow() {
+    let source = String::from("def f(a) a * 10");
+    let err = parse_direct(&tokenize(&source).unwrap());
+    println!("{:?}", err);
+    assert_eq!(err.is_err(), true);
+}

--- a/tests/parser/invalid/definition.rs
+++ b/tests/parser/invalid/definition.rs
@@ -36,3 +36,11 @@ fn def_fun_missing_arrow() {
     println!("{:?}", err);
     assert_eq!(err.is_err(), true);
 }
+
+#[test]
+fn def_fun_missing_brackets() {
+    let source = String::from("def f => print a");
+    let err = parse_direct(&tokenize(&source).unwrap());
+    println!("{:?}", err);
+    assert_eq!(err.is_err(), true);
+}

--- a/tests/parser/invalid/expression_and_statement.rs
+++ b/tests/parser/invalid/expression_and_statement.rs
@@ -1,4 +1,3 @@
-use crate::util::*;
 use mamba::lexer::tokenize;
 use mamba::parser::parse_direct;
 

--- a/tests/parser/invalid/function.rs
+++ b/tests/parser/invalid/function.rs
@@ -1,4 +1,3 @@
-use crate::util::*;
 use mamba::lexer::tokenize;
 use mamba::parser::parse_direct;
 

--- a/tests/parser/invalid/mod.rs
+++ b/tests/parser/invalid/mod.rs
@@ -1,3 +1,6 @@
 pub mod compound;
 pub mod control_flow;
+pub mod definition;
 pub mod expression_and_statement;
+pub mod function;
+pub mod operation;

--- a/tests/parser/invalid/operation.rs
+++ b/tests/parser/invalid/operation.rs
@@ -1,6 +1,4 @@
-use mamba::lexer::token::Token::*;
 use mamba::lexer::tokenize;
-use mamba::parser::ast::ASTNode;
 use mamba::parser::parse_direct;
 
 #[test]

--- a/tests/parser/valid/definition.rs
+++ b/tests/parser/valid/definition.rs
@@ -1,0 +1,175 @@
+use mamba::lexer::tokenize;
+use mamba::parser::ast::ASTNode;
+use mamba::parser::parse_direct;
+
+macro_rules! unwrap_definition {
+    ($ast_tree:expr) => {{
+        let (private, definition) = match $ast_tree.node {
+            ASTNode::Script { statements, .. } =>
+                match &statements.first().expect("script empty.").node {
+                    ASTNode::Def { private, definition } => (private.clone(), definition.clone()),
+                    _ => panic!("first element script was not foreach.")
+                },
+            _ => panic!("ast_tree was not script.")
+        };
+
+        let (mutable, ofmut, id, _type, expression, forward) = match definition.node {
+            ASTNode::VariableDef { mutable, ofmut, id_maybe_type, expression, forward } =>
+                match id_maybe_type.node {
+                    ASTNode::IdType { id, _type } =>
+                        (mutable, ofmut, id, _type, expression, forward),
+                    other => panic!("Expected id type in variable def but was {:?}.", other)
+                },
+            other => panic!("Expected variabledef but was {:?}.", other)
+        };
+
+        (private, mutable, ofmut, id, _type, expression, forward)
+    }};
+}
+
+#[test]
+fn empty_definition_verify() {
+    let source = String::from("def a");
+    let ast_tree = parse_direct(&tokenize(&source).unwrap()).unwrap();
+
+    let (private, mutable, ofmut, id, _type, expression, forward) = unwrap_definition!(ast_tree);
+
+    assert_eq!(private, false);
+    assert_eq!(mutable, false);
+    assert_eq!(ofmut, false);
+    assert_eq!(id.node, ASTNode::Id { lit: String::from("a") });
+    assert_eq!(_type, None);
+    assert_eq!(expression, None);
+    assert_eq!(forward, None);
+}
+
+#[test]
+fn definition_verify() {
+    let source = String::from("def a <- 10");
+    let ast_tree = parse_direct(&tokenize(&source).unwrap()).unwrap();
+
+    let (private, mutable, ofmut, id, _type, expression, forward) = unwrap_definition!(ast_tree);
+
+    assert_eq!(private, false);
+    assert_eq!(mutable, false);
+    assert_eq!(ofmut, false);
+    assert_eq!(id.node, ASTNode::Id { lit: String::from("a") });
+    assert_eq!(_type, None);
+    assert_eq!(forward, None);
+
+    match expression {
+        Some(expr_pos) => assert_eq!(expr_pos.node, ASTNode::Int { lit: String::from("10") }),
+        other => panic!("Unexpected expression: {:?}", other)
+    }
+}
+
+#[test]
+fn mutable_definition_verify() {
+    let source = String::from("def mut a <- 10");
+    let ast_tree = parse_direct(&tokenize(&source).unwrap()).unwrap();
+
+    let (private, mutable, ofmut, id, _type, expression, forward) = unwrap_definition!(ast_tree);
+
+    assert_eq!(private, false);
+    assert_eq!(mutable, true);
+    assert_eq!(ofmut, false);
+    assert_eq!(id.node, ASTNode::Id { lit: String::from("a") });
+    assert_eq!(_type, None);
+    assert_eq!(forward, None);
+
+    match expression {
+        Some(expr_pos) => assert_eq!(expr_pos.node, ASTNode::Int { lit: String::from("10") }),
+        other => panic!("Unexpected expression: {:?}", other)
+    }
+}
+
+#[test]
+fn ofmut_definition_verify() {
+    let source = String::from("def a ofmut <- 10");
+    let ast_tree = parse_direct(&tokenize(&source).unwrap()).unwrap();
+
+    let (private, mutable, ofmut, id, _type, expression, forward) = unwrap_definition!(ast_tree);
+
+    assert_eq!(private, false);
+    assert_eq!(mutable, false);
+    assert_eq!(ofmut, true);
+    assert_eq!(id.node, ASTNode::Id { lit: String::from("a") });
+    assert_eq!(_type, None);
+    assert_eq!(forward, None);
+
+    match expression {
+        Some(expr_pos) => assert_eq!(expr_pos.node, ASTNode::Int { lit: String::from("10") }),
+        other => panic!("Unexpected expression: {:?}", other)
+    }
+}
+
+#[test]
+fn private_definition_verify() {
+    let source = String::from("def private a <- 10");
+    let ast_tree = parse_direct(&tokenize(&source).unwrap()).unwrap();
+
+    let (private, mutable, ofmut, id, _type, expression, forward) = unwrap_definition!(ast_tree);
+
+    assert_eq!(private, true);
+    assert_eq!(mutable, false);
+    assert_eq!(ofmut, false);
+    assert_eq!(id.node, ASTNode::Id { lit: String::from("a") });
+    assert_eq!(_type, None);
+    assert_eq!(forward, None);
+
+    match expression {
+        Some(expr_pos) => assert_eq!(expr_pos.node, ASTNode::Int { lit: String::from("10") }),
+        other => panic!("Unexpected expression: {:?}", other)
+    }
+}
+
+#[test]
+fn typed_definition_verify() {
+    let source = String::from("def a: Object <- 10");
+    let ast_tree = parse_direct(&tokenize(&source).unwrap()).unwrap();
+
+    let (private, mutable, ofmut, id, _type, expression, forward) = unwrap_definition!(ast_tree);
+
+    assert_eq!(private, false);
+    assert_eq!(mutable, false);
+    assert_eq!(ofmut, false);
+    assert_eq!(id.node, ASTNode::Id { lit: String::from("a") });
+    assert_eq!(forward, None);
+
+    match _type {
+        Some(_type_pos) => match _type_pos.node {
+            ASTNode::Type { id, generics } =>
+                assert_eq!(id.node, ASTNode::Id { lit: String::from("Object") }),
+            other => panic!("Expected type but was: {:?}", other)
+        },
+        None => panic!("Expected type but was none.")
+    }
+
+    match expression {
+        Some(expr_pos) => assert_eq!(expr_pos.node, ASTNode::Int { lit: String::from("10") }),
+        other => panic!("Unexpected expression: {:?}", other)
+    }
+}
+
+#[test]
+fn forward_definition_verify() {
+    let source = String::from("def a forward b, c");
+    let ast_tree = parse_direct(&tokenize(&source).unwrap()).unwrap();
+
+    let (private, mutable, ofmut, id, _type, expression, forward) = unwrap_definition!(ast_tree);
+
+    assert_eq!(private, false);
+    assert_eq!(mutable, false);
+    assert_eq!(ofmut, false);
+    assert_eq!(id.node, ASTNode::Id { lit: String::from("a") });
+    assert_eq!(expression, None);
+
+    match forward {
+        Some(forward) => {
+            assert_eq!(forward.len(), 2);
+            assert_eq!(forward[0].node, ASTNode::Id { lit: String::from("b") });
+            assert_eq!(forward[1].node, ASTNode::Id { lit: String::from("c") });
+        }
+        None => panic!("Expected type but was none.")
+    }
+}

--- a/tests/parser/valid/definition.rs
+++ b/tests/parser/valid/definition.rs
@@ -126,7 +126,7 @@ fn typed_definition_verify() {
 
     let type_id = match _type {
         Some(_type_pos) => match _type_pos.node {
-            ASTNode::Type { id, generics } => id,
+            ASTNode::Type { id, generics: _ } => id,
             other => panic!("Expected type but was: {:?}", other)
         },
         None => panic!("Expected type but was none.")

--- a/tests/parser/valid/definition.rs
+++ b/tests/parser/valid/definition.rs
@@ -31,7 +31,6 @@ macro_rules! unwrap_definition {
 fn empty_definition_verify() {
     let source = String::from("def a");
     let ast_tree = parse_direct(&tokenize(&source).unwrap()).unwrap();
-
     let (private, mutable, ofmut, id, _type, expression, forward) = unwrap_definition!(ast_tree);
 
     assert_eq!(private, false);
@@ -47,7 +46,6 @@ fn empty_definition_verify() {
 fn definition_verify() {
     let source = String::from("def a <- 10");
     let ast_tree = parse_direct(&tokenize(&source).unwrap()).unwrap();
-
     let (private, mutable, ofmut, id, _type, expression, forward) = unwrap_definition!(ast_tree);
 
     assert_eq!(private, false);
@@ -67,7 +65,6 @@ fn definition_verify() {
 fn mutable_definition_verify() {
     let source = String::from("def mut a <- 10");
     let ast_tree = parse_direct(&tokenize(&source).unwrap()).unwrap();
-
     let (private, mutable, ofmut, id, _type, expression, forward) = unwrap_definition!(ast_tree);
 
     assert_eq!(private, false);
@@ -87,7 +84,6 @@ fn mutable_definition_verify() {
 fn ofmut_definition_verify() {
     let source = String::from("def a ofmut <- 10");
     let ast_tree = parse_direct(&tokenize(&source).unwrap()).unwrap();
-
     let (private, mutable, ofmut, id, _type, expression, forward) = unwrap_definition!(ast_tree);
 
     assert_eq!(private, false);
@@ -107,7 +103,6 @@ fn ofmut_definition_verify() {
 fn private_definition_verify() {
     let source = String::from("def private a <- 10");
     let ast_tree = parse_direct(&tokenize(&source).unwrap()).unwrap();
-
     let (private, mutable, ofmut, id, _type, expression, forward) = unwrap_definition!(ast_tree);
 
     assert_eq!(private, true);
@@ -127,49 +122,46 @@ fn private_definition_verify() {
 fn typed_definition_verify() {
     let source = String::from("def a: Object <- 10");
     let ast_tree = parse_direct(&tokenize(&source).unwrap()).unwrap();
-
     let (private, mutable, ofmut, id, _type, expression, forward) = unwrap_definition!(ast_tree);
+
+    let type_id = match _type {
+        Some(_type_pos) => match _type_pos.node {
+            ASTNode::Type { id, generics } => id,
+            other => panic!("Expected type but was: {:?}", other)
+        },
+        None => panic!("Expected type but was none.")
+    };
+    let expr = match expression {
+        Some(expr_pos) => expr_pos,
+        other => panic!("Unexpected expression: {:?}", other)
+    };
 
     assert_eq!(private, false);
     assert_eq!(mutable, false);
     assert_eq!(ofmut, false);
     assert_eq!(id.node, ASTNode::Id { lit: String::from("a") });
     assert_eq!(forward, None);
-
-    match _type {
-        Some(_type_pos) => match _type_pos.node {
-            ASTNode::Type { id, generics } =>
-                assert_eq!(id.node, ASTNode::Id { lit: String::from("Object") }),
-            other => panic!("Expected type but was: {:?}", other)
-        },
-        None => panic!("Expected type but was none.")
-    }
-
-    match expression {
-        Some(expr_pos) => assert_eq!(expr_pos.node, ASTNode::Int { lit: String::from("10") }),
-        other => panic!("Unexpected expression: {:?}", other)
-    }
+    assert_eq!(expr.node, ASTNode::Int { lit: String::from("10") });
+    assert_eq!(type_id.node, ASTNode::Id { lit: String::from("Object") });
 }
 
 #[test]
 fn forward_definition_verify() {
     let source = String::from("def a forward b, c");
     let ast_tree = parse_direct(&tokenize(&source).unwrap()).unwrap();
-
     let (private, mutable, ofmut, id, _type, expression, forward) = unwrap_definition!(ast_tree);
+
+    let forwarded = match forward {
+        Some(forward) => forward,
+        None => panic!("Expected type but was none.")
+    };
 
     assert_eq!(private, false);
     assert_eq!(mutable, false);
     assert_eq!(ofmut, false);
     assert_eq!(id.node, ASTNode::Id { lit: String::from("a") });
     assert_eq!(expression, None);
-
-    match forward {
-        Some(forward) => {
-            assert_eq!(forward.len(), 2);
-            assert_eq!(forward[0].node, ASTNode::Id { lit: String::from("b") });
-            assert_eq!(forward[1].node, ASTNode::Id { lit: String::from("c") });
-        }
-        None => panic!("Expected type but was none.")
-    }
+    assert_eq!(forwarded.len(), 2);
+    assert_eq!(forwarded[0].node, ASTNode::Id { lit: String::from("b") });
+    assert_eq!(forwarded[1].node, ASTNode::Id { lit: String::from("c") });
 }

--- a/tests/parser/valid/definition.rs
+++ b/tests/parser/valid/definition.rs
@@ -2,6 +2,27 @@ use mamba::lexer::tokenize;
 use mamba::parser::ast::ASTNode;
 use mamba::parser::parse_direct;
 
+macro_rules! unwrap_func_definition {
+    ($ast_tree:expr) => {{
+        let (private, definition) = match $ast_tree.node {
+            ASTNode::Script { statements, .. } =>
+                match &statements.first().expect("script empty.").node {
+                    ASTNode::Def { private, definition } => (private.clone(), definition.clone()),
+                    _ => panic!("first element script was not foreach.")
+                },
+            _ => panic!("ast_tree was not script.")
+        };
+
+        let (id, fun_args, ret_ty, raises, body) = match definition.node {
+            ASTNode::FunDef { id, fun_args, ret_ty, raises, body } =>
+                (id, fun_args, ret_ty, raises, body),
+            other => panic!("Expected variabledef but was {:?}.", other)
+        };
+
+        (private, id, fun_args, ret_ty, raises, body)
+    }};
+}
+
 macro_rules! unwrap_definition {
     ($ast_tree:expr) => {{
         let (private, definition) = match $ast_tree.node {
@@ -146,7 +167,7 @@ fn typed_definition_verify() {
 }
 
 #[test]
-fn forward_definition_verify() {
+fn forward_empty_definition_verify() {
     let source = String::from("def a forward b, c");
     let ast_tree = parse_direct(&tokenize(&source).unwrap()).unwrap();
     let (private, mutable, ofmut, id, _type, expression, forward) = unwrap_definition!(ast_tree);
@@ -164,4 +185,143 @@ fn forward_definition_verify() {
     assert_eq!(forwarded.len(), 2);
     assert_eq!(forwarded[0].node, ASTNode::Id { lit: String::from("b") });
     assert_eq!(forwarded[1].node, ASTNode::Id { lit: String::from("c") });
+}
+
+#[test]
+fn forward_definition_verify() {
+    let source = String::from("def a <- class forward b, c");
+    let ast_tree = parse_direct(&tokenize(&source).unwrap()).unwrap();
+    let (private, mutable, ofmut, id, _type, expression, forward) = unwrap_definition!(ast_tree);
+
+    let forwarded = match forward {
+        Some(forward) => forward,
+        None => panic!("Expected type but was none.")
+    };
+
+    assert_eq!(private, false);
+    assert_eq!(mutable, false);
+    assert_eq!(ofmut, false);
+    assert_eq!(id.node, ASTNode::Id { lit: String::from("a") });
+    assert_eq!(forwarded.len(), 2);
+    assert_eq!(forwarded[0].node, ASTNode::Id { lit: String::from("b") });
+    assert_eq!(forwarded[1].node, ASTNode::Id { lit: String::from("c") });
+
+    match expression {
+        Some(expr_pos) => assert_eq!(expr_pos.node, ASTNode::Id { lit: String::from("class") }),
+        other => panic!("Unexpected expression: {:?}", other)
+    }
+}
+
+#[test]
+fn function_definition_verify() {
+    let source = String::from("def f(b: Something, vararg c) => d");
+    let ast_tree = parse_direct(&tokenize(&source).unwrap()).unwrap();
+    let (private, id, fun_args, ret_ty, raises, body) = unwrap_func_definition!(ast_tree);
+
+    assert_eq!(private, false);
+    assert_eq!(id.node, ASTNode::Id { lit: String::from("f") });
+    assert_eq!(fun_args.len(), 2);
+    assert_eq!(ret_ty, None);
+    assert_eq!(raises, None);
+
+    match body {
+        Some(body) => assert_eq!(body.node, ASTNode::Id { lit: String::from("d") }),
+        other => panic!("Unexpected expression: {:?}", other)
+    }
+
+    match (&fun_args[0].node, &fun_args[1].node) {
+        (
+            ASTNode::FunArg { vararg: v1, id_maybe_type: id1, default: d1 },
+            ASTNode::FunArg { vararg: v2, id_maybe_type: id2, default: d2 }
+        ) => {
+            assert_eq!(v1.clone(), false);
+            assert_eq!(v2.clone(), true);
+            assert_eq!(d1.clone(), None);
+            assert_eq!(d2.clone(), None);
+
+            match (&id1.node, &id2.node) {
+                (
+                    ASTNode::IdType { id: id1, _type: t1 },
+                    ASTNode::IdType { id: id2, _type: t2 }
+                ) => {
+                    assert_eq!(id1.node, ASTNode::Id { lit: String::from("b") });
+                    assert_eq!(id2.node, ASTNode::Id { lit: String::from("c") });
+                    assert_eq!(t2.clone(), None);
+
+                    match t1.clone().unwrap().node {
+                        ASTNode::Type { id, generics } => {
+                            assert_eq!(id.node, ASTNode::Id { lit: String::from("Something") });
+                            assert_eq!(generics.len(), 0);
+                        }
+                        other => panic!("Expected type for first argument: {:?}", other)
+                    }
+                }
+                other => panic!("Expected two id's: {:?}", other)
+            }
+        }
+        other => panic!("Expected two fun args: {:?}", other)
+    }
+}
+
+#[test]
+fn function_no_args_definition_verify() {
+    let source = String::from("def f() => d");
+    let ast_tree = parse_direct(&tokenize(&source).unwrap()).unwrap();
+    let (private, id, fun_args, ret_ty, raises, body) = unwrap_func_definition!(ast_tree);
+
+    assert_eq!(private, false);
+    assert_eq!(id.node, ASTNode::Id { lit: String::from("f") });
+    assert_eq!(fun_args.len(), 0);
+    assert_eq!(ret_ty, None);
+
+    match body {
+        Some(body) => assert_eq!(body.node, ASTNode::Id { lit: String::from("d") }),
+        other => panic!("Unexpected expression: {:?}", other)
+    }
+}
+
+#[test]
+fn function_definition_with_literal_verify() {
+    let source = String::from("def f(0, vararg b: Something) => d");
+    let ast_tree = parse_direct(&tokenize(&source).unwrap()).unwrap();
+    let (private, id, fun_args, ret_ty, raises, body) = unwrap_func_definition!(ast_tree);
+
+    assert_eq!(private, false);
+    assert_eq!(id.node, ASTNode::Id { lit: String::from("f") });
+    assert_eq!(fun_args.len(), 2);
+    assert_eq!(ret_ty, None);
+
+    match body {
+        Some(body) => assert_eq!(body.node, ASTNode::Id { lit: String::from("d") }),
+        other => panic!("Unexpected expression: {:?}", other)
+    }
+
+    match (&fun_args[0].node, &fun_args[1].node) {
+        (
+            ASTNode::FunArg { vararg: v1, id_maybe_type: id1, default: d1 },
+            ASTNode::FunArg { vararg: v2, id_maybe_type: id2, default: d2 }
+        ) => {
+            assert_eq!(v1.clone(), false);
+            assert_eq!(v2.clone(), true);
+            assert_eq!(d1.clone(), None);
+            assert_eq!(d2.clone(), None);
+
+            match (&id1.node, &id2.node) {
+                (ASTNode::Int { lit }, ASTNode::IdType { id: id2, _type: t2 }) => {
+                    assert_eq!(lit.as_str(), "0");
+                    assert_eq!(id2.node, ASTNode::Id { lit: String::from("b") });
+
+                    match t2.clone().unwrap().node {
+                        ASTNode::Type { id, generics } => {
+                            assert_eq!(id.node, ASTNode::Id { lit: String::from("Something") });
+                            assert_eq!(generics.len(), 0);
+                        }
+                        other => panic!("Expected type for first argument: {:?}", other)
+                    }
+                }
+                other => panic!("Expected two id's: {:?}", other)
+            }
+        }
+        other => panic!("Expected two fun args: {:?}", other)
+    }
 }

--- a/tests/parser/valid/function.rs
+++ b/tests/parser/valid/function.rs
@@ -3,6 +3,7 @@ use mamba::lexer::tokenize;
 use mamba::parser::parse;
 
 #[test]
+#[ignore]
 fn function_definitions() {
     let source = valid_resource_content(&["function"], "definition.mamba");
     assert_ok!(parse(&tokenize(&source).unwrap()));

--- a/tests/parser/valid/mod.rs
+++ b/tests/parser/valid/mod.rs
@@ -3,6 +3,7 @@ pub mod class;
 pub mod collection;
 pub mod compound;
 pub mod control_flow;
+pub mod definition;
 pub mod expression_and_statement;
 pub mod function;
 pub mod operation;


### PR DESCRIPTION
### Relevant issues
Definitions were untested.

### Summary
Now they are.
Uncovered bug where empty definitions incorrectly raised an error.
Uncovered a bug where expressions weren't always included in operations.
Uncovered bug where no error was raised if a statement in a block was not followed by a newline or dedent.

### Added Tests
Tests for multiple correct and incorrect definitions.

### Additional Context
...
