### PR TITLE
Cache kcov in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,11 @@ before_install:
 
 cache:
   cargo: true
+  directories:
+    - /usr/local/share/doc/kcov
+    - /usr/local/bin/kcov
+    - /usr/local/bin/kcov-system-daemon
+    - /usr/local/share/man/man1/kcov.1
   install:
     # Install kcov
     - wget https://github.com/SimonKagstrom/kcov/archive/master.tar.gz

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,23 @@ sudo: true
 before_install:
   - sudo apt-get update
 
+cache:
+  cargo: true
+  install:
+    - bundle install --deployment # to cache vendor/bundle
+
+    # Install kcov
+    - wget https://github.com/SimonKagstrom/kcov/archive/master.tar.gz
+    - tar xzf master.tar.gz
+    - cd kcov-master
+    - mkdir build
+    - cd build
+    - cmake ..
+    - make
+    - sudo make install
+    - cd ../..
+    - rm -rf kcov-master
+
 addons:
   apt:
     packages:
@@ -23,18 +40,6 @@ before_script:
   - rustup install nightly
   - rustup component add rustfmt --toolchain nightly
   - rustup component add clippy
-
-  # Install kcov
-  - wget https://github.com/SimonKagstrom/kcov/archive/master.tar.gz
-  - tar xzf master.tar.gz
-  - cd kcov-master
-  - mkdir build
-  - cd build
-  - cmake ..
-  - make
-  - sudo make install
-  - cd ../..
-  - rm -rf kcov-master
 
 after_success:
   # Coverage report

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,10 +7,7 @@ before_install:
 cache:
   cargo: true
   directories:
-    - /usr/local/share/doc/kcov
-    - /usr/local/bin/kcov
-    - /usr/local/bin/kcov-system-daemon
-    - /usr/local/share/man/man1/kcov.1
+    - kcov
   install:
     # Install kcov
     - wget https://github.com/SimonKagstrom/kcov/archive/master.tar.gz

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,6 @@ before_install:
 cache:
   cargo: true
   install:
-    - bundle install --deployment # to cache vendor/bundle
-
     # Install kcov
     - wget https://github.com/SimonKagstrom/kcov/archive/master.tar.gz
     - tar xzf master.tar.gz


### PR DESCRIPTION
### Relevant issues
Travis builds are taking quite long (5 minutes).

### Summary
Cache cargo and kcov, which should speed up the build process.

### Added Tests
Check build passes and that coverage report is generated.

### Additional Context
...
