### PR TITLE
Expression wrapped in braces is no longer a tuple

### DIFF
--- a/src/parser/collection.rs
+++ b/src/parser/collection.rs
@@ -39,7 +39,11 @@ pub fn parse_tuple(it: &mut TPIterator) -> ParseResult {
     let (en_line, en_pos) = end_pos(it);
     check_next_is!(it, Token::RRBrack);
 
-    Ok(ASTNodePos { st_line, st_pos, en_line, en_pos, node: ASTNode::Tuple { elements } })
+    Ok(if elements.is_empty() || elements.len() >= 2 {
+        ASTNodePos { st_line, st_pos, en_line, en_pos, node: ASTNode::Tuple { elements } }
+    } else {
+        elements[0].clone()
+    })
 }
 
 fn parse_set(it: &mut TPIterator) -> ParseResult {

--- a/tests/parser/valid/collection.rs
+++ b/tests/parser/valid/collection.rs
@@ -134,24 +134,23 @@ fn tuple_empty_verify() {
 }
 
 #[test]
-fn tuple_single_verify() {
+fn tuple_single_is_expr_verify() {
     let source = String::from("(a)");
     let ast_tree = parse_direct(&tokenize(&source).unwrap()).unwrap();
 
     let _statements;
-    let elements = match ast_tree.node {
+    let lit = match ast_tree.node {
         ASTNode::Script { statements, .. } => {
             _statements = statements;
             match &_statements.first().expect("script empty.").node {
-                ASTNode::Tuple { elements } => elements,
+                ASTNode::Id { lit } => lit,
                 _ => panic!("first element script was not tuple.")
             }
         }
         _ => panic!("ast_tree was not script.")
     };
 
-    assert_eq!(elements.len(), 1);
-    assert_eq!(elements[0].node, ASTNode::Id { lit: String::from("a") });
+    assert_eq!(lit.as_str(), "a");
 }
 
 #[test]


### PR DESCRIPTION
### Relevant issues
As it is currently everything wrapped in brackets is a tuple.
This, however, can become confusing, especially when we want to do arithmetic, as the type checker will throw an error as we're doing arithmetic on a tuple.

### Summary
This doesn't always make sense. As [Jeff](https://github.com/Apanatshka) mentioned, some languages make it so that tuples have either 0, 2, or more elements, precisely to avoid this ambiguity.

So now a tuple with only 1 element is now no longer a tuple but an expression wrapped in braces.

### Added Tests
- Test that an expression wrapped in braces is indeed an expression and not a tuple.

### Additional Context
...
