### PR TITLE
Move mutable field from VarDef to IdType

### DIFF
--- a/src/desugar/node.rs
+++ b/src/desugar/node.rs
@@ -33,7 +33,7 @@ pub fn desugar_node(node_pos: &ASTNodePos) -> Core {
         ASTNode::LeOp => Core::LeOp,
         ASTNode::GeOp => Core::GeOp,
 
-        ASTNode::IdType { id, _type } => desugar_node(id),
+        ASTNode::IdType { id, .. } => desugar_node(id),
         ASTNode::Id { lit } => Core::Id { lit: lit.clone() },
         ASTNode::_Self => Core::Id { lit: String::from("self") },
         ASTNode::Init => Core::Id { lit: String::from("init") },

--- a/src/parser/_type.rs
+++ b/src/parser/_type.rs
@@ -184,6 +184,14 @@ pub fn parse_type_tuple(it: &mut TPIterator) -> ParseResult {
 }
 
 pub fn parse_id_maybe_type(it: &mut TPIterator) -> ParseResult {
+    let mutable;
+    if it.peek().is_some() && it.peek().unwrap().token == Token::Mut {
+        mutable = true;
+        it.next();
+    } else {
+        mutable = false;
+    }
+
     let id: Box<ASTNodePos> = get_or_err!(it, parse_id, "id maybe type");
 
     let (en_line, en_pos, _type) = match it.peek() {
@@ -196,6 +204,6 @@ pub fn parse_id_maybe_type(it: &mut TPIterator) -> ParseResult {
     };
 
     let (st_line, st_pos) = (id.st_line, id.st_pos);
-    let node = ASTNode::IdType { id, _type };
+    let node = ASTNode::IdType { id, mutable, _type };
     Ok(ASTNodePos { st_line, st_pos, en_line, en_pos, node })
 }

--- a/src/parser/ast.rs
+++ b/src/parser/ast.rs
@@ -56,7 +56,6 @@ pub enum ASTNode {
         definition: Box<ASTNodePos>
     },
     VariableDef {
-        mutable:       bool,
         ofmut:         bool,
         id_maybe_type: Box<ASTNodePos>,
         expression:    Option<Box<ASTNodePos>>,
@@ -104,8 +103,9 @@ pub enum ASTNode {
     },
 
     IdType {
-        id:    Box<ASTNodePos>,
-        _type: Option<Box<ASTNodePos>>
+        id:      Box<ASTNodePos>,
+        mutable: bool,
+        _type:   Option<Box<ASTNodePos>>
     },
     TypeDef {
         _type: Box<ASTNodePos>,

--- a/tests/desugar/collection.rs
+++ b/tests/desugar/collection.rs
@@ -25,8 +25,9 @@ fn tuple_verify() {
 fn set_verify() {
     let elements = vec![
         to_pos_unboxed!(ASTNode::IdType {
-            id:    to_pos!(ASTNode::Id { lit: String::from("a") }),
-            _type: Some(to_pos!(ASTNode::Type {
+            id:      to_pos!(ASTNode::Id { lit: String::from("a") }),
+            mutable: false,
+            _type:   Some(to_pos!(ASTNode::Type {
                 id:       to_pos!(ASTNode::Id { lit: String::from("some_type") }),
                 generics: vec![]
             }))

--- a/tests/desugar/definition.rs
+++ b/tests/desugar/definition.rs
@@ -21,7 +21,6 @@ fn reassign_verify() {
 #[test]
 fn variable_private_def_verify() {
     let definition = to_pos!(ASTNode::VariableDef {
-        mutable:       false,
         ofmut:         false,
         id_maybe_type: to_pos!(ASTNode::Id { lit: String::from("d") }),
         expression:    Some(to_pos!(ASTNode::Int { lit: String::from("98") })),
@@ -42,7 +41,6 @@ fn variable_private_def_verify() {
 #[test]
 fn variable_def_verify() {
     let definition = to_pos!(ASTNode::VariableDef {
-        mutable:       false,
         ofmut:         false,
         id_maybe_type: to_pos!(ASTNode::Id { lit: String::from("d") }),
         expression:    Some(to_pos!(ASTNode::Int { lit: String::from("98") })),
@@ -63,7 +61,6 @@ fn variable_def_verify() {
 #[test]
 fn variable_def_empty_verify() {
     let definition = to_pos!(ASTNode::VariableDef {
-        mutable:       false,
         ofmut:         false,
         id_maybe_type: to_pos!(ASTNode::Id { lit: String::from("d") }),
         expression:    None,

--- a/tests/parser/valid/call.rs
+++ b/tests/parser/valid/call.rs
@@ -38,8 +38,8 @@ fn anon_fun_verify() {
     assert_eq!(args.len(), 2);
     let (id1, id2) = match (&args[0], &args[1]) {
         (
-            ASTNodePos { node: ASTNode::IdType { id: id1, _type: None }, .. },
-            ASTNodePos { node: ASTNode::IdType { id: id2, _type: None }, .. }
+            ASTNodePos { node: ASTNode::IdType { id: id1, _type: None, mutable: false }, .. },
+            ASTNodePos { node: ASTNode::IdType { id: id2, _type: None, mutable: false }, .. }
         ) => (id1.clone(), id2.clone()),
         other => panic!("Id's of anon fun not id maybe type: {:?}", other)
     };

--- a/tests/parser/valid/definition.rs
+++ b/tests/parser/valid/definition.rs
@@ -35,9 +35,9 @@ macro_rules! unwrap_definition {
         };
 
         let (mutable, ofmut, id, _type, expression, forward) = match definition.node {
-            ASTNode::VariableDef { mutable, ofmut, id_maybe_type, expression, forward } =>
+            ASTNode::VariableDef { ofmut, id_maybe_type, expression, forward } =>
                 match id_maybe_type.node {
-                    ASTNode::IdType { id, _type } =>
+                    ASTNode::IdType { id, mutable, _type } =>
                         (mutable, ofmut, id, _type, expression, forward),
                     other => panic!("Expected id type in variable def but was {:?}.", other)
                 },
@@ -241,8 +241,8 @@ fn function_definition_verify() {
 
             match (&id1.node, &id2.node) {
                 (
-                    ASTNode::IdType { id: id1, _type: t1 },
-                    ASTNode::IdType { id: id2, _type: t2 }
+                    ASTNode::IdType { id: id1, _type: t1, mutable: false },
+                    ASTNode::IdType { id: id2, _type: t2, mutable: false }
                 ) => {
                     assert_eq!(id1.node, ASTNode::Id { lit: String::from("b") });
                     assert_eq!(id2.node, ASTNode::Id { lit: String::from("c") });
@@ -307,7 +307,7 @@ fn function_definition_with_literal_verify() {
             assert_eq!(d2.clone(), None);
 
             match (&id1.node, &id2.node) {
-                (ASTNode::Int { lit }, ASTNode::IdType { id: id2, _type: t2 }) => {
+                (ASTNode::Int { lit }, ASTNode::IdType { id: id2, mutable: false, _type: t2 }) => {
                     assert_eq!(lit.as_str(), "0");
                     assert_eq!(id2.node, ASTNode::Id { lit: String::from("b") });
 


### PR DESCRIPTION
### Relevant issues
#27 

### Summary
This reflects the change in the grammar.
A variable definition does not contain any information about the mutability of the definition.
This is now stored in the id alongside type information.

### Added Tests
Modified existing tests.

### Additional Context
...
