### PR TITLE
Test mamba class to python class

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -9,20 +9,21 @@ branches:
 
 environment:
   matrix:
-
-### MSVC Toolchains ###
-
   # Stable 64-bit MSVC
     - channel: stable
+      PYTHON: "C:\\Python37"
       target: x86_64-pc-windows-msvc
   # Nightly 64-bit MSVC
     - channel: nightly
+      PYTHON: "C:\\Python37"
       target: x86_64-pc-windows-msvc
 
 install:
   - appveyor DownloadFile https://win.rustup.rs/ -FileName rustup-init.exe
   - rustup-init -yv --default-toolchain %channel% --default-host %target%
   - set PATH=%PATH%;%USERPROFILE%\.cargo\bin
+
+  - "%PYTHON%/Scripts/pip.exe install nose"
 
   - if %channel% == "nightly" rustup install nightly
 
@@ -46,3 +47,4 @@ skip_commits:
   files:
   - '*.md'
   - .gitignore
+  - .travis

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,12 +22,16 @@ branches:
     - master
 
 before_script:
+  # Python
+  - sudo apt-get install python3
+
+  # Cargo components
   - rustup install stable
   - rustup install nightly
   - rustup component add rustfmt --toolchain nightly
   - rustup component add clippy
 
-  # Install kcov
+  # Kcov
   - wget https://github.com/SimonKagstrom/kcov/archive/master.tar.gz
   - tar xzf master.tar.gz
   - cd kcov-master

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,4 @@
-dist: xenial
-language: pyhon rust
-python:
-  - "3.7"
+language: rust
 
 sudo: true
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
-language: rust
-
 dist: xenial
-language: python
+language: pyhon rust
 python:
   - "3.7"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,10 @@
 language: rust
 
+dist: xenial
+language: python
+python:
+  - "3.7"
+
 sudo: true
 before_install:
   - sudo apt-get update

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,7 @@
 language: rust
+dist: xenial
+python:
+  - "3.7"
 
 sudo: true
 before_install:

--- a/src/core/construct.rs
+++ b/src/core/construct.rs
@@ -224,6 +224,6 @@ pub enum Core {
     UnderScore,
 
     Pass,
-    Undefined,
+    None,
     Empty
 }

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -71,22 +71,23 @@ fn to_py(core: &Core, ind: usize) -> String {
             )
         }
 
-        Core::Assign { left, right } => format!(
-            "{} = {}",
-            to_py(left.as_ref(), ind),
-            {
-                let right = to_py(right.as_ref(), ind);
-                if right.is_empty() { String::from("None") } else { right }
-            }),
-        Core::VarDef { private, id, right } => format!(
-            "{}{} = {}",
-            if *private { "_" } else { "" },
-            to_py(id.as_ref(), ind),
-            {
-                let right = to_py(right.as_ref(), ind);
-                if right.is_empty() { String::from("None") } else { right }
+        Core::Assign { left, right } => format!("{} = {}", to_py(left.as_ref(), ind), {
+            let right = to_py(right.as_ref(), ind);
+            if right.is_empty() {
+                String::from("None")
+            } else {
+                right
             }
-        ),
+        }),
+        Core::VarDef { private, id, right } =>
+            format!("{}{} = {}", if *private { "_" } else { "" }, to_py(id.as_ref(), ind), {
+                let right = to_py(right.as_ref(), ind);
+                if right.is_empty() {
+                    String::from("None")
+                } else {
+                    right
+                }
+            }),
 
         Core::FunArg { vararg, id, default } => format!(
             "{}{}{}",

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -71,23 +71,14 @@ fn to_py(core: &Core, ind: usize) -> String {
             )
         }
 
-        Core::Assign { left, right } => format!("{} = {}", to_py(left.as_ref(), ind), {
-            let right = to_py(right.as_ref(), ind);
-            if right.is_empty() {
-                String::from("None")
-            } else {
-                right
-            }
-        }),
-        Core::VarDef { private, id, right } =>
-            format!("{}{} = {}", if *private { "_" } else { "" }, to_py(id.as_ref(), ind), {
-                let right = to_py(right.as_ref(), ind);
-                if right.is_empty() {
-                    String::from("None")
-                } else {
-                    right
-                }
-            }),
+        Core::Assign { left, right } =>
+            format!("{} = {}", to_py(left.as_ref(), ind), to_py(right.as_ref(), ind)),
+        Core::VarDef { private, id, right } => format!(
+            "{}{} = {}",
+            if *private { "_" } else { "" },
+            to_py(id.as_ref(), ind),
+            to_py(right.as_ref(), ind)
+        ),
 
         Core::FunArg { vararg, id, default } => format!(
             "{}{}{}",
@@ -189,7 +180,7 @@ fn to_py(core: &Core, ind: usize) -> String {
         ),
 
         Core::Pass => String::from("pass"),
-        Core::Undefined => String::from("None"),
+        Core::None => String::from("None"),
         Core::Empty => String::new(),
 
         other => panic!("To python not implemented yet for: {:?}", other)

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -64,21 +64,28 @@ fn to_py(core: &Core, ind: usize) -> String {
             };
 
             format!(
-                "\n{}{}({}): {}",
-                indent(ind),
+                "def {}({}): {}",
                 name,
                 comma_delimited(args, ind),
                 to_py(body.as_ref(), ind + 1)
             )
         }
 
-        Core::Assign { left, right } =>
-            format!("{} = {}", to_py(left.as_ref(), ind), to_py(right.as_ref(), ind)),
+        Core::Assign { left, right } => format!(
+            "{} = {}",
+            to_py(left.as_ref(), ind),
+            {
+                let right = to_py(right.as_ref(), ind);
+                if right.is_empty() { String::from("None") } else { right }
+            }),
         Core::VarDef { private, id, right } => format!(
             "{}{} = {}",
             if *private { "_" } else { "" },
             to_py(id.as_ref(), ind),
-            to_py(right.as_ref(), ind)
+            {
+                let right = to_py(right.as_ref(), ind);
+                if right.is_empty() { String::from("None") } else { right }
+            }
         ),
 
         Core::FunArg { vararg, id, default } => format!(
@@ -93,7 +100,7 @@ fn to_py(core: &Core, ind: usize) -> String {
         ),
 
         Core::AnonFun { args, body } =>
-            format!("lambda {} : {}", comma_delimited(args, ind), to_py(body, ind)),
+            format!("lambda {}: {}", comma_delimited(args, ind), to_py(body, ind)),
 
         Core::Block { statements } => format!("\n{}", newline_delimited(statements, ind)),
 

--- a/src/desugar/definition.rs
+++ b/src/desugar/definition.rs
@@ -17,7 +17,7 @@ pub fn desugar_definition(node: &ASTNode) -> Core {
                     (id, None) => Core::VarDef {
                         private: *private,
                         id:      Box::from(desugar_node(&id)),
-                        right:   Box::from(Core::Empty)
+                        right:   Box::from(Core::None)
                     }
                 },
             ASTNode::FunDef { id, fun_args, body: expression, .. } => Core::FunDef {

--- a/src/desugar/definition.rs
+++ b/src/desugar/definition.rs
@@ -20,15 +20,26 @@ pub fn desugar_definition(node: &ASTNode) -> Core {
                         right:   Box::from(Core::Empty)
                     }
                 },
-            ASTNode::FunDef { id, fun_args, body: expression, .. } => Core::FunDef {
-                private: *private,
-                id:      Box::from(desugar_node(&id)),
-                args:    desugar_vec(&fun_args),
-                body:    Box::from(match expression {
-                    Some(expr) => desugar_node(&expr),
-                    None => Core::Empty
-                })
-            },
+            ASTNode::FunDef { id, fun_args, body: expression, .. } => {
+                let args = desugar_vec(&fun_args);
+                println!("{:?}", args);
+                if args.iter().any(|x| match &x {
+                    Core::FunArg { .. } => false,
+                    _ => true
+                }) {
+                    Core::Empty
+                } else {
+                    Core::FunDef {
+                        private: *private,
+                        id:      Box::from(desugar_node(&id)),
+                        args:    desugar_vec(&fun_args),
+                        body:    Box::from(match expression {
+                            Some(expr) => desugar_node(&expr),
+                            None => Core::Empty
+                        })
+                    }
+                }
+            }
             definition => panic!("invalid definition format: {:?}.", definition)
         },
         other => panic!("Expected control flow but was: {:?}.", other)

--- a/src/desugar/definition.rs
+++ b/src/desugar/definition.rs
@@ -20,26 +20,15 @@ pub fn desugar_definition(node: &ASTNode) -> Core {
                         right:   Box::from(Core::Empty)
                     }
                 },
-            ASTNode::FunDef { id, fun_args, body: expression, .. } => {
-                let args = desugar_vec(&fun_args);
-                println!("{:?}", args);
-                if args.iter().any(|x| match &x {
-                    Core::FunArg { .. } => false,
-                    _ => true
-                }) {
-                    Core::Empty
-                } else {
-                    Core::FunDef {
-                        private: *private,
-                        id:      Box::from(desugar_node(&id)),
-                        args:    desugar_vec(&fun_args),
-                        body:    Box::from(match expression {
-                            Some(expr) => desugar_node(&expr),
-                            None => Core::Empty
-                        })
-                    }
-                }
-            }
+            ASTNode::FunDef { id, fun_args, body: expression, .. } => Core::FunDef {
+                private: *private,
+                id:      Box::from(desugar_node(&id)),
+                args:    desugar_vec(&fun_args),
+                body:    Box::from(match expression {
+                    Some(expr) => desugar_node(&expr),
+                    None => Core::Empty
+                })
+            },
             definition => panic!("invalid definition format: {:?}.", definition)
         },
         other => panic!("Expected control flow but was: {:?}.", other)

--- a/src/desugar/node.rs
+++ b/src/desugar/node.rs
@@ -190,7 +190,7 @@ pub fn desugar_node(node_pos: &ASTNodePos) -> Core {
                     cond:  vec![Core::Not {
                         expr: Box::from(Core::Eq {
                             left:  Box::from(Core::Id { lit: String::from("$temp") }),
-                            right: Box::from(Core::Undefined)
+                            right: Box::from(Core::None)
                         })
                     }],
                     then:  Box::from(Core::Id { lit: String::from("$temp") }),

--- a/src/parser/definition.rs
+++ b/src/parser/definition.rs
@@ -175,31 +175,26 @@ fn parse_fun_arg(it: &mut TPIterator, pos: i32) -> ParseResult {
         ($factor:expr, $ast:ident) => {{
             let (en_line, en_pos) = end_pos(it);
             it.next();
-            Box::from(ASTNodePos {
-                st_line,
-                st_pos,
-                en_line,
-                en_pos,
-                node: ASTNode::$ast { lit: $factor }
-            })
+            ASTNodePos { st_line, st_pos, en_line, en_pos, node: ASTNode::$ast { lit: $factor } }
         }};
     }
 
     let (en_line, en_pos) = end_pos(it);
     let id_maybe_type = match it.peek() {
-        Some(TokenPos { token: Token::Real(real), .. }) => literal!(real.to_string(), Real),
-        Some(TokenPos { token: Token::Int(int), .. }) => literal!(int.to_string(), Int),
-        Some(TokenPos { token: Token::Bool(ref _bool), .. }) => literal!(*_bool, Bool),
-        Some(TokenPos { token: Token::Str(str), .. }) => literal!(str.to_string(), Str),
+        Some(TokenPos { token: Token::Real(real), .. }) =>
+            return Ok(literal!(real.to_string(), Real)),
+        Some(TokenPos { token: Token::Int(int), .. }) => return Ok(literal!(int.to_string(), Int)),
+        Some(TokenPos { token: Token::Bool(ref _bool), .. }) => return Ok(literal!(*_bool, Bool)),
+        Some(TokenPos { token: Token::Str(str), .. }) => return Ok(literal!(str.to_string(), Str)),
         Some(TokenPos { token: Token::ENum(num, exp), .. }) => {
             it.next();
-            Box::from(ASTNodePos {
+            return Ok(ASTNodePos {
                 st_line,
                 st_pos,
                 en_line,
                 en_pos,
                 node: ASTNode::ENum { num: num.to_string(), exp: exp.to_string() }
-            })
+            });
         }
         _ => get_or_err!(it, parse_id_maybe_type, format!("argument (pos {})", pos))
     };

--- a/src/parser/definition.rs
+++ b/src/parser/definition.rs
@@ -171,34 +171,7 @@ fn parse_fun_arg(it: &mut TPIterator, pos: i32) -> ParseResult {
         vararg = false;
     }
 
-    macro_rules! literal {
-        ($factor:expr, $ast:ident) => {{
-            let (en_line, en_pos) = end_pos(it);
-            it.next();
-            ASTNodePos { st_line, st_pos, en_line, en_pos, node: ASTNode::$ast { lit: $factor } }
-        }};
-    }
-
-    let (en_line, en_pos) = end_pos(it);
-    let id_maybe_type = match it.peek() {
-        Some(TokenPos { token: Token::Real(real), .. }) =>
-            return Ok(literal!(real.to_string(), Real)),
-        Some(TokenPos { token: Token::Int(int), .. }) => return Ok(literal!(int.to_string(), Int)),
-        Some(TokenPos { token: Token::Bool(ref _bool), .. }) => return Ok(literal!(*_bool, Bool)),
-        Some(TokenPos { token: Token::Str(str), .. }) => return Ok(literal!(str.to_string(), Str)),
-        Some(TokenPos { token: Token::ENum(num, exp), .. }) => {
-            it.next();
-            return Ok(ASTNodePos {
-                st_line,
-                st_pos,
-                en_line,
-                en_pos,
-                node: ASTNode::ENum { num: num.to_string(), exp: exp.to_string() }
-            });
-        }
-        _ => get_or_err!(it, parse_id_maybe_type, format!("argument (pos {})", pos))
-    };
-
+    let id_maybe_type = get_or_err!(it, parse_id_maybe_type, format!("argument (pos {})", pos));
     let default = match it.peek() {
         Some(TokenPos { token: Token::Assign, .. }) => {
             it.next();

--- a/src/parser/file.rs
+++ b/src/parser/file.rs
@@ -74,6 +74,7 @@ pub fn parse_import(it: &mut TPIterator) -> ParseResult {
 pub fn parse_class_body(it: &mut TPIterator) -> ParseResult {
     let mut isa = Vec::new();
     if let Some(TokenPos { token: Token::IsA, .. }) = it.peek() {
+        it.next();
         isa.push(get_or_err_direct!(it, parse_id, "generic"));
         while let Some(&t) = it.peek() {
             match t.token {

--- a/tests/command.rs
+++ b/tests/command.rs
@@ -3,8 +3,8 @@ use crate::util::valid_resource_path;
 use mamba::command::mamba_to_python;
 use mamba::command::mamba_to_python_direct;
 use std::fs::OpenOptions;
-use std::process::Command;
 use std::path::Path;
+use std::process::Command;
 
 mod util;
 

--- a/tests/command.rs
+++ b/tests/command.rs
@@ -26,7 +26,7 @@ fn output_class_output_non_existent() {
     let path = &mut Path::new(&source);
     let out_path = &mut Path::new(&output);
     match mamba_to_python(path, out_path) {
-        Ok(_) => check_valid_resource_exists_and_delete(&["class"], "class.py"),
+        Ok(_) => check_valid_resource_exists_and_delete(&["class"], "class-other.py"),
         Err(err) => panic!("{}", err)
     };
 }
@@ -56,7 +56,7 @@ fn test_empty_file_direct() {
     let path = &mut Path::new(&source);
 
     match mamba_to_python_direct(path) {
-        Ok(_) => check_valid_resource_exists_and_delete(&["class"], "class.py"),
+        Ok(_) => check_valid_resource_exists_and_delete(&[], "empty_file.py"),
         Err(err) => panic!("{}", err)
     };
 }

--- a/tests/command.rs
+++ b/tests/command.rs
@@ -3,12 +3,13 @@ use crate::util::valid_resource_path;
 use mamba::command::mamba_to_python;
 use mamba::command::mamba_to_python_direct;
 use std::fs::OpenOptions;
+use std::process::Command;
 use std::path::Path;
 
 mod util;
 
 #[test]
-fn output_class_direct() {
+fn output_class_direct_valid_syntax() {
     let source = valid_resource_path(&["class"], "class.mamba");
     let path = &mut Path::new(&source);
 

--- a/tests/command.rs
+++ b/tests/command.rs
@@ -4,7 +4,6 @@ use mamba::command::mamba_to_python;
 use mamba::command::mamba_to_python_direct;
 use std::fs::OpenOptions;
 use std::path::Path;
-use std::process::Command;
 
 mod util;
 

--- a/tests/desugar/definition.rs
+++ b/tests/desugar/definition.rs
@@ -75,7 +75,7 @@ fn variable_def_empty_verify() {
 
     assert_eq!(private, true);
     assert_eq!(*id, Core::Id { lit: String::from("d") });
-    assert_eq!(*right, Core::Empty);
+    assert_eq!(*right, Core::None);
 }
 
 // TODO add tests for default arguments once implemented

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -10,6 +10,7 @@ mod util;
 mod core;
 mod desugar;
 mod lexer;
+mod output;
 mod parser;
 
 #[test]

--- a/tests/output/common.rs
+++ b/tests/output/common.rs
@@ -1,0 +1,4 @@
+#[cfg(target_os = "linux")]
+pub static PYTHON: &str = "python3";
+#[cfg(target_os = "windows")]
+pub static PYTHON: &str = "py";

--- a/tests/output/mod.rs
+++ b/tests/output/mod.rs
@@ -1,0 +1,1 @@
+pub mod syntax;

--- a/tests/output/mod.rs
+++ b/tests/output/mod.rs
@@ -1,1 +1,3 @@
+mod common;
+
 pub mod syntax;

--- a/tests/output/syntax.rs
+++ b/tests/output/syntax.rs
@@ -9,10 +9,7 @@ fn output_class_valid_syntax() {
     let path = &mut Path::new(&source);
 
     let path = mamba_to_python_direct(path).unwrap();
-    let mut cmd = Command::new("py")
-        .arg("-m").arg("py_compile")
-        .arg(path)
-        .output().unwrap();
+    let mut cmd = Command::new("py").arg("-m").arg("py_compile").arg(path).output().unwrap();
 
     if cmd.status.code().unwrap() != 0 {
         panic!("{}", String::from_utf8(cmd.stderr).unwrap());

--- a/tests/output/syntax.rs
+++ b/tests/output/syntax.rs
@@ -6,24 +6,19 @@ use std::process::Command;
 #[test]
 fn output_tuple_valid_syntax() {
     let source = valid_resource_path(&["collection"], "tuple.mamba");
-    let path = &mut Path::new(&source);
-
-    let path = mamba_to_python_direct(path).unwrap();
+    let path = mamba_to_python_direct(Path::new(&source)).unwrap();
     let mut cmd = Command::new("py").arg("-m").arg("py_compile").arg(path).output().unwrap();
 
     if cmd.status.code().unwrap() != 0 {
         panic!("{}", String::from_utf8(cmd.stderr).unwrap());
     }
-    check_valid_resource_exists_and_delete(&["collection"], "tuple.py");
 }
 
 #[test]
 #[ignore]
 fn output_class_valid_syntax() {
     let source = valid_resource_path(&["class"], "class.mamba");
-    let path = &mut Path::new(&source);
-
-    let path = mamba_to_python_direct(path).unwrap();
+    let path = mamba_to_python_direct(Path::new(&source)).unwrap();
     let mut cmd = Command::new("py").arg("-m").arg("py_compile").arg(path).output().unwrap();
 
     if cmd.status.code().unwrap() != 0 {

--- a/tests/output/syntax.rs
+++ b/tests/output/syntax.rs
@@ -1,3 +1,4 @@
+use crate::output::common::PYTHON;
 use crate::util::*;
 use mamba::command::mamba_to_python_direct;
 use std::path::Path;
@@ -7,12 +8,12 @@ use std::process::Command;
 fn output_tuple_valid_syntax() {
     let source = valid_resource_path(&["collection"], "tuple.mamba");
     let path = mamba_to_python_direct(Path::new(&source)).unwrap();
-    let python = if cfg!(windows) { "py" } else { "python3" };
-    let cmd = Command::new(python).arg("-m").arg("py_compile").arg(path).output().unwrap();
 
+    let cmd = Command::new(PYTHON).arg("-m").arg("py_compile").arg(path).output().unwrap();
     if cmd.status.code().unwrap() != 0 {
         panic!("{}", String::from_utf8(cmd.stderr).unwrap());
     }
+    check_valid_resource_exists_and_delete(&["collection"], "tuple.py");
 }
 
 #[test]
@@ -20,10 +21,10 @@ fn output_tuple_valid_syntax() {
 fn output_class_valid_syntax() {
     let source = valid_resource_path(&["class"], "class.mamba");
     let path = mamba_to_python_direct(Path::new(&source)).unwrap();
-    let python = if cfg!(windows) { "py" } else { "python3" };
-    let cmd = Command::new(python).arg("-m").arg("py_compile").arg(path).output().unwrap();
 
+    let cmd = Command::new(PYTHON).arg("-m").arg("py_compile").arg(path).output().unwrap();
     if cmd.status.code().unwrap() != 0 {
         panic!("{}", String::from_utf8(cmd.stderr).unwrap());
     }
+    check_valid_resource_exists_and_delete(&["class"], "class.py");
 }

--- a/tests/output/syntax.rs
+++ b/tests/output/syntax.rs
@@ -7,7 +7,8 @@ use std::process::Command;
 fn output_tuple_valid_syntax() {
     let source = valid_resource_path(&["collection"], "tuple.mamba");
     let path = mamba_to_python_direct(Path::new(&source)).unwrap();
-    let mut cmd = Command::new("py").arg("-m").arg("py_compile").arg(path).output().unwrap();
+    let python = if cfg!(windows) { "py" } else { "python3" };
+    let cmd = Command::new(python).arg("-m").arg("py_compile").arg(path).output().unwrap();
 
     if cmd.status.code().unwrap() != 0 {
         panic!("{}", String::from_utf8(cmd.stderr).unwrap());
@@ -19,7 +20,8 @@ fn output_tuple_valid_syntax() {
 fn output_class_valid_syntax() {
     let source = valid_resource_path(&["class"], "class.mamba");
     let path = mamba_to_python_direct(Path::new(&source)).unwrap();
-    let mut cmd = Command::new("py").arg("-m").arg("py_compile").arg(path).output().unwrap();
+    let python = if cfg!(windows) { "py" } else { "python3" };
+    let cmd = Command::new(python).arg("-m").arg("py_compile").arg(path).output().unwrap();
 
     if cmd.status.code().unwrap() != 0 {
         panic!("{}", String::from_utf8(cmd.stderr).unwrap());

--- a/tests/output/syntax.rs
+++ b/tests/output/syntax.rs
@@ -1,0 +1,20 @@
+use crate::util::*;
+use mamba::command::mamba_to_python_direct;
+use std::path::Path;
+use std::process::Command;
+
+#[test]
+fn output_class_valid_syntax() {
+    let source = valid_resource_path(&["class"], "class.mamba");
+    let path = &mut Path::new(&source);
+
+    let path = mamba_to_python_direct(path).unwrap();
+    let mut cmd = Command::new("py")
+        .arg("-m").arg("py_compile")
+        .arg(path)
+        .output().unwrap();
+
+    if cmd.status.code().unwrap() != 0 {
+        panic!("{}", String::from_utf8(cmd.stderr).unwrap());
+    }
+}

--- a/tests/output/syntax.rs
+++ b/tests/output/syntax.rs
@@ -4,6 +4,7 @@ use std::path::Path;
 use std::process::Command;
 
 #[test]
+#[ignore]
 fn output_class_valid_syntax() {
     let source = valid_resource_path(&["class"], "class.mamba");
     let path = &mut Path::new(&source);

--- a/tests/output/syntax.rs
+++ b/tests/output/syntax.rs
@@ -4,6 +4,20 @@ use std::path::Path;
 use std::process::Command;
 
 #[test]
+fn output_tuple_valid_syntax() {
+    let source = valid_resource_path(&["collection"], "tuple.mamba");
+    let path = &mut Path::new(&source);
+
+    let path = mamba_to_python_direct(path).unwrap();
+    let mut cmd = Command::new("py").arg("-m").arg("py_compile").arg(path).output().unwrap();
+
+    if cmd.status.code().unwrap() != 0 {
+        panic!("{}", String::from_utf8(cmd.stderr).unwrap());
+    }
+    check_valid_resource_exists_and_delete(&["collection"], "tuple.py");
+}
+
+#[test]
 #[ignore]
 fn output_class_valid_syntax() {
     let source = valid_resource_path(&["class"], "class.mamba");

--- a/tests/parser/valid/definition.rs
+++ b/tests/parser/valid/definition.rs
@@ -267,7 +267,7 @@ fn function_definition_verify() {
 fn function_no_args_definition_verify() {
     let source = String::from("def f() => d");
     let ast_tree = parse_direct(&tokenize(&source).unwrap()).unwrap();
-    let (private, id, fun_args, ret_ty, raises, body) = unwrap_func_definition!(ast_tree);
+    let (private, id, fun_args, ret_ty, _, body) = unwrap_func_definition!(ast_tree);
 
     assert_eq!(private, false);
     assert_eq!(id.node, ASTNode::Id { lit: String::from("f") });
@@ -282,7 +282,7 @@ fn function_no_args_definition_verify() {
 
 #[test]
 fn function_definition_with_literal_verify() {
-    let source = String::from("def f(0, vararg b: Something) => d");
+    let source = String::from("def f(x, vararg b: Something) => d");
     let ast_tree = parse_direct(&tokenize(&source).unwrap()).unwrap();
     let (private, id, fun_args, ret_ty, raises, body) = unwrap_func_definition!(ast_tree);
 
@@ -307,8 +307,11 @@ fn function_definition_with_literal_verify() {
             assert_eq!(d2.clone(), None);
 
             match (&id1.node, &id2.node) {
-                (ASTNode::Int { lit }, ASTNode::IdType { id: id2, mutable: false, _type: t2 }) => {
-                    assert_eq!(lit.as_str(), "0");
+                (
+                    ASTNode::IdType { id: id1, mutable: false, _type: None },
+                    ASTNode::IdType { id: id2, mutable: false, _type: t2 }
+                ) => {
+                    assert_eq!(id1.node, ASTNode::Id { lit: String::from("x") });
                     assert_eq!(id2.node, ASTNode::Id { lit: String::from("b") });
 
                     match t2.clone().unwrap().node {

--- a/tests/parser/valid/definition.rs
+++ b/tests/parser/valid/definition.rs
@@ -284,7 +284,7 @@ fn function_no_args_definition_verify() {
 fn function_definition_with_literal_verify() {
     let source = String::from("def f(x, vararg b: Something) => d");
     let ast_tree = parse_direct(&tokenize(&source).unwrap()).unwrap();
-    let (private, id, fun_args, ret_ty, raises, body) = unwrap_func_definition!(ast_tree);
+    let (private, id, fun_args, ret_ty, _, body) = unwrap_func_definition!(ast_tree);
 
     assert_eq!(private, false);
     assert_eq!(id.node, ASTNode::Id { lit: String::from("f") });

--- a/tests/resources/valid/class/class.mamba
+++ b/tests/resources/valid/class/class.mamba
@@ -1,12 +1,12 @@
 from Math import abs
 import something
 
-type MyClass
+type MyType
     def fun_a: () -> ()
     def factorial: Int -> Int
 
 # This class has no state
-stateless MyClassStateless
+stateless MyClass isa MyType
     def SOME_CONSTANT <- 3.5E20
 
     def constant_func() => 400
@@ -19,7 +19,7 @@ type OtherState isa MyClass when
     other_field < 50
 
 # This class does have state
-stateful MyClassStateful
+stateful MyClass isa MyType
     def private z_modified
     def private mut other_field <- 10
 

--- a/tests/resources/valid/class/class.mamba
+++ b/tests/resources/valid/class/class.mamba
@@ -26,18 +26,19 @@ stateful MyClassStateful
     def init(self, my_field: Int, z: Int) =>
         self.z_modified <- z * SOME_CONSTANT
 
-    def connect(self: SomeState) => other_field <- 200
+    def connect(self: SomeState) => self.other_field <- 200
 
     def fun_a(self) => print self
 
     def private fun_b(self) => print "this function is private!"
 
-    def factorial(0) => 1
-    def factorial(x: Int) => x * factorial (x - 1)
-    def factorial_infinite(x: Int) => x * factorial x
+    def factorial(self, 0) => 1
+    def factorial(self, x: Int) => x * self.factorial (x - 1)
+    def factorial_infinite(self, x: Int) => x * self.factorial x
 
-    def postfix1() => a b
-    def postfix2() => a b c
-    def postfix3() => a b c d
+    def postfix1(self) => self.a b
+    def postfix2(self) => self.a b c
+    def postfix3(self) => self.a b c d
 
-    def fancy() => some_higher_order(\x => x * 2)
+    def some_higher_order (self, fun: Int -> Int) => 0
+    def fancy(self) => self.some_higher_order(\x => x * 2)

--- a/tests/resources/valid/class/class.mamba
+++ b/tests/resources/valid/class/class.mamba
@@ -23,22 +23,21 @@ stateful MyClass isa MyType
     def private z_modified
     def private mut other_field <- 10
 
-    def init(self, my_field: Int, z: Int) =>
+    def init(mut self, my_field: Int, z: Int) =>
         self.z_modified <- z * SOME_CONSTANT
 
-    def connect(self: SomeState) => self.other_field <- 200
+    def connect(mut self: SomeState) => self.other_field <- 200
 
     def fun_a(self) => print self
 
     def private fun_b(self) => print "this function is private!"
 
-    def factorial(self, 0) => 1
-    def factorial(self, x: Int) => x * self.factorial (x - 1)
+    def factorial(self, x: Int <- 0) => x * self.factorial (x - 1)
     def factorial_infinite(self, x: Int) => x * self.factorial x
 
-    def postfix1(self) => self.a b
-    def postfix2(self) => self.a b c
-    def postfix3(self) => self.a b c d
+    def a(self) => self.a self.b
+    def b(self, c) => self.a self.b self.c
+    def c(self, d) => self.a self.b self.c d
 
     def some_higher_order (self, fun: Int -> Int) => 0
     def fancy(self) => self.some_higher_order(\x => x * 2)

--- a/tests/resources/valid/collection/tuple.mamba
+++ b/tests/resources/valid/collection/tuple.mamba
@@ -1,9 +1,9 @@
 def a <- (a, b)
 def b <- ()
 def (c, d)
-def (e, f) <- (2, true)
+def (e, f) <- (2, False)
 
 def a ofmut <- (a, b)
 def b ofmut <- ()
 def (c, d) ofmut
-def (e, f) ofmut <- (2, true)
+def (e, f) ofmut <- (2, True)


### PR DESCRIPTION
### Relevant issues
Start of #32 

### Summary
Add a smoke test to check the generated Python file.
We ignore the test for now until we have more complex desugaring rules, such as:
- Detecting whether something is a field or function
- Returning the value of a function explicitly in Python if this is the intended behaviour
- Combining Stateful and Stateless classes (and explicitly adding self argument if stateless)
- Use pattern matching for arguments with default arguments (i.e. `my_function (0) => ...`)

### Added Tests
Test to check output of mamba class.
This test, however, is ignored for now.

### Additional Context
...