### PR TITLE
Create Type enum

### DIFF
--- a/src/type_checker/type.rs
+++ b/src/type_checker/type.rs
@@ -1,0 +1,21 @@
+pub enum Type {
+    Empty,
+    Undefined,
+
+    Int,
+    ENum,
+    Float,
+    String,
+    Bool,
+
+    Set { ty: Box<Type> },
+    List { ty: Box<Type> },
+    Map { ty: Box<Type> },
+    Tuple { ty: Vec<Type> },
+
+    Range { ty: Box<Type> },
+    AnonFun { arg: Vec<Type>, out: Box<Type> },
+
+    Custom { lit: String },
+    Maybe { ty: Box<Type> },
+}


### PR DESCRIPTION
### Relevant issues
This will not only come handy in the type checker but also during the desugar stage.
This is a stepping stone towards for instance #19 and  #64.
Therefore, even without a type checker, we still need knowledge of types to convert certain language construct to Python code.

### Summary
For instance, when we assign to a value, we need to know whether it is a tuple or not.
Instead of creating another custom alias in the desugarer, it is probably better to re-use the types from the type checker (which is still to be written).

### Added Tests
Cannot test enum

### Additional Context
...
