### PR TITLE
Simplify ENum

### DIFF
--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -29,8 +29,7 @@ fn to_py(core: &Core, ind: usize) -> String {
         Core::Id { lit } => lit.clone(),
         Core::Str { _str } => format!("\'{}\'", _str),
         Core::Int { int } => int.clone(),
-        Core::ENum { num, exp } =>
-            format!("Enum({}, {})", num, if exp.is_empty() { "0" } else { exp }),
+        Core::ENum { num, exp } => format!("({} * 10 ** {})", num, exp),
         Core::Float { float } => float.clone(),
         Core::Bool { _bool } => String::from(if *_bool { "True" } else { "False" }),
 

--- a/src/desugar/node.rs
+++ b/src/desugar/node.rs
@@ -27,7 +27,10 @@ pub fn desugar_node(node_pos: &ASTNodePos) -> Core {
 
         ASTNode::Int { lit } => Core::Int { int: lit.clone() },
         ASTNode::Real { lit } => Core::Float { float: lit.clone() },
-        ASTNode::ENum { num, exp } => Core::ENum { num: num.clone(), exp: exp.clone() },
+        ASTNode::ENum { num, exp } => Core::ENum {
+            num: num.clone(),
+            exp: if exp.is_empty() { String::from("0") } else { exp.clone() }
+        },
         ASTNode::Str { lit } => Core::Str { _str: lit.clone() },
 
         ASTNode::AddOp => Core::AddOp,

--- a/tests/desugar/control_flow.rs
+++ b/tests/desugar/control_flow.rs
@@ -50,7 +50,7 @@ fn while_verify() {
 
     assert_eq!(core_cond.len(), 1);
     assert_eq!(core_cond[0], Core::Id { lit: String::from("cond") });
-    assert_eq!(*core_body, Core::ENum { num: String::from("num"), exp: String::from("") });
+    assert_eq!(*core_body, Core::ENum { num: String::from("num"), exp: String::from("0") });
 }
 
 #[test]


### PR DESCRIPTION
### Relevant issues
...

### Summary
It might be overdoing it to define a custom class for this.
Instead of using the constructor of a hypothetical `ENum` class, it is good enough for now to use the built-in `**` power operator of Python.
Whether `exp` of an Enum is empty is now checked during the desugar stage, not in the core language.

So for instance:
- `2.7E23` becomes `(2.7 * 10 ** 23)`
- `4E` becomes `(2.7 * 10 ** 1)`
- `8.5E-9` becomes `8.5 * 10 ** -9`

### Added Tests
Change the `verify_while` test to reflect the behaviour that enum desugaring is now slightly more advanced, in that it checks if the `exp` is empty instead of doing this in the core language.

### Additional Context
...