### PR TITLE
Allow dead code in common core of test package

### DIFF
--- a/tests/command.rs
+++ b/tests/command.rs
@@ -1,11 +1,11 @@
-use crate::util::check_valid_resource_exists_and_delete;
-use crate::util::valid_resource_path;
+use crate::common::check_valid_resource_exists_and_delete;
+use crate::common::valid_resource_path;
 use mamba::command::mamba_to_python;
 use mamba::command::mamba_to_python_direct;
 use std::fs::OpenOptions;
 use std::path::Path;
 
-mod util;
+mod common;
 
 #[test]
 fn output_class_direct_valid_syntax() {

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -4,16 +4,19 @@ use std::io::Read;
 use std::path::Path;
 use std::path::PathBuf;
 
+#[allow(dead_code)]
 pub fn valid_resource_content(dirs: &[&str], file: &str) -> String {
     resource_content(true, dirs, file)
 }
 
 pub fn valid_resource_path(dirs: &[&str], file: &str) -> String { resource_path(true, dirs, file) }
 
+#[allow(dead_code)]
 pub fn invalid_resource_content(dirs: &[&str], file: &str) -> String {
     resource_content(false, dirs, file)
 }
 
+#[allow(dead_code)]
 pub fn invalid_resource_path(dirs: &[&str], file: &str) -> String {
     resource_path(false, dirs, file)
 }
@@ -49,6 +52,7 @@ pub fn check_valid_resource_exists_and_delete(subdirs: &[&str], file: &str) -> b
     remove(&valid_resource_path(subdirs, file))
 }
 
+#[allow(dead_code)]
 pub fn check_invalid_resource_exists_and_delete(subdirs: &[&str], file: &str) -> bool {
     remove(&invalid_resource_path(subdirs, file))
 }

--- a/tests/core/class.rs
+++ b/tests/core/class.rs
@@ -1,4 +1,4 @@
-use crate::util::*;
+use crate::common::*;
 use mamba::core::to_py_source;
 use mamba::desugar::desugar;
 use mamba::lexer::tokenize;

--- a/tests/core/collection.rs
+++ b/tests/core/collection.rs
@@ -1,4 +1,4 @@
-use crate::util::*;
+use crate::common::*;
 use mamba::core::to_py_source;
 use mamba::desugar::desugar;
 use mamba::lexer::tokenize;

--- a/tests/core/compound.rs
+++ b/tests/core/compound.rs
@@ -1,4 +1,4 @@
-use crate::util::*;
+use crate::common::*;
 use mamba::core::to_py_source;
 use mamba::desugar::desugar;
 use mamba::lexer::tokenize;

--- a/tests/core/control_flow.rs
+++ b/tests/core/control_flow.rs
@@ -1,4 +1,4 @@
-use crate::util::*;
+use crate::common::*;
 use mamba::core::to_py_source;
 use mamba::desugar::desugar;
 use mamba::lexer::tokenize;

--- a/tests/core/function.rs
+++ b/tests/core/function.rs
@@ -1,4 +1,4 @@
-use crate::util::*;
+use crate::common::*;
 use mamba::core::to_py_source;
 use mamba::desugar::desugar;
 use mamba::lexer::tokenize;

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -1,11 +1,11 @@
-use crate::util::check_valid_resource_exists_and_delete;
-use crate::util::valid_resource_path;
+use crate::common::check_valid_resource_exists_and_delete;
+use crate::common::valid_resource_path;
 use assert_cmd::prelude::*;
 use std::prelude::v1::Result::Ok;
 use std::process::Command;
 
 #[macro_use]
-mod util;
+mod common;
 
 mod core;
 mod desugar;

--- a/tests/output/syntax.rs
+++ b/tests/output/syntax.rs
@@ -1,5 +1,5 @@
+use crate::common::*;
 use crate::output::common::PYTHON;
-use crate::util::*;
 use mamba::command::mamba_to_python_direct;
 use std::path::Path;
 use std::process::Command;

--- a/tests/parser/invalid/compound.rs
+++ b/tests/parser/invalid/compound.rs
@@ -1,4 +1,4 @@
-use crate::util::*;
+use crate::common::*;
 use mamba::lexer::tokenize;
 use mamba::parser::parse;
 

--- a/tests/parser/mod.rs
+++ b/tests/parser/mod.rs
@@ -1,4 +1,4 @@
-use crate::util::*;
+use crate::common::*;
 use mamba::lexer::tokenize;
 use mamba::parser::parse;
 

--- a/tests/parser/valid/class.rs
+++ b/tests/parser/valid/class.rs
@@ -1,4 +1,4 @@
-use crate::util::*;
+use crate::common::*;
 use mamba::lexer::tokenize;
 use mamba::parser::parse;
 

--- a/tests/parser/valid/collection.rs
+++ b/tests/parser/valid/collection.rs
@@ -1,4 +1,4 @@
-use crate::util::*;
+use crate::common::*;
 use mamba::lexer::tokenize;
 use mamba::parser::ast::ASTNode;
 use mamba::parser::parse_direct;

--- a/tests/parser/valid/compound.rs
+++ b/tests/parser/valid/compound.rs
@@ -1,4 +1,4 @@
-use crate::util::*;
+use crate::common::*;
 use mamba::lexer::tokenize;
 use mamba::parser::parse;
 

--- a/tests/parser/valid/control_flow.rs
+++ b/tests/parser/valid/control_flow.rs
@@ -1,4 +1,4 @@
-use crate::util::*;
+use crate::common::*;
 use mamba::lexer::tokenize;
 use mamba::parser::ast::ASTNode;
 use mamba::parser::ast::ASTNodePos;

--- a/tests/parser/valid/function.rs
+++ b/tests/parser/valid/function.rs
@@ -1,4 +1,4 @@
-use crate::util::*;
+use crate::common::*;
 use mamba::lexer::tokenize;
 use mamba::parser::parse;
 


### PR DESCRIPTION
### Relevant issues
...

### Summary
We no longer get useless compile messages, as these utility functions
were actually used.

### Added Tests
...

### Additional Context
...
