### PR TITLE
Add ImportAs and Import to Core language

### DIFF
--- a/src/core/construct.rs
+++ b/src/core/construct.rs
@@ -7,10 +7,12 @@ pub enum Core {
     },
     FromImport {
         from:   Box<Core>,
-        import: Vec<Core>,
-        _as:    Vec<Core>
+        import: Box<Core>
     },
     Import {
+        import: Vec<Core>
+    },
+    ImportAs {
         import: Vec<Core>,
         _as:    Vec<Core>
     },

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -6,25 +6,11 @@ pub fn to_py_source(core: &Core) -> String { format!("{}\n", to_py(&core, 0)) }
 
 fn to_py(core: &Core, ind: usize) -> String {
     match core {
-        Core::FromImport { from, import, _as } => format!(
-            "from {} import {}{}",
-            to_py(from, ind),
-            comma_delimited(import, ind),
-            if _as.is_empty() {
-                String::new()
-            } else {
-                format!(" as {}", comma_delimited(_as, ind))
-            }
-        ),
-        Core::Import { import, _as } => format!(
-            "import {}{}",
-            comma_delimited(import, ind),
-            if _as.is_empty() {
-                String::new()
-            } else {
-                format!(" as {}", comma_delimited(_as, ind))
-            }
-        ),
+        Core::FromImport { from, import } =>
+            format!("from {} {}", to_py(from, ind), to_py(import, ind)),
+        Core::Import { import } => format!("import {}", comma_delimited(import, ind)),
+        Core::ImportAs { import, _as } =>
+            format!("import {} as {}", comma_delimited(import, ind), comma_delimited(_as, ind)),
 
         Core::Id { lit } => lit.clone(),
         Core::Str { _str } => format!("\'{}\'", _str),

--- a/tests/command.rs
+++ b/tests/command.rs
@@ -4,7 +4,6 @@ use mamba::command::mamba_to_python;
 use mamba::command::mamba_to_python_direct;
 use std::fs::OpenOptions;
 use std::path::Path;
-use std::process::Command;
 
 mod common;
 

--- a/tests/desugar/expression_and_statements.rs
+++ b/tests/desugar/expression_and_statements.rs
@@ -6,35 +6,28 @@ use mamba::parser::ast::ASTNodePos;
 #[test]
 fn break_verify() {
     let _break = to_pos!(ASTNode::Break);
-    let core = desugar(&_break);
-    assert_eq!(core, Core::Break);
+    assert_eq!(desugar(&_break), Core::Break);
 }
 
 #[test]
 fn continue_verify() {
     let _continue = to_pos!(ASTNode::Continue);
-    let core = desugar(&_continue);
-    assert_eq!(core, Core::Continue);
+    assert_eq!(desugar(&_continue), Core::Continue);
 }
 
 #[test]
 fn pass_verify() {
     let pass = to_pos!(ASTNode::Pass);
-    let core = desugar(&pass);
-    assert_eq!(core, Core::Pass);
+    assert_eq!(desugar(&pass), Core::Pass);
 }
 
 #[test]
 fn print_verify() {
     let expr = to_pos!(ASTNode::Str { lit: String::from("a") });
     let print_stmt = to_pos!(ASTNode::Print { expr });
-
-    let expr_core = match desugar(&print_stmt) {
-        Core::Print { expr } => expr,
-        other => panic!("Expected print but got: {:?}", other)
-    };
-
-    assert_eq!(*expr_core, Core::Str { _str: String::from("a") });
+    assert_eq!(desugar(&print_stmt), Core::Print {
+        expr: Box::from(Core::Str { _str: String::from("a") })
+    });
 }
 
 #[test]
@@ -42,38 +35,27 @@ fn return_verify() {
     let expr = to_pos!(ASTNode::Str { lit: String::from("a") });
     let print_stmt = to_pos!(ASTNode::Return { expr });
 
-    let expr_core = match desugar(&print_stmt) {
-        Core::Return { expr } => expr,
-        other => panic!("Expected print but got: {:?}", other)
-    };
-
-    assert_eq!(*expr_core, Core::Str { _str: String::from("a") });
+    assert_eq!(desugar(&print_stmt), Core::Return {
+        expr: Box::from(Core::Str { _str: String::from("a") })
+    });
 }
 
 #[test]
 fn return_empty_verify() {
     let print_stmt = to_pos!(ASTNode::ReturnEmpty);
-
-    let expr_core = match desugar(&print_stmt) {
-        Core::Return { expr } => expr,
-        other => panic!("Expected print but got: {:?}", other)
-    };
-
-    assert_eq!(*expr_core, Core::None);
+    assert_eq!(desugar(&print_stmt), Core::Return { expr: Box::from(Core::None) });
 }
 
 #[test]
 fn init_verify() {
     let _break = to_pos!(ASTNode::Init);
-    let core = desugar(&_break);
-    assert_eq!(core, Core::Id { lit: String::from("init") });
+    assert_eq!(desugar(&_break), Core::Id { lit: String::from("init") });
 }
 
 #[test]
 fn self_verify() {
     let _break = to_pos!(ASTNode::_Self);
-    let core = desugar(&_break);
-    assert_eq!(core, Core::Id { lit: String::from("self") });
+    assert_eq!(desugar(&_break), Core::Id { lit: String::from("self") });
 }
 
 #[test]
@@ -82,8 +64,8 @@ fn import_verify() {
         import: vec![to_pos_unboxed!(ASTNode::Id { lit: String::from("a") })],
         _as:    vec![to_pos_unboxed!(ASTNode::Id { lit: String::from("b") })]
     });
-    let core = desugar(&_break);
-    assert_eq!(core, Core::Import {
+
+    assert_eq!(desugar(&_break), Core::ImportAs {
         import: vec![Core::Id { lit: String::from("a") }],
         _as:    vec![Core::Id { lit: String::from("b") }]
     });
@@ -99,10 +81,11 @@ fn from_import_as_verify() {
         })
     });
 
-    let core = desugar(&_break);
-    assert_eq!(core, Core::FromImport {
+    assert_eq!(desugar(&_break), Core::FromImport {
         from:   Box::from(Core::Id { lit: String::from("f") }),
-        import: vec![Core::Id { lit: String::from("a") }],
-        _as:    vec![Core::Id { lit: String::from("b") }]
+        import: Box::from(Core::ImportAs {
+            import: vec![Core::Id { lit: String::from("a") }],
+            _as:    vec![Core::Id { lit: String::from("b") }]
+        })
     });
 }


### PR DESCRIPTION
### Relevant issues
...

### Summary
Add `ImportAs` and `Import` to Core language, so it more closely reflects the `ASTNode` structure.

### Added Tests
Modified existing tests to reflect the new structure.

### Additional Context
...
