### PR TITLE
Add desugaring of `foward`

### DIFF
--- a/src/desugar/definition.rs
+++ b/src/desugar/definition.rs
@@ -66,7 +66,11 @@ pub fn desugar_definition(node: &ASTNode, ctx: &Context, state: &State) -> Core 
 
 fn forward_def(id: String, method: String) -> Core {
     // TODO derive args from object type and method from context
-    let args = vec![Core::Id { lit: String::from("self") }];
+    let args = vec![Core::FunArg {
+        vararg:  false,
+        id:      Box::from(Core::Id { lit: String::from("self") }),
+        default: Box::from(Core::Empty)
+    }];
     let object = Box::from(Core::PropertyCall {
         object:   Box::from(Core::Id { lit: String::from("self") }),
         property: id

--- a/src/desugar/definition.rs
+++ b/src/desugar/definition.rs
@@ -80,6 +80,6 @@ fn forward_def(id: String, method: String) -> Core {
         private: false,
         id:      Box::from(Core::Id { lit: method.clone() }),
         args:    args.clone(),
-        body:    Box::from(Core::MethodCall { object, method, args })
+        body:    Box::from(Core::MethodCall { object, method, args: vec![] })
     }
 }

--- a/src/desugar/definition.rs
+++ b/src/desugar/definition.rs
@@ -29,17 +29,22 @@ pub fn desugar_definition(node: &ASTNode, ctx: &Context, state: &State) -> Core 
                     }
                 };
 
-                let mut statements = vec![item];
-                forward.iter().for_each(|node_pos| match (&id, &node_pos.node) {
-                    (Core::Id { lit: item_lit }, ASTNode::Id { lit: method_lit }) =>
-                        statements.push(forward_def(item_lit.clone(), method_lit.clone())),
-                    (Core::Id { .. }, other) =>
-                        panic!("Expected id in forward but was: {:?}", other),
-                    (other, _) =>
-                        panic!("Expected forward on an id, but tried to forward on: {:?}", other),
-                });
-
-                Core::Block { statements }
+                if forward.is_empty() {
+                    item
+                } else {
+                    let mut statements = vec![item];
+                    forward.iter().for_each(|node_pos| match (&id, &node_pos.node) {
+                        (Core::Id { lit: item_lit }, ASTNode::Id { lit: method_lit }) =>
+                            statements.push(forward_def(item_lit.clone(), method_lit.clone())),
+                        (Core::Id { .. }, other) =>
+                            panic!("Expected id in forward but was: {:?}", other),
+                        (other, _) => panic!(
+                            "Expected forward on an id, but tried to forward on: {:?}",
+                            other
+                        )
+                    });
+                    Core::Block { statements }
+                }
             }
             ASTNode::FunDef { id, fun_args, body: expression, .. } => Core::FunDef {
                 private: *private,

--- a/src/parser/ast.rs
+++ b/src/parser/ast.rs
@@ -61,7 +61,7 @@ pub enum ASTNode {
         ofmut:         bool,
         id_maybe_type: Box<ASTNodePos>,
         expression:    Option<Box<ASTNodePos>>,
-        forward:       Option<Vec<ASTNodePos>>
+        forward:       Vec<ASTNodePos>
     },
     FunDef {
         id:       Box<ASTNodePos>,

--- a/src/parser/definition.rs
+++ b/src/parser/definition.rs
@@ -222,10 +222,10 @@ fn parse_variable_def_id(id: ASTNodePos, it: &mut TPIterator) -> ParseResult {
         expression = None
     }
 
-    let forward: Option<Vec<ASTNodePos>> = match it.peek() {
+    let forward: Vec<ASTNodePos> = match it.peek() {
         Some(TokenPos { token: Token::Forward, .. }) =>
-            Some(get_or_err_direct!(it, parse_forward, "definition raises")),
-        _ => None
+            get_or_err_direct!(it, parse_forward, "definition raises"),
+        _ => vec![]
     };
 
     let (en_line, en_pos) = match &expression {

--- a/tests/desugar/definition.rs
+++ b/tests/desugar/definition.rs
@@ -150,11 +150,7 @@ fn variable_def_forward_verify() {
             property: String::from("object")
         }),
         method: String::from("m1"),
-        args:   vec![Core::FunArg {
-            vararg:  false,
-            id:      Box::from(Core::Id { lit: String::from("self") }),
-            default: Box::from(Core::Empty)
-        }]
+        args:   vec![]
     });
 }
 

--- a/tests/desugar/definition.rs
+++ b/tests/desugar/definition.rs
@@ -24,7 +24,7 @@ fn variable_private_def_verify() {
         ofmut:         false,
         id_maybe_type: to_pos!(ASTNode::Id { lit: String::from("d") }),
         expression:    Some(to_pos!(ASTNode::Int { lit: String::from("98") })),
-        forward:       None
+        forward:       vec![]
     });
     let def = to_pos!(ASTNode::Def { private: false, definition });
 
@@ -44,7 +44,7 @@ fn variable_def_verify() {
         ofmut:         false,
         id_maybe_type: to_pos!(ASTNode::Id { lit: String::from("d") }),
         expression:    Some(to_pos!(ASTNode::Int { lit: String::from("98") })),
-        forward:       None
+        forward:       vec![]
     });
     let def = to_pos!(ASTNode::Def { private: true, definition });
 
@@ -72,7 +72,7 @@ fn tuple_def_verify() {
         ofmut:         false,
         id_maybe_type: to_pos!(ASTNode::Tuple { elements }),
         expression:    Some(to_pos!(ASTNode::Tuple { elements: expressions })),
-        forward:       None
+        forward:       vec![]
     });
     let def = to_pos!(ASTNode::Def { private: true, definition });
 
@@ -95,7 +95,7 @@ fn variable_def_none_verify() {
         ofmut:         false,
         id_maybe_type: to_pos!(ASTNode::Id { lit: String::from("d") }),
         expression:    None,
-        forward:       None
+        forward:       vec![]
     });
     let def = to_pos!(ASTNode::Def { private: true, definition });
 
@@ -119,7 +119,7 @@ fn tuple_def_none_verify() {
         ofmut:         false,
         id_maybe_type: to_pos!(ASTNode::Tuple { elements }),
         expression:    None,
-        forward:       None
+        forward:       vec![]
     });
 
     let def = to_pos!(ASTNode::Def { private: true, definition });

--- a/tests/desugar/definition.rs
+++ b/tests/desugar/definition.rs
@@ -110,6 +110,55 @@ fn variable_def_none_verify() {
 }
 
 #[test]
+fn variable_def_forward_verify() {
+    let definition = to_pos!(ASTNode::VariableDef {
+        ofmut:         false,
+        id_maybe_type: to_pos!(ASTNode::Id { lit: String::from("object") }),
+        expression:    None,
+        forward:       vec![to_pos_unboxed!(ASTNode::Id { lit: String::from("m1") })]
+    });
+    let def = to_pos!(ASTNode::Def { private: true, definition });
+
+    let (private, id, right, fprivate, fid, fargs, fbody) = match desugar(&def) {
+        Core::Block { statements } => match (statements[0].clone(), statements[1].clone()) {
+            (
+                Core::VarDef { private, id, right },
+                Core::FunDef { private: fprivate, id: fid, args: fargs, body: fbody }
+            ) => (private, id, right, fprivate, fid, fargs, fbody),
+            (other1, other2) =>
+                panic!("Expected vardef and fundef but got: {:?} and {:?}", other1, other2),
+        },
+        other => panic!("Expected block but got: {:?}.", other)
+    };
+
+    assert_eq!(private, true);
+    assert_eq!(*id, Core::Id { lit: String::from("object") });
+    assert_eq!(*right, Core::None);
+
+    assert_eq!(fprivate, false);
+    assert_eq!(*fid, Core::Id { lit: String::from("m1") });
+    assert_eq!(fargs.len(), 1);
+    assert_eq!(fargs[0], Core::FunArg {
+        vararg:  false,
+        id:      Box::from(Core::Id { lit: String::from("self") }),
+        default: Box::from(Core::Empty)
+    });
+
+    assert_eq!(*fbody, Core::MethodCall {
+        object: Box::from(Core::PropertyCall {
+            object:   Box::from(Core::Id { lit: String::from("self") }),
+            property: String::from("object")
+        }),
+        method: String::from("m1"),
+        args:   vec![Core::FunArg {
+            vararg:  false,
+            id:      Box::from(Core::Id { lit: String::from("self") }),
+            default: Box::from(Core::Empty)
+        }]
+    });
+}
+
+#[test]
 fn tuple_def_none_verify() {
     let elements = vec![
         to_pos_unboxed!(ASTNode::Id { lit: String::from("a") }),
@@ -134,7 +183,6 @@ fn tuple_def_none_verify() {
     assert_eq!(*right, Core::Tuple { elements: vec![Core::None, Core::None] });
 }
 
-// TODO add tests for default arguments once implemented
 #[test]
 fn fun_def_verify() {
     let definition = to_pos!(ASTNode::FunDef {

--- a/tests/output/syntax.rs
+++ b/tests/output/syntax.rs
@@ -17,7 +17,6 @@ fn output_tuple_valid_syntax() {
 }
 
 #[test]
-#[ignore]
 fn output_class_valid_syntax() {
     let source = valid_resource_path(&["class"], "class.mamba");
     let path = mamba_to_python_direct(Path::new(&source)).unwrap();
@@ -26,5 +25,5 @@ fn output_class_valid_syntax() {
     if cmd.status.code().unwrap() != 0 {
         panic!("{}", String::from_utf8(cmd.stderr).unwrap());
     }
-    check_valid_resource_exists_and_delete(&["class"], "class.py");
+    //    check_valid_resource_exists_and_delete(&["class"], "class.py");
 }

--- a/tests/output/syntax.rs
+++ b/tests/output/syntax.rs
@@ -17,6 +17,7 @@ fn output_tuple_valid_syntax() {
 }
 
 #[test]
+#[ignore]
 fn output_class_valid_syntax() {
     let source = valid_resource_path(&["class"], "class.mamba");
     let path = mamba_to_python_direct(Path::new(&source)).unwrap();

--- a/tests/parser/valid/definition.rs
+++ b/tests/parser/valid/definition.rs
@@ -60,7 +60,7 @@ fn empty_definition_verify() {
     assert_eq!(id.node, ASTNode::Id { lit: String::from("a") });
     assert_eq!(_type, None);
     assert_eq!(expression, None);
-    assert_eq!(forward, None);
+    assert_eq!(forward, vec![]);
 }
 
 #[test]
@@ -74,7 +74,7 @@ fn definition_verify() {
     assert_eq!(ofmut, false);
     assert_eq!(id.node, ASTNode::Id { lit: String::from("a") });
     assert_eq!(_type, None);
-    assert_eq!(forward, None);
+    assert_eq!(forward, vec![]);
 
     match expression {
         Some(expr_pos) => assert_eq!(expr_pos.node, ASTNode::Int { lit: String::from("10") }),
@@ -93,7 +93,7 @@ fn mutable_definition_verify() {
     assert_eq!(ofmut, false);
     assert_eq!(id.node, ASTNode::Id { lit: String::from("a") });
     assert_eq!(_type, None);
-    assert_eq!(forward, None);
+    assert_eq!(forward, vec![]);
 
     match expression {
         Some(expr_pos) => assert_eq!(expr_pos.node, ASTNode::Int { lit: String::from("10") }),
@@ -112,7 +112,7 @@ fn ofmut_definition_verify() {
     assert_eq!(ofmut, true);
     assert_eq!(id.node, ASTNode::Id { lit: String::from("a") });
     assert_eq!(_type, None);
-    assert_eq!(forward, None);
+    assert_eq!(forward, vec![]);
 
     match expression {
         Some(expr_pos) => assert_eq!(expr_pos.node, ASTNode::Int { lit: String::from("10") }),
@@ -131,7 +131,7 @@ fn private_definition_verify() {
     assert_eq!(ofmut, false);
     assert_eq!(id.node, ASTNode::Id { lit: String::from("a") });
     assert_eq!(_type, None);
-    assert_eq!(forward, None);
+    assert_eq!(forward, vec![]);
 
     match expression {
         Some(expr_pos) => assert_eq!(expr_pos.node, ASTNode::Int { lit: String::from("10") }),
@@ -161,7 +161,7 @@ fn typed_definition_verify() {
     assert_eq!(mutable, false);
     assert_eq!(ofmut, false);
     assert_eq!(id.node, ASTNode::Id { lit: String::from("a") });
-    assert_eq!(forward, None);
+    assert_eq!(forward, vec![]);
     assert_eq!(expr.node, ASTNode::Int { lit: String::from("10") });
     assert_eq!(type_id.node, ASTNode::Id { lit: String::from("Object") });
 }
@@ -172,19 +172,14 @@ fn forward_empty_definition_verify() {
     let ast_tree = parse_direct(&tokenize(&source).unwrap()).unwrap();
     let (private, mutable, ofmut, id, _type, expression, forward) = unwrap_definition!(ast_tree);
 
-    let forwarded = match forward {
-        Some(forward) => forward,
-        None => panic!("Expected type but was none.")
-    };
-
     assert_eq!(private, false);
     assert_eq!(mutable, false);
     assert_eq!(ofmut, false);
     assert_eq!(id.node, ASTNode::Id { lit: String::from("a") });
     assert_eq!(expression, None);
-    assert_eq!(forwarded.len(), 2);
-    assert_eq!(forwarded[0].node, ASTNode::Id { lit: String::from("b") });
-    assert_eq!(forwarded[1].node, ASTNode::Id { lit: String::from("c") });
+    assert_eq!(forward.len(), 2);
+    assert_eq!(forward[0].node, ASTNode::Id { lit: String::from("b") });
+    assert_eq!(forward[1].node, ASTNode::Id { lit: String::from("c") });
 }
 
 #[test]
@@ -193,18 +188,13 @@ fn forward_definition_verify() {
     let ast_tree = parse_direct(&tokenize(&source).unwrap()).unwrap();
     let (private, mutable, ofmut, id, _type, expression, forward) = unwrap_definition!(ast_tree);
 
-    let forwarded = match forward {
-        Some(forward) => forward,
-        None => panic!("Expected type but was none.")
-    };
-
     assert_eq!(private, false);
     assert_eq!(mutable, false);
     assert_eq!(ofmut, false);
     assert_eq!(id.node, ASTNode::Id { lit: String::from("a") });
-    assert_eq!(forwarded.len(), 2);
-    assert_eq!(forwarded[0].node, ASTNode::Id { lit: String::from("b") });
-    assert_eq!(forwarded[1].node, ASTNode::Id { lit: String::from("c") });
+    assert_eq!(forward.len(), 2);
+    assert_eq!(forward[0].node, ASTNode::Id { lit: String::from("b") });
+    assert_eq!(forward[1].node, ASTNode::Id { lit: String::from("c") });
 
     match expression {
         Some(expr_pos) => assert_eq!(expr_pos.node, ASTNode::Id { lit: String::from("class") }),

--- a/tests/resources/valid/class/class.mamba
+++ b/tests/resources/valid/class/class.mamba
@@ -20,6 +20,8 @@ type OtherState isa MyClass when
 
 # This class does have state
 stateful MyClass isa MyType
+    def something: MyClass forward method_1, method_2
+
     def private z_modified
     def private mut other_field <- 10
 


### PR DESCRIPTION
### Relevant issues
...

### Summary
We have the `forward` keyword, similar to Perl.
This allows us to easily forward methods of the contained object (remember, we use composition, not inheritance).
This is only a partial implementation however, we still have no way of checking what arguments the method of the contained object requires. 
Once we have a way of building a context which contains information about each identifier's type and the accompanying methods we can look up which arguments are required for a forward.

In short, the following:

    # a is a method which takes no arguments, b takes two arguments
    def private my_class <- MyClass() forward a, b

Is essentially desugared to the following:

```python
_my_class = MyClass()
def a(self): self.my_class.a()
def b(self, arg1, arg2): self.my_class.b(arg1, arg2)
```

Although currently, due to not knowing any information about methods `a` and `b`, it is for now (incorrectly) desugared to:

```python
_my_class = MyClass()
def a(self): self.my_class.a()
def b(self): self.my_class.b()
```

### Added Tests
Test to check that desugaring of a `foward` produces a block with:
- The original variable definition
- A method for each single forward

### Additional Context
...  