### PR TITLE
Add panic messages and use unimplemented macro in desugar stage

### DIFF
--- a/src/desugar/node.rs
+++ b/src/desugar/node.rs
@@ -240,11 +240,23 @@ pub fn desugar_node(node_pos: &ASTNodePos, ctx: &Context, state: &State) -> Core
                 other => panic!("desugarer didn't recognize while making class: {:?}.", other)
             },
 
-        ASTNode::TypeDef { .. } => Core::Empty,
-        ASTNode::TypeAlias { .. } => Core::Empty,
+        ASTNode::TypeDef { .. }
+        | ASTNode::TypeAlias { .. }
+        | ASTNode::TypeTup { .. }
+        | ASTNode::Type { .. }
+        | ASTNode::TypeFun { .. } => Core::Empty,
+
+        ASTNode::Condition { .. } => unimplemented!("Condition has not yet been implemented."),
 
         ASTNode::Pass => Core::Pass,
 
-        other => panic!("desugarer didn't recognize {:?}.", other)
+        ASTNode::Body { .. } => panic!("Body cannot be top level."),
+        ASTNode::VariableDef { .. } => panic!("Variable definition cannot be top level."),
+        ASTNode::FunDef { .. } => panic!("Function definition cannot be top level."),
+
+        ASTNode::Raises { .. } => Core::Empty,
+
+        ASTNode::Handle { .. } => unimplemented!("Handle has not yet been implemented."),
+        ASTNode::Retry { .. } => unimplemented!("Retry has not yet bee implemented.")
     }
 }

--- a/src/parser/ast.rs
+++ b/src/parser/ast.rs
@@ -41,14 +41,6 @@ pub enum ASTNode {
     },
     Init,
 
-    ModName {
-        name: String
-    },
-    ModNameIsA {
-        name: String,
-        isa:  Vec<String>
-    },
-
     Reassign {
         left:  Box<ASTNodePos>,
         right: Box<ASTNodePos>

--- a/tests/desugar/definition.rs
+++ b/tests/desugar/definition.rs
@@ -2,6 +2,7 @@ use mamba::core::construct::Core;
 use mamba::desugar::desugar;
 use mamba::parser::ast::ASTNode;
 use mamba::parser::ast::ASTNodePos;
+use std::panic;
 
 #[test]
 fn reassign_verify() {
@@ -302,4 +303,33 @@ fn anon_fun_verify() {
     assert_eq!(args[0], Core::Id { lit: String::from("first") });
     assert_eq!(args[1], Core::Id { lit: String::from("second") });
     assert_eq!(*body, Core::Str { _str: String::from("this_string") });
+}
+
+#[test]
+fn top_level_var_def_panic_verify() {
+    let var_def = to_pos!(ASTNode::VariableDef {
+        ofmut:         false,
+        id_maybe_type: to_pos!(ASTNode::Pass),
+        expression:    None,
+        forward:       vec![]
+    });
+
+    panic::set_hook(Box::new(|_info| {}));
+    let result = std::panic::catch_unwind(|| desugar(&var_def));
+    assert!(result.is_err());
+}
+
+#[test]
+fn top_level_fun_def_panic_verify() {
+    let var_def = to_pos!(ASTNode::FunDef {
+        id:       Box::from(to_pos!(ASTNode::Pass)),
+        fun_args: vec![],
+        ret_ty:   None,
+        raises:   None,
+        body:     None
+    });
+
+    panic::set_hook(Box::new(|_info| {}));
+    let result = std::panic::catch_unwind(|| desugar(&var_def));
+    assert!(result.is_err());
 }

--- a/tests/desugar/expression_and_statements.rs
+++ b/tests/desugar/expression_and_statements.rs
@@ -2,6 +2,7 @@ use mamba::core::construct::Core;
 use mamba::desugar::desugar;
 use mamba::parser::ast::ASTNode;
 use mamba::parser::ast::ASTNodePos;
+use std::panic;
 
 #[test]
 fn break_verify() {
@@ -88,4 +89,22 @@ fn from_import_as_verify() {
             _as:    vec![Core::Id { lit: String::from("b") }]
         })
     });
+}
+
+#[test]
+fn top_level_body_panic_verify() {
+    let var_def = to_pos!(ASTNode::Body { isa: vec![], definitions: vec![] });
+
+    panic::set_hook(Box::new(|_info| {}));
+    let result = std::panic::catch_unwind(|| desugar(&var_def));
+    assert!(result.is_err());
+}
+
+#[test]
+fn raises_empty_verify() {
+    let type_def = to_pos!(ASTNode::Raises {
+        expr_or_stmt: Box::from(to_pos!(ASTNode::Pass)),
+        errors:       vec![]
+    });
+    assert_eq!(desugar(&type_def), Core::Empty);
 }

--- a/tests/desugar/mod.rs
+++ b/tests/desugar/mod.rs
@@ -6,3 +6,4 @@ pub mod control_flow;
 pub mod definition;
 pub mod expression_and_statements;
 pub mod operation;
+pub mod types;

--- a/tests/desugar/types.rs
+++ b/tests/desugar/types.rs
@@ -1,0 +1,35 @@
+use mamba::core::construct::Core;
+use mamba::desugar::desugar;
+use mamba::parser::ast::ASTNode;
+use mamba::parser::ast::ASTNodePos;
+
+#[test]
+fn type_def_empty_verify() {
+    let type_def =
+        to_pos!(ASTNode::TypeDef { _type: Box::from(to_pos!(ASTNode::Pass)), body: None });
+    assert_eq!(desugar(&type_def), Core::Empty);
+}
+
+#[test]
+fn type_alias_empty_verify() {
+    let type_def = to_pos!(ASTNode::TypeAlias {
+        _type:      Box::from(to_pos!(ASTNode::Pass)),
+        conditions: None
+    });
+    assert_eq!(desugar(&type_def), Core::Empty);
+}
+
+#[test]
+fn type_tup_empty_verify() {
+    let type_def = to_pos!(ASTNode::TypeTup { types: vec![] });
+    assert_eq!(desugar(&type_def), Core::Empty);
+}
+
+#[test]
+fn type_fun_empty_verify() {
+    let type_def = to_pos!(ASTNode::TypeFun {
+        _type: Box::from(to_pos!(ASTNode::Pass)),
+        body:  Box::from(to_pos!(ASTNode::Pass))
+    });
+    assert_eq!(desugar(&type_def), Core::Empty);
+}

--- a/tests/resources/valid/class/class.mamba
+++ b/tests/resources/valid/class/class.mamba
@@ -26,6 +26,7 @@ stateful MyClass isa MyType
     def private mut other_field <- 10
 
     def init(mut self, my_field: Int, z: Int) =>
+        if z > 10 then return Err("Something is wrong!")
         self.z_modified <- z * SOME_CONSTANT
 
     def connect(mut self: SomeState) => self.other_field <- 200


### PR DESCRIPTION
### Relevant issues
...

### Summary
Make more explicit what should and shouldn't be encountered in the desugar stage.
This makes it easier to see on first glance what can and can't be desugared, and what should and shouldn't be encountered.

### Added Tests
...

### Additional Context
...
