### PR TITLE
Properly implemenent handle statement

### DIFF
--- a/src/lexer/token.rs
+++ b/src/lexer/token.rs
@@ -174,7 +174,7 @@ impl fmt::Display for Token {
             Token::RCBrack => String::from("}"),
             Token::Ver => String::from("|"),
             Token::To => String::from("->"),
-            Token::BTo => String::from("=> String::from("),
+            Token::BTo => String::from("=>"),
 
             Token::NL => String::from("<newline>"),
             Token::Indent => String::from("<indent>"),

--- a/src/parser/expr_or_stmt.rs
+++ b/src/parser/expr_or_stmt.rs
@@ -50,6 +50,7 @@ pub fn parse_handle(expr_or_stmt: ASTNodePos, it: &mut TPIterator) -> ParseResul
     let (st_line, st_pos) = start_pos(it);
     check_next_is!(it, Token::Handle);
 
+    check_next_is!(it, Token::NL);
     let cases = get_or_err_direct!(it, parse_match_cases, "handle cases");
 
     let node = ASTNode::Handle { expr_or_stmt: Box::from(expr_or_stmt), cases };

--- a/src/parser/expr_or_stmt.rs
+++ b/src/parser/expr_or_stmt.rs
@@ -49,7 +49,6 @@ pub fn parse_raise(expr_or_stmt: ASTNodePos, it: &mut TPIterator) -> ParseResult
 pub fn parse_handle(expr_or_stmt: ASTNodePos, it: &mut TPIterator) -> ParseResult {
     let (st_line, st_pos) = start_pos(it);
     check_next_is!(it, Token::Handle);
-    check_next_is!(it, Token::When);
 
     let cases = get_or_err_direct!(it, parse_match_cases, "handle cases");
 

--- a/tests/parser/valid/error.rs
+++ b/tests/parser/valid/error.rs
@@ -1,0 +1,15 @@
+use crate::common::valid_resource_content;
+use mamba::lexer::tokenize;
+use mamba::parser::parse;
+
+#[test]
+fn handle_verify() {
+    let source = valid_resource_content(&["error"], "handle.mamba");
+    parse(&tokenize(&source).unwrap());
+}
+
+#[test]
+fn raises_verify() {
+    let source = valid_resource_content(&["error"], "raise.mamba");
+    parse(&tokenize(&source).unwrap());
+}

--- a/tests/parser/valid/mod.rs
+++ b/tests/parser/valid/mod.rs
@@ -4,6 +4,7 @@ pub mod collection;
 pub mod compound;
 pub mod control_flow;
 pub mod definition;
+pub mod error;
 pub mod expression_and_statement;
 pub mod function;
 pub mod operation;

--- a/tests/resources/valid/error/handle.mamba
+++ b/tests/resources/valid/error/handle.mamba
@@ -1,0 +1,2 @@
+def a <- f(10) handle
+    err => print "Something went wrong"

--- a/tests/resources/valid/error/raise.mamba
+++ b/tests/resources/valid/error/raise.mamba
@@ -1,0 +1,3 @@
+def f(x: Int): Int raises[Err] => if x > 0 then return Err("asdf") else 10
+
+f(10) raises [MyErr]


### PR DESCRIPTION
### Relevant issues
...

### Summary
The handle statement now coincides with the grammar:
- It expects a newline before the conditions
- It does not require the `when` token after the `handle` token

### Added Tests
Tests to verify
- That handle works correctly
- That raise works both in the function signature and in-line

### Additional Context
...
