### PR TITLE
Restructure lexer and add Comment Token

### DIFF
--- a/src/core/construct.rs
+++ b/src/core/construct.rs
@@ -227,5 +227,8 @@ pub enum Core {
 
     Pass,
     None,
-    Empty
+    Empty,
+    Comment {
+        comment: String
+    }
 }

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -209,6 +209,7 @@ fn to_py(core: &Core, ind: usize) -> String {
         Core::Pass => String::from("pass"),
         Core::None => String::from("None"),
         Core::Empty => String::new(),
+        Core::Comment { comment } => format!("#{}", comment),
 
         other => panic!("To python not implemented yet for: {:?}", other)
     }

--- a/src/desugar/node.rs
+++ b/src/desugar/node.rs
@@ -248,6 +248,7 @@ pub fn desugar_node(node_pos: &ASTNodePos, ctx: &Context, state: &State) -> Core
 
         ASTNode::Condition { .. } => unimplemented!("Condition has not yet been implemented."),
 
+        ASTNode::Comment { .. } => unimplemented!(),
         ASTNode::Pass => Core::Pass,
 
         ASTNode::Body { .. } => panic!("Body cannot be top level."),

--- a/src/desugar/node.rs
+++ b/src/desugar/node.rs
@@ -248,7 +248,7 @@ pub fn desugar_node(node_pos: &ASTNodePos, ctx: &Context, state: &State) -> Core
 
         ASTNode::Condition { .. } => unimplemented!("Condition has not yet been implemented."),
 
-        ASTNode::Comment { .. } => unimplemented!(),
+        ASTNode::Comment { comment } => Core::Comment { comment: comment.clone() },
         ASTNode::Pass => Core::Pass,
 
         ASTNode::Body { .. } => panic!("Body cannot be top level."),

--- a/src/lexer/common.rs
+++ b/src/lexer/common.rs
@@ -4,7 +4,6 @@ use crate::lexer::token::TokenPos;
 #[derive(Clone)]
 pub struct State {
     newlines: Vec<TokenPos>,
-
     current_indent: i32,
     line_indent: i32,
     hit_token_this_line: bool,

--- a/src/lexer/common.rs
+++ b/src/lexer/common.rs
@@ -23,5 +23,7 @@ impl State {
         }
     }
 
-    pub fn token(token: Token) {}
+    pub fn token(mut self, token: Token) {}
+
+    pub fn space(mut self) {}
 }

--- a/src/lexer/common.rs
+++ b/src/lexer/common.rs
@@ -7,7 +7,7 @@ pub struct State {
     line_indent: i32,
     hit_token_this_line: bool,
     pub line: i32,
-    pub pos: i32,
+    pub pos: i32
 }
 
 impl State {
@@ -40,11 +40,15 @@ impl State {
         } as i32;
 
         let mut res = if self.line_indent >= self.current_indent {
-            vec![TokenPos { line: self.line, pos: self.pos, token: Token::Indent };
-                 ((self.line_indent - self.current_indent) / 4) as usize]
+            vec![
+                TokenPos { line: self.line, pos: self.pos, token: Token::Indent };
+                ((self.line_indent - self.current_indent) / 4) as usize
+            ]
         } else {
-            vec![TokenPos { line: self.line, pos: self.pos, token: Token::Dedent };
-                 ((self.current_indent - self.line_indent) / 4) as usize]
+            vec![
+                TokenPos { line: self.line, pos: self.pos, token: Token::Dedent };
+                ((self.current_indent - self.line_indent) / 4) as usize
+            ]
         };
 
         self.current_indent = self.line_indent;

--- a/src/lexer/common.rs
+++ b/src/lexer/common.rs
@@ -3,6 +3,8 @@ use crate::lexer::token::TokenPos;
 
 #[derive(Clone)]
 pub struct State {
+    newlines: Vec<TokenPos>,
+
     current_indent: i32,
     line_indent: i32,
     hit_token_this_line: bool,
@@ -12,24 +14,39 @@ pub struct State {
 
 impl State {
     pub fn new() -> State {
-        State { current_indent: 1, line_indent: 1, hit_token_this_line: false, line: 1, pos: 1 }
+        State {
+            newlines: Vec::new(),
+            current_indent: 1,
+            line_indent: 1,
+            hit_token_this_line: false,
+            line: 1,
+            pos: 1
+        }
     }
 
+    /// Change state depending on given [Token](lexer::token::Token) and return
+    /// [TokenPos](lexer::token::TokenPos) with current line and position
+    /// (1-indexed).
+    ///
+    /// Newline tokens are not immediately returned. Instead, they are returned
+    /// in a batch once a non-newline token is encountered.
+    /// This allows us to ensure that if we have multiple newlines followed by a
+    /// dedent, that the remaining newlines are placed after the dedent.
+    /// Therefore, dedents are placed as early as possible.
     pub fn token(&mut self, token: Token) -> Vec<TokenPos> {
         debug_assert_ne!(token, Token::Indent);
         debug_assert_ne!(token, Token::Dedent);
-
         if token == Token::NL {
-            let res = vec![TokenPos { line: self.line, pos: self.pos, token: token.clone() }];
-            self.hit_token_this_line = false;
-            self.line_indent = 1;
-            self.pos = 1;
-            self.line += 1;
-            return res;
+            return self.newline();
         }
 
         self.hit_token_this_line = true;
-        let mut res = if self.line_indent >= self.current_indent {
+        let mut res = match self.newlines.pop() {
+            Some(nl_token_pos) => vec![nl_token_pos],
+            None => vec![]
+        };
+
+        res.append(&mut if self.line_indent >= self.current_indent {
             vec![
                 TokenPos { line: self.line, pos: self.pos, token: Token::Indent };
                 ((self.line_indent - self.current_indent) / 4) as usize
@@ -39,12 +56,12 @@ impl State {
                 TokenPos { line: self.line, pos: self.pos, token: Token::Dedent };
                 ((self.current_indent - self.line_indent) / 4) as usize
             ]
-        };
-        match res.last() {
-            Some(TokenPos { token: Token::Dedent, .. }) =>
-                res.push(TokenPos { line: self.line, pos: self.pos, token: Token::NL }),
-            _ => ()
-        };
+        });
+
+        while let Some(nl_token_pos) = self.newlines.pop() {
+            debug_assert_eq!(nl_token_pos.token, Token::NL);
+            res.push(nl_token_pos);
+        }
 
         res.push(TokenPos { line: self.line, pos: self.pos, token: token.clone() });
 
@@ -61,6 +78,15 @@ impl State {
         } as i32;
 
         res
+    }
+
+    fn newline(&mut self) -> Vec<TokenPos> {
+        self.newlines.push(TokenPos { line: self.line, pos: self.pos, token: Token::NL });
+        self.hit_token_this_line = false;
+        self.line_indent = 1;
+        self.pos = 1;
+        self.line += 1;
+        return vec![];
     }
 
     pub fn space(&mut self) {

--- a/src/lexer/common.rs
+++ b/src/lexer/common.rs
@@ -1,29 +1,59 @@
 use crate::lexer::token::Token;
+use crate::lexer::token::TokenPos;
 
+#[derive(Clone)]
 pub struct State {
     current_indent: i32,
-    line_indent:    i32,
-
-    last_nl: bool,
-
+    line_indent: i32,
+    hit_token_this_line: bool,
     pub line: i32,
-    pub pos:  i32
+    pub pos: i32
 }
 
 impl State {
     pub fn new() -> State {
-        State {
-            current_indent: 0,
-            line_indent:    0,
+        State { current_indent: 0, line_indent: 0, hit_token_this_line: false, line: 0, pos: 0 }
+    }
 
-            last_nl: false,
+    pub fn token(&mut self, token: &Token) -> Vec<TokenPos> {
+        debug_assert_ne!(*token, Token::Indent);
+        debug_assert_ne!(*token, Token::Dedent);
 
-            line: 0,
-            pos:  0
+        if *token == Token::NL {
+            self.pos = 1;
+            self.line += 1;
+            return vec![];
+        }
+
+        self.pos += match token {
+            Token::Id(id) => id.len(),
+            Token::Real(real) => real.len(),
+            Token::Int(int) => int.len(),
+            Token::Bool(true) => 4,
+            Token::Bool(false) => 5,
+            Token::Str(_str) => _str.len() + 2,
+            Token::ENum(num, exp) => num.len() + exp.len() + 1,
+            other => format!("{}", other).len()
+        } as i32;
+
+        self.hit_token_this_line = true;
+        if self.line_indent >= self.current_indent {
+            vec![
+                TokenPos { line: self.line, pos: self.pos, token: Token::Indent };
+                ((self.line_indent - self.current_indent) % 4) as usize
+            ]
+        } else {
+            vec![
+                TokenPos { line: self.line, pos: self.pos, token: Token::Dedent };
+                ((self.current_indent - self.line_indent) % 4) as usize
+            ]
         }
     }
 
-    pub fn token(mut self, token: Token) {}
-
-    pub fn space(mut self) {}
+    pub fn space(&mut self) {
+        self.pos += 1;
+        if !self.hit_token_this_line {
+            self.line_indent += 1;
+        }
+    }
 }

--- a/src/lexer/common.rs
+++ b/src/lexer/common.rs
@@ -7,12 +7,12 @@ pub struct State {
     line_indent: i32,
     hit_token_this_line: bool,
     pub line: i32,
-    pub pos: i32
+    pub pos: i32,
 }
 
 impl State {
     pub fn new() -> State {
-        State { current_indent: 0, line_indent: 0, hit_token_this_line: false, line: 0, pos: 0 }
+        State { current_indent: 1, line_indent: 1, hit_token_this_line: false, line: 1, pos: 1 }
     }
 
     pub fn token(&mut self, token: &Token) -> Vec<TokenPos> {
@@ -20,9 +20,12 @@ impl State {
         debug_assert_ne!(*token, Token::Dedent);
 
         if *token == Token::NL {
+            let res = vec![TokenPos { line: self.line, pos: self.pos, token: Token::NL }];
+            self.hit_token_this_line = false;
             self.pos = 1;
             self.line += 1;
-            return vec![];
+
+            return res;
         }
 
         self.pos += match token {
@@ -40,12 +43,12 @@ impl State {
         if self.line_indent >= self.current_indent {
             vec![
                 TokenPos { line: self.line, pos: self.pos, token: Token::Indent };
-                ((self.line_indent - self.current_indent) % 4) as usize
+                ((self.line_indent - self.current_indent) / 4) as usize
             ]
         } else {
             vec![
                 TokenPos { line: self.line, pos: self.pos, token: Token::Dedent };
-                ((self.current_indent - self.line_indent) % 4) as usize
+                ((self.current_indent - self.line_indent) / 4) as usize
             ]
         }
     }

--- a/src/lexer/common.rs
+++ b/src/lexer/common.rs
@@ -1,7 +1,27 @@
-macro_rules! next_and {
-    ($it:expr, $pos:expr, $stmt:stmt) => {{
-        $it.next();
-        *$pos += 1;
-        $stmt
-    }};
+use crate::lexer::token::Token;
+
+pub struct State {
+    current_indent: i32,
+    line_indent:    i32,
+
+    last_nl: bool,
+
+    pub line: i32,
+    pub pos:  i32
+}
+
+impl State {
+    pub fn new() -> State {
+        State {
+            current_indent: 0,
+            line_indent:    0,
+
+            last_nl: false,
+
+            line: 0,
+            pos:  0
+        }
+    }
+
+    pub fn token(token: Token) {}
 }

--- a/src/lexer/mod.rs
+++ b/src/lexer/mod.rs
@@ -97,7 +97,10 @@ pub fn tokenize(input: &str) -> Result<Vec<TokenPos>, String> {
             },
             '#' => {
                 let mut comment = String::new();
-                while it.peek().is_some() && *it.peek().unwrap() != '\n' && *it.peek().unwrap() != '\r' {
+                while it.peek().is_some()
+                    && *it.peek().unwrap() != '\n'
+                    && *it.peek().unwrap() != '\r'
+                {
                     comment.push(it.next().unwrap());
                 }
                 create(&mut state, Token::Comment(comment))
@@ -161,9 +164,7 @@ fn next_and_create(it: &mut Peekable<Chars>, state: &mut State, token: Token) ->
     create(state, token)
 }
 
-fn create(state: &mut State, token: Token) -> Vec<TokenPos> {
-    state.token(token)
-}
+fn create(state: &mut State, token: Token) -> Vec<TokenPos> { state.token(token) }
 
 fn as_op_or_id(string: String) -> Token {
     match string.as_ref() {

--- a/src/lexer/mod.rs
+++ b/src/lexer/mod.rs
@@ -1,7 +1,6 @@
+use crate::lexer::common::State;
 use crate::lexer::token::Token;
 use crate::lexer::token::TokenPos;
-use std::iter::Peekable;
-use std::str::Chars;
 
 pub mod token;
 
@@ -44,321 +43,50 @@ mod common;
 pub fn tokenize(input: &str) -> Result<Vec<TokenPos>, String> {
     let mut it = input.chars().peekable();
     let mut tokens = Vec::new();
+    let mut state = State::new();
 
-    let mut cur_ind = 0;
-    let mut line_ind = 0;
-    let mut cons_spaces = 0;
-    let mut last_nl = true;
-    let mut cons_nl = 0;
+    while let Some(c) = it.next() {
+        let token_pos = match c {
+            ':' => create(&state, Token::DoublePoint),
+            '(' => create(&state, Token::LRBrack),
+            ')' => create(&state, Token::RRBrack),
+            '[' => create(&state, Token::LSBrack),
+            ']' => create(&state, Token::RSBrack),
+            '{' => create(&state, Token::LCBrack),
+            '}' => create(&state, Token::RCBrack),
 
-    let mut line = 1;
-    let mut pos = 1;
-
-    macro_rules! next_pos_and_tp {
-        ($amount:expr, $tok:path) => {{
-            next_pos!($amount, $tok);
-            it.next();
-        }};
-        ($fun:path) => {{
-            next_pos!($fun);
-            it.next();
-        }};
-    };
-
-    macro_rules! indentation {
-        () => {{
-            let mut indent_pos = 1;
-            for _ in cur_ind..line_ind {
-                tokens.push(TokenPos { line, pos: indent_pos, token: Token::Indent });
-                indent_pos += 4;
-            }
-            for _ in line_ind..cur_ind {
-                tokens.push(TokenPos { line, pos, token: Token::Dedent });
-            }
-
-            for _ in 1..cons_nl {
-                tokens.push(TokenPos { line, pos, token: Token::NL });
-            }
-
-            cur_ind = line_ind;
-            cons_nl = 0;
-            last_nl = false;
-        }};
-    }
-
-    macro_rules! next_pos {
-        ($amount:expr, $tok:path) => {{
-            indentation!();
-            pos += $amount;
-            tokens.push(TokenPos { line, pos, token: $tok });
-        }};
-        ($fun:path) => {{
-            indentation!();
-            tokens.push(TokenPos { line, pos, token: $fun(&mut it, &mut pos) });
-        }};
-    };
-
-    macro_rules! next_line_and_tp {
-        () => {{
-            if !last_nl {
-                cur_ind = line_ind;
-                tokens.push(TokenPos { line, pos, token: Token::NL });
-            }
-
-            cons_nl += 1;
-            line += 1;
-            pos = 1;
-
-            line_ind = 0;
-            last_nl = true;
-            it.next();
-        }};
-    };
-
-    macro_rules! increase_indent {
-        () => {{
-            pos += 4;
-            line_ind += 1;
-        }};
-    };
-
-    while let Some(&c) = it.peek() {
-        match c {
-            '.' => match (it.next(), it.peek()) {
-                (_, Some('.')) => match (it.next(), it.peek()) {
-                    (_, Some('=')) => next_pos_and_tp!(3, Token::RangeIncl),
-                    _ => next_pos!(2, Token::Range)
-                },
-                _ => next_pos!(1, Token::Point)
+            '\n' => create(&state, Token::NL),
+            '\r' => match it.next() {
+                Some('\n') => create(&state, Token::NL),
+                _ => panic!("Create good error message.")
             },
-            ':' => next_pos_and_tp!(1, Token::DoublePoint),
-            '_' => next_pos!(get_id_or_op),
-            ',' => next_pos_and_tp!(1, Token::Comma),
-            '(' => next_pos_and_tp!(1, Token::LRBrack),
-            ')' => next_pos_and_tp!(1, Token::RRBrack),
-            '[' => next_pos_and_tp!(1, Token::LSBrack),
-            ']' => next_pos_and_tp!(1, Token::RSBrack),
-            '{' => next_pos_and_tp!(1, Token::LCBrack),
-            '}' => next_pos_and_tp!(1, Token::RCBrack),
-            '?' => match (it.next(), it.peek()) {
-                (_, Some('.')) => next_pos_and_tp!(1, Token::QuestCall),
-                (_, Some('o')) => match (it.next(), it.peek()) {
-                    (_, Some('r')) => {
-                        next_pos_and_tp!(2, Token::QuestOr);
-                        pos += 3
-                    }
-                    (_, Some(other)) => return Err(format!("Expected `?or`. Was '{}'.", other)),
-                    (_, None) => return Err("Expected `?or`.".to_string())
-                },
-                _ => next_pos!(0, Token::Quest)
-            },
-            '|' => next_pos_and_tp!(1, Token::Ver),
-            '\n' => next_line_and_tp!(),
-            '\r' => match (it.next(), it.peek()) {
-                (_, Some('\n')) => next_line_and_tp!(),
-                (_, Some(other)) =>
-                    return Err(format!("Expected newline after carriage return. Was '{}'.", other)),
-                (_, None) => return Err("File ended with carriage return.".to_string())
-            },
-            '\t' => increase_indent!(),
-            '<' | '>' | '+' | '-' | '*' | '/' | '\\' | '^' | '=' => next_pos!(get_operator),
-            '0'...'9' => next_pos!(get_number),
-            '"' => next_pos!(get_string),
-            'a'...'z' | 'A'...'Z' => next_pos!(get_id_or_op),
-            '#' => ignore_comment(&mut it),
-            ' ' => {
-                pos += 1;
-                cons_spaces += 1;
-                if cons_spaces == 4 {
-                    cons_spaces = 0;
-                    increase_indent!();
-                    pos -= 4;
+
+            '#' => {
+                let mut comment = String::new();
+                while it.peek().is_some() && it.peek().unwrap().is_numeric() {
+                    comment.push(it.next().unwrap());
                 }
-                it.next();
-                continue;
+                create(&state, Token::Comment(comment))
             }
-            c => return Err(format!("Unrecognized character: '{}'.", c))
-        }
 
-        cons_spaces = 0;
+            '0'..='9' => {
+                let mut number = c.to_string();
+                while it.peek().is_some() && it.peek().unwrap().is_numeric() {
+                    number.push(it.next().unwrap());
+                }
+                create(&state, Token::Int(number))
+            }
+            'a'..='z' | 'A'..='Z' | '_' => unimplemented!(),
+
+            other => panic!("Create good error message.")
+        };
+
+        tokens.push(token_pos);
     }
 
     Ok(tokens)
 }
 
-fn ignore_comment(it: &mut Peekable<Chars>) {
-    while let Some(c) = it.peek() {
-        match c {
-            '\n' => break,
-            _ => {
-                it.next();
-                continue;
-            }
-        }
-    }
-}
-
-fn get_operator(it: &mut Peekable<Chars>, pos: &mut i32) -> Token {
-    *pos += 1;
-    match it.next() {
-        Some('<') => match it.peek() {
-            Some('=') => next_and!(it, pos, Token::Leq),
-            Some('-') => next_and!(it, pos, Token::Assign),
-            _ => Token::Le
-        },
-        Some('>') => match it.peek() {
-            Some('=') => next_and!(it, pos, Token::Geq),
-            _ => Token::Ge
-        },
-        Some('+') => Token::Add,
-        Some('-') => match it.peek() {
-            Some('>') => next_and!(it, pos, Token::To),
-            _ => Token::Sub
-        },
-        Some('/') => match it.peek() {
-            Some('=') => next_and!(it, pos, Token::Neq),
-            _ => Token::Div
-        },
-        Some('\\') => Token::BSlash,
-        Some('*') => Token::Mul,
-        Some('^') => Token::Pow,
-        Some('=') => match it.peek() {
-            Some('>') => next_and!(it, pos, Token::BTo),
-            _ => Token::Eq
-        },
-        _ => panic!("get operator received a character it shouldn't have.")
-    }
-}
-
-fn get_number(it: &mut Peekable<Chars>, pos: &mut i32) -> Token {
-    let mut num = String::new();
-    let mut exp = String::new();
-    let mut e_found = false;
-    let mut comma = false;
-
-    match it.next() {
-        Some(digit @ '0'...'9') => num.push(digit),
-        _ => panic!("get number received a character it shouldn't have.")
-    }
-    *pos += 1;
-
-    while let Some(&c) = it.peek() {
-        match c {
-            '0'...'9' if !e_found => next_and!(it, pos, num.push(c)),
-            '0'...'9' if e_found => next_and!(it, pos, exp.push(c)),
-            'e' | 'E' if e_found => break,
-            'e' | 'E' => next_and!(it, pos, e_found = true),
-            '.' if comma || e_found => break,
-            '.' => next_and!(it, pos, {
-                num.push(c);
-                comma = true;
-            }),
-            _ => break
-        }
-    }
-
-    match (e_found, comma) {
-        (true, _) => Token::ENum(num, exp),
-        (false, true) => Token::Real(num),
-        (false, false) => Token::Int(num)
-    }
-}
-
-fn get_string(it: &mut Peekable<Chars>, pos: &mut i32) -> Token {
-    it.next();
-    let mut result = String::new();
-    let mut last_backslash = false;
-
-    while let Some(&c) = it.peek() {
-        match c {
-            '"' => next_and!(it, pos, {
-                if !last_backslash {
-                    break;
-                } else {
-                    result.push(c)
-                };
-                last_backslash = false
-            }),
-            '\\' => next_and!(it, pos, {
-                result.push(c);
-                last_backslash = true
-            }),
-            _ => next_and!(it, pos, {
-                result.push(c);
-                last_backslash = false
-            })
-        }
-    }
-
-    *pos += 1; // for closing " character
-    Token::Str(result)
-}
-
-fn get_id_or_op(it: &mut Peekable<Chars>, pos: &mut i32) -> Token {
-    let mut result = String::new();
-
-    while let Some(&c) = it.peek() {
-        match c {
-            'a'...'z' | 'A'...'Z' | '0'...'9' | '_' => next_and!(it, pos, result.push(c)),
-            _ => break
-        }
-    }
-
-    match result.as_ref() {
-        "_" => Token::Underscore,
-
-        "from" => Token::From,
-        "type" => Token::Type,
-        "stateful" => Token::Stateful,
-        "stateless" => Token::Stateless,
-        "as" => Token::As,
-        "private" => Token::Private,
-
-        "import" => Token::Import,
-        "forward" => Token::Forward,
-        "self" => Token::_Self,
-        "vararg" => Token::Vararg,
-        "init" => Token::Init,
-
-        "def" => Token::Def,
-        "ofmut" => Token::OfMut,
-        "mut" => Token::Mut,
-        "and" => Token::And,
-        "or" => Token::Or,
-        "not" => Token::Not,
-        "is" => Token::Is,
-        "isa" => Token::IsA,
-        "isnt" => Token::IsN,
-        "isnta" => Token::IsNA,
-        "mod" => Token::Mod,
-        "sqrt" => Token::Sqrt,
-        "while" => Token::While,
-        "foreach" => Token::For,
-
-        "if" => Token::If,
-        "else" => Token::Else,
-        "match" => Token::Match,
-        "with" => Token::With,
-        "continue" => Token::Continue,
-        "break" => Token::Break,
-        "return" => Token::Ret,
-        "then" => Token::Then,
-        "do" => Token::Do,
-
-        "in" => Token::In,
-
-        "raises" => Token::Raises,
-        "handle" => Token::Handle,
-        "retry" => Token::Retry,
-        "when" => Token::When,
-
-        "True" => Token::Bool(true),
-        "False" => Token::Bool(false),
-        "print" => Token::Print,
-
-        "undefined" => Token::Undefined,
-        "pass" => Token::Pass,
-
-        _ => Token::Id(result)
-    }
+fn create(mut state: &State, token: Token) -> TokenPos {
+    TokenPos { line: state.line, pos: state.pos, token }
 }

--- a/src/lexer/mod.rs
+++ b/src/lexer/mod.rs
@@ -1,6 +1,7 @@
 use crate::lexer::common::State;
 use crate::lexer::token::Token;
 use crate::lexer::token::TokenPos;
+use std::iter::Peekable;
 
 pub mod token;
 
@@ -54,13 +55,44 @@ pub fn tokenize(input: &str) -> Result<Vec<TokenPos>, String> {
             ']' => create(&state, Token::RSBrack),
             '{' => create(&state, Token::LCBrack),
             '}' => create(&state, Token::RCBrack),
-
+            '|' => create(&state, Token::Ver),
             '\n' => create(&state, Token::NL),
             '\r' => match it.next() {
                 Some('\n') => create(&state, Token::NL),
                 _ => panic!("Create good error message.")
             },
-
+            '.' => match it.peek() {
+                Some('.') => match (it.next(), it.peek()) {
+                    (_, Some('=')) => next_and_create(it, &state, Token::RangeIncl),
+                    (..) => create(&state, Token::Range)
+                },
+                _ => create(&state, Token::Point)
+            },
+            '<' => match it.peek() {
+                Some('-') => next_and_create(it, &state, Token::Assign),
+                Some('=') => next_and_create(it, &state, Token::Leq),
+                _ => create(&state, Token::Le)
+            },
+            '>' => match it.peek() {
+                Some('=') => next_and_create(it, &state, Token::Geq),
+                _ => create(&state, Token::Ge)
+            },
+            '+' => create(&state, Token::Add),
+            '-' => match it.peek() {
+                Some('>') => next_and_create(it, &state, Token::To),
+                _ => create(&state, Token::Sub)
+            },
+            '*' => create(&state, Token::Mul),
+            '/' => match it.peek() {
+                Some('=') => next_and_create(it, &state, Token::Neq),
+                _ => create(&state, Token::Div)
+            },
+            '\\' => create(&state, Token::BSlash),
+            '^' => create(&state, Token::Pow),
+            '=' => match it.peek() {
+                Some('>') => next_and_create(it, &state, Token::BTo),
+                _ => create(&state, Token::Eq)
+            },
             '#' => {
                 let mut comment = String::new();
                 while it.peek().is_some() && it.peek().unwrap().is_numeric() {
@@ -68,7 +100,6 @@ pub fn tokenize(input: &str) -> Result<Vec<TokenPos>, String> {
                 }
                 create(&state, Token::Comment(comment))
             }
-
             '0'..='9' => {
                 let mut number = c.to_string();
                 while it.peek().is_some() && it.peek().unwrap().is_numeric() {
@@ -76,17 +107,108 @@ pub fn tokenize(input: &str) -> Result<Vec<TokenPos>, String> {
                 }
                 create(&state, Token::Int(number))
             }
-            'a'..='z' | 'A'..='Z' | '_' => unimplemented!(),
-
+            'a'..='z' | 'A'..='Z' | '_' => {
+                let mut id_or_operation = c.to_string();
+                while let Some(c) = it.peek() {
+                    match c {
+                        'a'..='z' | 'A'..='Z' | '_' | '0'..='9' => id_or_operation.push(*c),
+                        _ => break
+                    }
+                }
+                create(&state, as_op_or_id(id_or_operation))
+            }
+            '"' => {
+                let mut string = String::new();
+                while let Some(c) = it.next() {
+                    if c == '"' {
+                        break;
+                    }
+                    string.push(c)
+                }
+                create(&state, Token::Str(string))
+            }
+            ' ' => {
+                &state.space();
+                None
+            }
             other => panic!("Create good error message.")
         };
 
-        tokens.push(token_pos);
+        if token_pos.is_some() {
+            tokens.push(token_pos.unwrap());
+        }
     }
 
     Ok(tokens)
 }
 
-fn create(mut state: &State, token: Token) -> TokenPos {
-    TokenPos { line: state.line, pos: state.pos, token }
+fn next_and_create(mut it: &Peekable<Char>, mut state: &State, token: Token) -> Option<TokenPos> {
+    it.next();
+    state.token(token);
+    Some(TokenPos { line: state.line, pos: state.pos, token })
+}
+
+fn create(mut state: &State, token: Token) -> Option<TokenPos> {
+    state.token(token);
+    Some(TokenPos { line: state.line, pos: state.pos, token })
+}
+
+fn as_op_or_id(mut string: String) -> Token {
+    match string.as_ref() {
+        "_" => Token::Underscore,
+
+        "from" => Token::From,
+        "type" => Token::Type,
+        "stateful" => Token::Stateful,
+        "stateless" => Token::Stateless,
+        "as" => Token::As,
+        "private" => Token::Private,
+
+        "import" => Token::Import,
+        "forward" => Token::Forward,
+        "self" => Token::_Self,
+        "vararg" => Token::Vararg,
+        "init" => Token::Init,
+
+        "def" => Token::Def,
+        "ofmut" => Token::OfMut,
+        "mut" => Token::Mut,
+        "and" => Token::And,
+        "or" => Token::Or,
+        "not" => Token::Not,
+        "is" => Token::Is,
+        "isa" => Token::IsA,
+        "isnt" => Token::IsN,
+        "isnta" => Token::IsNA,
+        "mod" => Token::Mod,
+        "sqrt" => Token::Sqrt,
+        "while" => Token::While,
+        "foreach" => Token::For,
+
+        "if" => Token::If,
+        "else" => Token::Else,
+        "match" => Token::Match,
+        "with" => Token::With,
+        "continue" => Token::Continue,
+        "break" => Token::Break,
+        "return" => Token::Ret,
+        "then" => Token::Then,
+        "do" => Token::Do,
+
+        "in" => Token::In,
+
+        "raises" => Token::Raises,
+        "handle" => Token::Handle,
+        "retry" => Token::Retry,
+        "when" => Token::When,
+
+        "True" => Token::Bool(true),
+        "False" => Token::Bool(false),
+        "print" => Token::Print,
+
+        "undefined" => Token::Undefined,
+        "pass" => Token::Pass,
+
+        _ => Token::Id(string)
+    }
 }

--- a/src/lexer/mod.rs
+++ b/src/lexer/mod.rs
@@ -100,6 +100,14 @@ pub fn tokenize(input: &str) -> Result<Vec<TokenPos>, String> {
                 }
                 create(&state, Token::Comment(comment))
             }
+            '?' => match it.peek() {
+                Some('.') => next_and_create(it, &state, Token::QuestCall),
+                Some('o') => match (it.next(), it.peek()) {
+                    (_, Some('r')) => create(&state, Token::QuestOr),
+                    _ => panic!("Create good error message.")
+                }
+                _ => create(&state, Token::Quest)
+            }
             '0'..='9' => {
                 let mut number = c.to_string();
                 while it.peek().is_some() && it.peek().unwrap().is_numeric() {

--- a/src/lexer/mod.rs
+++ b/src/lexer/mod.rs
@@ -41,7 +41,7 @@ mod common;
 /// let result = tokenize(&source);
 /// assert_eq!(result.is_err(), true);
 /// ```
-#[allow(clippy::cyclomatic_complexity)]
+#[allow(clippy::cyclomatic_complexity,clippy::while_let_on_iterator)]
 pub fn tokenize(input: &str) -> Result<Vec<TokenPos>, String> {
     let mut it = input.chars().peekable();
     let mut tokens = Vec::new();
@@ -61,7 +61,7 @@ pub fn tokenize(input: &str) -> Result<Vec<TokenPos>, String> {
             '\n' => create(&mut state, Token::NL),
             '\r' => match it.next() {
                 Some('\n') => create(&mut state, Token::NL),
-                _ => panic!("Create good error message.")
+                _ => return Err(String::from("Create good error message."))
             },
             '.' => match it.peek() {
                 Some('.') => match (it.next(), it.peek()) {
@@ -109,7 +109,7 @@ pub fn tokenize(input: &str) -> Result<Vec<TokenPos>, String> {
                 Some('.') => next_and_create(&mut it, &mut state, Token::QuestCall),
                 Some('o') => match (it.next(), it.peek()) {
                     (_, Some('r')) => next_and_create(&mut it, &mut state, Token::QuestOr),
-                    _ => panic!("Create good error message.")
+                    _ => return Err(String::from("Create good error message."))
                 },
                 _ => create(&mut state, Token::Quest)
             },
@@ -184,7 +184,7 @@ pub fn tokenize(input: &str) -> Result<Vec<TokenPos>, String> {
                 vec![]
             }
 
-            other => panic!("Create good error message: {}.", other)
+            other => return Err(format!("Create good error message: {}.", other))
         };
 
         for tp in token_pos {

--- a/src/lexer/mod.rs
+++ b/src/lexer/mod.rs
@@ -41,7 +41,7 @@ mod common;
 /// let result = tokenize(&source);
 /// assert_eq!(result.is_err(), true);
 /// ```
-#[allow(clippy::cyclomatic_complexity,clippy::while_let_on_iterator)]
+#[allow(clippy::cyclomatic_complexity, clippy::while_let_on_iterator)]
 pub fn tokenize(input: &str) -> Result<Vec<TokenPos>, String> {
     let mut it = input.chars().peekable();
     let mut tokens = Vec::new();

--- a/src/lexer/mod.rs
+++ b/src/lexer/mod.rs
@@ -97,7 +97,7 @@ pub fn tokenize(input: &str) -> Result<Vec<TokenPos>, String> {
             },
             '#' => {
                 let mut comment = String::new();
-                while it.peek().is_some() && it.peek().unwrap().is_numeric() {
+                while it.peek().is_some() && *it.peek().unwrap() != '\n' && *it.peek().unwrap() != '\r' {
                     comment.push(it.next().unwrap());
                 }
                 create(&mut state, Token::Comment(comment))
@@ -162,9 +162,7 @@ fn next_and_create(it: &mut Peekable<Chars>, state: &mut State, token: Token) ->
 }
 
 fn create(state: &mut State, token: Token) -> Vec<TokenPos> {
-    let mut tokens = state.token(&token);
-    tokens.push(TokenPos { line: state.line, pos: state.pos, token });
-    tokens
+    state.token(token)
 }
 
 fn as_op_or_id(string: String) -> Token {

--- a/src/lexer/mod.rs
+++ b/src/lexer/mod.rs
@@ -108,7 +108,7 @@ pub fn tokenize(input: &str) -> Result<Vec<TokenPos>, String> {
             '?' => match it.peek() {
                 Some('.') => next_and_create(&mut it, &mut state, Token::QuestCall),
                 Some('o') => match (it.next(), it.peek()) {
-                    (_, Some('r')) => create(&mut state, Token::QuestOr),
+                    (_, Some('r')) => next_and_create(&mut it, &mut state, Token::QuestOr),
                     _ => panic!("Create good error message.")
                 },
                 _ => create(&mut state, Token::Quest)
@@ -169,11 +169,13 @@ pub fn tokenize(input: &str) -> Result<Vec<TokenPos>, String> {
             }
             '"' => {
                 let mut string = String::new();
+                let mut back_slash = false;
                 while let Some(c) = it.next() {
-                    if c == '"' {
+                    if !back_slash && c == '"' {
                         break;
                     }
-                    string.push(c)
+                    string.push(c);
+                    back_slash = c == '\\';
                 }
                 create(&mut state, Token::Str(string))
             }

--- a/src/lexer/token.rs
+++ b/src/lexer/token.rs
@@ -105,7 +105,8 @@ pub enum Token {
     Print,
 
     Pass,
-    Undefined
+    Undefined,
+    Comment(String)
 }
 
 impl fmt::Display for Token {
@@ -206,7 +207,8 @@ impl fmt::Display for Token {
 
             Token::Pass => String::from("pass"),
             Token::Print => String::from("print"),
-            Token::Undefined => String::from("undefined")
+            Token::Undefined => String::from("undefined"),
+            Token::Comment(string) => format!("{} (comment)", string)
         })
     }
 }

--- a/src/parser/ast.rs
+++ b/src/parser/ast.rs
@@ -3,93 +3,93 @@
 /// The start and end positions can be used to generate useful error messages.
 pub struct ASTNodePos {
     pub st_line: i32,
-    pub st_pos: i32,
+    pub st_pos:  i32,
     pub en_line: i32,
-    pub en_pos: i32,
-    pub node: ASTNode,
+    pub en_pos:  i32,
+    pub node:    ASTNode
 }
 
 #[derive(PartialEq, Eq, Hash, Debug, Clone)]
 pub enum ASTNode {
     File {
-        imports: Vec<ASTNodePos>,
-        modules: Vec<ASTNodePos>,
-        type_defs: Vec<ASTNodePos>,
+        imports:   Vec<ASTNodePos>,
+        modules:   Vec<ASTNodePos>,
+        type_defs: Vec<ASTNodePos>
     },
     Import {
         import: Vec<ASTNodePos>,
-        _as: Vec<ASTNodePos>,
+        _as:    Vec<ASTNodePos>
     },
     FromImport {
-        id: Box<ASTNodePos>,
-        import: Box<ASTNodePos>,
+        id:     Box<ASTNodePos>,
+        import: Box<ASTNodePos>
     },
     Stateful {
         _type: Box<ASTNodePos>,
-        body: Box<ASTNodePos>,
+        body:  Box<ASTNodePos>
     },
     Stateless {
         _type: Box<ASTNodePos>,
-        body: Box<ASTNodePos>,
+        body:  Box<ASTNodePos>
     },
     Script {
         statements: Vec<ASTNodePos>
     },
     Body {
-        isa: Vec<ASTNodePos>,
-        definitions: Vec<ASTNodePos>,
+        isa:         Vec<ASTNodePos>,
+        definitions: Vec<ASTNodePos>
     },
     Init,
 
     Reassign {
-        left: Box<ASTNodePos>,
-        right: Box<ASTNodePos>,
+        left:  Box<ASTNodePos>,
+        right: Box<ASTNodePos>
     },
     Def {
-        private: bool,
-        definition: Box<ASTNodePos>,
+        private:    bool,
+        definition: Box<ASTNodePos>
     },
     VariableDef {
-        ofmut: bool,
+        ofmut:         bool,
         id_maybe_type: Box<ASTNodePos>,
-        expression: Option<Box<ASTNodePos>>,
-        forward: Vec<ASTNodePos>,
+        expression:    Option<Box<ASTNodePos>>,
+        forward:       Vec<ASTNodePos>
     },
     FunDef {
-        id: Box<ASTNodePos>,
+        id:       Box<ASTNodePos>,
         fun_args: Vec<ASTNodePos>,
-        ret_ty: Option<Box<ASTNodePos>>,
-        raises: Option<Vec<ASTNodePos>>,
-        body: Option<Box<ASTNodePos>>,
+        ret_ty:   Option<Box<ASTNodePos>>,
+        raises:   Option<Vec<ASTNodePos>>,
+        body:     Option<Box<ASTNodePos>>
     },
 
     AnonFun {
         args: Vec<ASTNodePos>,
-        body: Box<ASTNodePos>,
+        body: Box<ASTNodePos>
     },
 
     Raises {
         expr_or_stmt: Box<ASTNodePos>,
-        errors: Vec<ASTNodePos>,
+        errors:       Vec<ASTNodePos>
     },
     Handle {
         expr_or_stmt: Box<ASTNodePos>,
-        cases: Vec<ASTNodePos>,
+        cases:        Vec<ASTNodePos>
     },
     Retry,
 
     DirectCall {
         name: Box<ASTNodePos>,
-        args: Vec<ASTNodePos>,
+        args: Vec<ASTNodePos>
     },
     MethodCall {
         instance: Box<ASTNodePos>,
-        name: Box<ASTNodePos>,
-        args: Vec<ASTNodePos>,
+        name:     Box<ASTNodePos>,
+        args:     Vec<ASTNodePos>
     },
     Call {
-        left: Box<ASTNodePos>,
-        right: Box<ASTNodePos>,
+        left:  Box<ASTNodePos>,
+        right: Box<ASTNodePos>
     },
 
     Id {
@@ -97,37 +97,37 @@ pub enum ASTNode {
     },
 
     IdType {
-        id: Box<ASTNodePos>,
+        id:      Box<ASTNodePos>,
         mutable: bool,
-        _type: Option<Box<ASTNodePos>>,
+        _type:   Option<Box<ASTNodePos>>
     },
     TypeDef {
         _type: Box<ASTNodePos>,
-        body: Option<Box<ASTNodePos>>,
+        body:  Option<Box<ASTNodePos>>
     },
     TypeAlias {
-        _type: Box<ASTNodePos>,
-        conditions: Option<Vec<ASTNodePos>>,
+        _type:      Box<ASTNodePos>,
+        conditions: Option<Vec<ASTNodePos>>
     },
     TypeTup {
         types: Vec<ASTNodePos>
     },
     Type {
-        id: Box<ASTNodePos>,
-        generics: Vec<ASTNodePos>,
+        id:       Box<ASTNodePos>,
+        generics: Vec<ASTNodePos>
     },
     TypeFun {
         _type: Box<ASTNodePos>,
-        body: Box<ASTNodePos>,
+        body:  Box<ASTNodePos>
     },
     Condition {
-        cond: Box<ASTNodePos>,
-        _else: Option<Box<ASTNodePos>>,
+        cond:  Box<ASTNodePos>,
+        _else: Option<Box<ASTNodePos>>
     },
     FunArg {
-        vararg: bool,
+        vararg:        bool,
         id_maybe_type: Box<ASTNodePos>,
-        default: Option<Box<ASTNodePos>>,
+        default:       Option<Box<ASTNodePos>>
     },
 
     _Self,
@@ -146,15 +146,15 @@ pub enum ASTNode {
         elements: Vec<ASTNodePos>
     },
     SetBuilder {
-        items: Box<ASTNodePos>,
-        conditions: Vec<ASTNodePos>,
+        items:      Box<ASTNodePos>,
+        conditions: Vec<ASTNodePos>
     },
     List {
         elements: Vec<ASTNodePos>
     },
     ListBuilder {
-        items: Box<ASTNodePos>,
-        conditions: Vec<ASTNodePos>,
+        items:      Box<ASTNodePos>,
+        conditions: Vec<ASTNodePos>
     },
     Tuple {
         elements: Vec<ASTNodePos>
@@ -162,11 +162,11 @@ pub enum ASTNode {
 
     Range {
         from: Box<ASTNodePos>,
-        to: Box<ASTNodePos>,
+        to:   Box<ASTNodePos>
     },
     RangeIncl {
         from: Box<ASTNodePos>,
-        to: Box<ASTNodePos>,
+        to:   Box<ASTNodePos>
     },
 
     Block {
@@ -181,7 +181,7 @@ pub enum ASTNode {
     },
     ENum {
         num: String,
-        exp: String,
+        exp: String
     },
     Str {
         lit: String
@@ -191,112 +191,112 @@ pub enum ASTNode {
     },
 
     Add {
-        left: Box<ASTNodePos>,
-        right: Box<ASTNodePos>,
+        left:  Box<ASTNodePos>,
+        right: Box<ASTNodePos>
     },
     AddU {
         expr: Box<ASTNodePos>
     },
     Sub {
-        left: Box<ASTNodePos>,
-        right: Box<ASTNodePos>,
+        left:  Box<ASTNodePos>,
+        right: Box<ASTNodePos>
     },
     SubU {
         expr: Box<ASTNodePos>
     },
     Mul {
-        left: Box<ASTNodePos>,
-        right: Box<ASTNodePos>,
+        left:  Box<ASTNodePos>,
+        right: Box<ASTNodePos>
     },
     Div {
-        left: Box<ASTNodePos>,
-        right: Box<ASTNodePos>,
+        left:  Box<ASTNodePos>,
+        right: Box<ASTNodePos>
     },
     Mod {
-        left: Box<ASTNodePos>,
-        right: Box<ASTNodePos>,
+        left:  Box<ASTNodePos>,
+        right: Box<ASTNodePos>
     },
     Pow {
-        left: Box<ASTNodePos>,
-        right: Box<ASTNodePos>,
+        left:  Box<ASTNodePos>,
+        right: Box<ASTNodePos>
     },
     Sqrt {
         expr: Box<ASTNodePos>
     },
 
     Le {
-        left: Box<ASTNodePos>,
-        right: Box<ASTNodePos>,
+        left:  Box<ASTNodePos>,
+        right: Box<ASTNodePos>
     },
     Ge {
-        left: Box<ASTNodePos>,
-        right: Box<ASTNodePos>,
+        left:  Box<ASTNodePos>,
+        right: Box<ASTNodePos>
     },
     Leq {
-        left: Box<ASTNodePos>,
-        right: Box<ASTNodePos>,
+        left:  Box<ASTNodePos>,
+        right: Box<ASTNodePos>
     },
     Geq {
-        left: Box<ASTNodePos>,
-        right: Box<ASTNodePos>,
+        left:  Box<ASTNodePos>,
+        right: Box<ASTNodePos>
     },
     Is {
-        left: Box<ASTNodePos>,
-        right: Box<ASTNodePos>,
+        left:  Box<ASTNodePos>,
+        right: Box<ASTNodePos>
     },
     IsN {
-        left: Box<ASTNodePos>,
-        right: Box<ASTNodePos>,
+        left:  Box<ASTNodePos>,
+        right: Box<ASTNodePos>
     },
     Eq {
-        left: Box<ASTNodePos>,
-        right: Box<ASTNodePos>,
+        left:  Box<ASTNodePos>,
+        right: Box<ASTNodePos>
     },
     Neq {
-        left: Box<ASTNodePos>,
-        right: Box<ASTNodePos>,
+        left:  Box<ASTNodePos>,
+        right: Box<ASTNodePos>
     },
     IsA {
-        left: Box<ASTNodePos>,
-        right: Box<ASTNodePos>,
+        left:  Box<ASTNodePos>,
+        right: Box<ASTNodePos>
     },
     IsNA {
-        left: Box<ASTNodePos>,
-        right: Box<ASTNodePos>,
+        left:  Box<ASTNodePos>,
+        right: Box<ASTNodePos>
     },
     Not {
         expr: Box<ASTNodePos>
     },
     And {
-        left: Box<ASTNodePos>,
-        right: Box<ASTNodePos>,
+        left:  Box<ASTNodePos>,
+        right: Box<ASTNodePos>
     },
     Or {
-        left: Box<ASTNodePos>,
-        right: Box<ASTNodePos>,
+        left:  Box<ASTNodePos>,
+        right: Box<ASTNodePos>
     },
 
     IfElse {
-        cond: Vec<ASTNodePos>,
-        then: Box<ASTNodePos>,
-        _else: Option<Box<ASTNodePos>>,
+        cond:  Vec<ASTNodePos>,
+        then:  Box<ASTNodePos>,
+        _else: Option<Box<ASTNodePos>>
     },
     Match {
-        cond: Vec<ASTNodePos>,
-        cases: Vec<ASTNodePos>,
+        cond:  Vec<ASTNodePos>,
+        cases: Vec<ASTNodePos>
     },
     Case {
         cond: Box<ASTNodePos>,
-        body: Box<ASTNodePos>,
+        body: Box<ASTNodePos>
     },
     For {
-        expr: Vec<ASTNodePos>,
+        expr:       Vec<ASTNodePos>,
         collection: Box<ASTNodePos>,
-        body: Box<ASTNodePos>,
+        body:       Box<ASTNodePos>
     },
     While {
         cond: Vec<ASTNodePos>,
-        body: Box<ASTNodePos>,
+        body: Box<ASTNodePos>
     },
     Break,
     Continue,
@@ -309,14 +309,14 @@ pub enum ASTNode {
     Pass,
 
     QuestOr {
-        _do: Box<ASTNodePos>,
-        _default: Box<ASTNodePos>,
+        _do:      Box<ASTNodePos>,
+        _default: Box<ASTNodePos>
     },
 
     Print {
         expr: Box<ASTNodePos>
     },
     Comment {
-        text: String
-    },
+        comment: String
+    }
 }

--- a/src/parser/ast.rs
+++ b/src/parser/ast.rs
@@ -3,93 +3,93 @@
 /// The start and end positions can be used to generate useful error messages.
 pub struct ASTNodePos {
     pub st_line: i32,
-    pub st_pos:  i32,
+    pub st_pos: i32,
     pub en_line: i32,
-    pub en_pos:  i32,
-    pub node:    ASTNode
+    pub en_pos: i32,
+    pub node: ASTNode,
 }
 
 #[derive(PartialEq, Eq, Hash, Debug, Clone)]
 pub enum ASTNode {
     File {
-        imports:   Vec<ASTNodePos>,
-        modules:   Vec<ASTNodePos>,
-        type_defs: Vec<ASTNodePos>
+        imports: Vec<ASTNodePos>,
+        modules: Vec<ASTNodePos>,
+        type_defs: Vec<ASTNodePos>,
     },
     Import {
         import: Vec<ASTNodePos>,
-        _as:    Vec<ASTNodePos>
+        _as: Vec<ASTNodePos>,
     },
     FromImport {
-        id:     Box<ASTNodePos>,
-        import: Box<ASTNodePos>
+        id: Box<ASTNodePos>,
+        import: Box<ASTNodePos>,
     },
     Stateful {
         _type: Box<ASTNodePos>,
-        body:  Box<ASTNodePos>
+        body: Box<ASTNodePos>,
     },
     Stateless {
         _type: Box<ASTNodePos>,
-        body:  Box<ASTNodePos>
+        body: Box<ASTNodePos>,
     },
     Script {
         statements: Vec<ASTNodePos>
     },
     Body {
-        isa:         Vec<ASTNodePos>,
-        definitions: Vec<ASTNodePos>
+        isa: Vec<ASTNodePos>,
+        definitions: Vec<ASTNodePos>,
     },
     Init,
 
     Reassign {
-        left:  Box<ASTNodePos>,
-        right: Box<ASTNodePos>
+        left: Box<ASTNodePos>,
+        right: Box<ASTNodePos>,
     },
     Def {
-        private:    bool,
-        definition: Box<ASTNodePos>
+        private: bool,
+        definition: Box<ASTNodePos>,
     },
     VariableDef {
-        ofmut:         bool,
+        ofmut: bool,
         id_maybe_type: Box<ASTNodePos>,
-        expression:    Option<Box<ASTNodePos>>,
-        forward:       Vec<ASTNodePos>
+        expression: Option<Box<ASTNodePos>>,
+        forward: Vec<ASTNodePos>,
     },
     FunDef {
-        id:       Box<ASTNodePos>,
+        id: Box<ASTNodePos>,
         fun_args: Vec<ASTNodePos>,
-        ret_ty:   Option<Box<ASTNodePos>>,
-        raises:   Option<Vec<ASTNodePos>>,
-        body:     Option<Box<ASTNodePos>>
+        ret_ty: Option<Box<ASTNodePos>>,
+        raises: Option<Vec<ASTNodePos>>,
+        body: Option<Box<ASTNodePos>>,
     },
 
     AnonFun {
         args: Vec<ASTNodePos>,
-        body: Box<ASTNodePos>
+        body: Box<ASTNodePos>,
     },
 
     Raises {
         expr_or_stmt: Box<ASTNodePos>,
-        errors:       Vec<ASTNodePos>
+        errors: Vec<ASTNodePos>,
     },
     Handle {
         expr_or_stmt: Box<ASTNodePos>,
-        cases:        Vec<ASTNodePos>
+        cases: Vec<ASTNodePos>,
     },
     Retry,
 
     DirectCall {
         name: Box<ASTNodePos>,
-        args: Vec<ASTNodePos>
+        args: Vec<ASTNodePos>,
     },
     MethodCall {
         instance: Box<ASTNodePos>,
-        name:     Box<ASTNodePos>,
-        args:     Vec<ASTNodePos>
+        name: Box<ASTNodePos>,
+        args: Vec<ASTNodePos>,
     },
     Call {
-        left:  Box<ASTNodePos>,
-        right: Box<ASTNodePos>
+        left: Box<ASTNodePos>,
+        right: Box<ASTNodePos>,
     },
 
     Id {
@@ -97,37 +97,37 @@ pub enum ASTNode {
     },
 
     IdType {
-        id:      Box<ASTNodePos>,
+        id: Box<ASTNodePos>,
         mutable: bool,
-        _type:   Option<Box<ASTNodePos>>
+        _type: Option<Box<ASTNodePos>>,
     },
     TypeDef {
         _type: Box<ASTNodePos>,
-        body:  Option<Box<ASTNodePos>>
+        body: Option<Box<ASTNodePos>>,
     },
     TypeAlias {
-        _type:      Box<ASTNodePos>,
-        conditions: Option<Vec<ASTNodePos>>
+        _type: Box<ASTNodePos>,
+        conditions: Option<Vec<ASTNodePos>>,
     },
     TypeTup {
         types: Vec<ASTNodePos>
     },
     Type {
-        id:       Box<ASTNodePos>,
-        generics: Vec<ASTNodePos>
+        id: Box<ASTNodePos>,
+        generics: Vec<ASTNodePos>,
     },
     TypeFun {
         _type: Box<ASTNodePos>,
-        body:  Box<ASTNodePos>
+        body: Box<ASTNodePos>,
     },
     Condition {
-        cond:  Box<ASTNodePos>,
-        _else: Option<Box<ASTNodePos>>
+        cond: Box<ASTNodePos>,
+        _else: Option<Box<ASTNodePos>>,
     },
     FunArg {
-        vararg:        bool,
+        vararg: bool,
         id_maybe_type: Box<ASTNodePos>,
-        default:       Option<Box<ASTNodePos>>
+        default: Option<Box<ASTNodePos>>,
     },
 
     _Self,
@@ -146,15 +146,15 @@ pub enum ASTNode {
         elements: Vec<ASTNodePos>
     },
     SetBuilder {
-        items:      Box<ASTNodePos>,
-        conditions: Vec<ASTNodePos>
+        items: Box<ASTNodePos>,
+        conditions: Vec<ASTNodePos>,
     },
     List {
         elements: Vec<ASTNodePos>
     },
     ListBuilder {
-        items:      Box<ASTNodePos>,
-        conditions: Vec<ASTNodePos>
+        items: Box<ASTNodePos>,
+        conditions: Vec<ASTNodePos>,
     },
     Tuple {
         elements: Vec<ASTNodePos>
@@ -162,11 +162,11 @@ pub enum ASTNode {
 
     Range {
         from: Box<ASTNodePos>,
-        to:   Box<ASTNodePos>
+        to: Box<ASTNodePos>,
     },
     RangeIncl {
         from: Box<ASTNodePos>,
-        to:   Box<ASTNodePos>
+        to: Box<ASTNodePos>,
     },
 
     Block {
@@ -181,7 +181,7 @@ pub enum ASTNode {
     },
     ENum {
         num: String,
-        exp: String
+        exp: String,
     },
     Str {
         lit: String
@@ -191,112 +191,112 @@ pub enum ASTNode {
     },
 
     Add {
-        left:  Box<ASTNodePos>,
-        right: Box<ASTNodePos>
+        left: Box<ASTNodePos>,
+        right: Box<ASTNodePos>,
     },
     AddU {
         expr: Box<ASTNodePos>
     },
     Sub {
-        left:  Box<ASTNodePos>,
-        right: Box<ASTNodePos>
+        left: Box<ASTNodePos>,
+        right: Box<ASTNodePos>,
     },
     SubU {
         expr: Box<ASTNodePos>
     },
     Mul {
-        left:  Box<ASTNodePos>,
-        right: Box<ASTNodePos>
+        left: Box<ASTNodePos>,
+        right: Box<ASTNodePos>,
     },
     Div {
-        left:  Box<ASTNodePos>,
-        right: Box<ASTNodePos>
+        left: Box<ASTNodePos>,
+        right: Box<ASTNodePos>,
     },
     Mod {
-        left:  Box<ASTNodePos>,
-        right: Box<ASTNodePos>
+        left: Box<ASTNodePos>,
+        right: Box<ASTNodePos>,
     },
     Pow {
-        left:  Box<ASTNodePos>,
-        right: Box<ASTNodePos>
+        left: Box<ASTNodePos>,
+        right: Box<ASTNodePos>,
     },
     Sqrt {
         expr: Box<ASTNodePos>
     },
 
     Le {
-        left:  Box<ASTNodePos>,
-        right: Box<ASTNodePos>
+        left: Box<ASTNodePos>,
+        right: Box<ASTNodePos>,
     },
     Ge {
-        left:  Box<ASTNodePos>,
-        right: Box<ASTNodePos>
+        left: Box<ASTNodePos>,
+        right: Box<ASTNodePos>,
     },
     Leq {
-        left:  Box<ASTNodePos>,
-        right: Box<ASTNodePos>
+        left: Box<ASTNodePos>,
+        right: Box<ASTNodePos>,
     },
     Geq {
-        left:  Box<ASTNodePos>,
-        right: Box<ASTNodePos>
+        left: Box<ASTNodePos>,
+        right: Box<ASTNodePos>,
     },
     Is {
-        left:  Box<ASTNodePos>,
-        right: Box<ASTNodePos>
+        left: Box<ASTNodePos>,
+        right: Box<ASTNodePos>,
     },
     IsN {
-        left:  Box<ASTNodePos>,
-        right: Box<ASTNodePos>
+        left: Box<ASTNodePos>,
+        right: Box<ASTNodePos>,
     },
     Eq {
-        left:  Box<ASTNodePos>,
-        right: Box<ASTNodePos>
+        left: Box<ASTNodePos>,
+        right: Box<ASTNodePos>,
     },
     Neq {
-        left:  Box<ASTNodePos>,
-        right: Box<ASTNodePos>
+        left: Box<ASTNodePos>,
+        right: Box<ASTNodePos>,
     },
     IsA {
-        left:  Box<ASTNodePos>,
-        right: Box<ASTNodePos>
+        left: Box<ASTNodePos>,
+        right: Box<ASTNodePos>,
     },
     IsNA {
-        left:  Box<ASTNodePos>,
-        right: Box<ASTNodePos>
+        left: Box<ASTNodePos>,
+        right: Box<ASTNodePos>,
     },
     Not {
         expr: Box<ASTNodePos>
     },
     And {
-        left:  Box<ASTNodePos>,
-        right: Box<ASTNodePos>
+        left: Box<ASTNodePos>,
+        right: Box<ASTNodePos>,
     },
     Or {
-        left:  Box<ASTNodePos>,
-        right: Box<ASTNodePos>
+        left: Box<ASTNodePos>,
+        right: Box<ASTNodePos>,
     },
 
     IfElse {
-        cond:  Vec<ASTNodePos>,
-        then:  Box<ASTNodePos>,
-        _else: Option<Box<ASTNodePos>>
+        cond: Vec<ASTNodePos>,
+        then: Box<ASTNodePos>,
+        _else: Option<Box<ASTNodePos>>,
     },
     Match {
-        cond:  Vec<ASTNodePos>,
-        cases: Vec<ASTNodePos>
+        cond: Vec<ASTNodePos>,
+        cases: Vec<ASTNodePos>,
     },
     Case {
         cond: Box<ASTNodePos>,
-        body: Box<ASTNodePos>
+        body: Box<ASTNodePos>,
     },
     For {
-        expr:       Vec<ASTNodePos>,
+        expr: Vec<ASTNodePos>,
         collection: Box<ASTNodePos>,
-        body:       Box<ASTNodePos>
+        body: Box<ASTNodePos>,
     },
     While {
         cond: Vec<ASTNodePos>,
-        body: Box<ASTNodePos>
+        body: Box<ASTNodePos>,
     },
     Break,
     Continue,
@@ -309,11 +309,14 @@ pub enum ASTNode {
     Pass,
 
     QuestOr {
-        _do:      Box<ASTNodePos>,
-        _default: Box<ASTNodePos>
+        _do: Box<ASTNodePos>,
+        _default: Box<ASTNodePos>,
     },
 
     Print {
         expr: Box<ASTNodePos>
-    }
+    },
+    Comment {
+        text: String
+    },
 }

--- a/src/parser/block.rs
+++ b/src/parser/block.rs
@@ -15,6 +15,7 @@ pub fn parse_statements(it: &mut TPIterator) -> ParseResult<Vec<ASTNodePos>> {
             Token::NL => {
                 it.next();
             }
+            Token::Comment(_) => (),
             _ => {
                 statements.push(get_or_err_direct!(it, parse_expr_or_stmt, "block"));
                 if let Some(&t) = it.peek() {

--- a/src/parser/block.rs
+++ b/src/parser/block.rs
@@ -11,7 +11,11 @@ pub fn parse_statements(it: &mut TPIterator) -> ParseResult<Vec<ASTNodePos>> {
     let mut statements: Vec<ASTNodePos> = Vec::new();
     while let Some(&t) = it.peek() {
         match &t.token {
-            Token::Dedent | Token::Stateful | Token::Stateless | Token::Type => break,
+            Token::Dedent => {
+                it.next();
+                break;
+            }
+            Token::Stateful | Token::Stateless | Token::Type => break,
             Token::NL => {
                 it.next();
             }
@@ -40,13 +44,11 @@ pub fn parse_block(it: &mut TPIterator) -> ParseResult {
     check_next_is!(it, Token::Indent);
 
     let statements: Vec<ASTNodePos> = get_or_err_direct!(it, parse_statements, "block");
-    if it.peek().is_some() {
-        check_next_is!(it, Token::Dedent);
-    }
 
     let (en_line, en_pos) = match statements.last() {
         Some(stmt) => (stmt.en_line, stmt.en_pos),
         None => (st_line, st_pos)
     };
+
     Ok(ASTNodePos { st_line, st_pos, en_line, en_pos, node: ASTNode::Block { statements } })
 }

--- a/src/parser/block.rs
+++ b/src/parser/block.rs
@@ -10,12 +10,17 @@ use crate::parser::TPIterator;
 pub fn parse_statements(it: &mut TPIterator) -> ParseResult<Vec<ASTNodePos>> {
     let mut statements: Vec<ASTNodePos> = Vec::new();
     while let Some(&t) = it.peek() {
-        match t.token {
+        match &t.token {
             Token::Dedent | Token::Stateful | Token::Stateless | Token::Type => break,
             Token::NL => {
                 it.next();
             }
-            Token::Comment(_) => (),
+            Token::Comment(comment) => {
+                let node = ASTNode::Comment { comment: comment.clone() };
+                let node_pos = ASTNodePos { st_line: 0, st_pos: 0, en_line: 0, en_pos: 0, node };
+                statements.push(node_pos);
+                it.next();
+            }
             _ => {
                 statements.push(get_or_err_direct!(it, parse_expr_or_stmt, "block"));
                 if let Some(&t) = it.peek() {

--- a/src/parser/block.rs
+++ b/src/parser/block.rs
@@ -21,7 +21,13 @@ pub fn parse_statements(it: &mut TPIterator) -> ParseResult<Vec<ASTNodePos>> {
             }
             Token::Comment(comment) => {
                 let node = ASTNode::Comment { comment: comment.clone() };
-                let node_pos = ASTNodePos { st_line: 0, st_pos: 0, en_line: 0, en_pos: 0, node };
+                let node_pos = ASTNodePos {
+                    st_line: t.line,
+                    st_pos: t.pos,
+                    en_line: t.line,
+                    en_pos: t.pos + comment.len() as i32,
+                    node
+                };
                 statements.push(node_pos);
                 it.next();
             }

--- a/src/parser/control_flow_expr.rs
+++ b/src/parser/control_flow_expr.rs
@@ -40,14 +40,6 @@ fn parse_if(it: &mut TPIterator) -> ParseResult {
     check_next_is!(it, Token::Then);
     let then: Box<ASTNodePos> = get_or_err!(it, parse_expr_or_stmt, "if then branch");
 
-    while let Some(&t) = it.peek() {
-        if t.token == Token::NL {
-            it.next();
-        } else {
-            break;
-        }
-    }
-
     let _else = if let Some(&&TokenPos { token: Token::Else, .. }) = it.peek() {
         it.next();
         Some(get_or_err!(it, parse_expr_or_stmt, "if else branch"))

--- a/src/parser/control_flow_expr.rs
+++ b/src/parser/control_flow_expr.rs
@@ -40,6 +40,14 @@ fn parse_if(it: &mut TPIterator) -> ParseResult {
     check_next_is!(it, Token::Then);
     let then: Box<ASTNodePos> = get_or_err!(it, parse_expr_or_stmt, "if then branch");
 
+    while let Some(&t) = it.peek() {
+        if t.token == Token::NL {
+            it.next();
+        } else {
+            break;
+        }
+    }
+
     let _else = if let Some(&&TokenPos { token: Token::Else, .. }) = it.peek() {
         it.next();
         Some(get_or_err!(it, parse_expr_or_stmt, "if else branch"))

--- a/tests/lexer/lexer.rs
+++ b/tests/lexer/lexer.rs
@@ -60,7 +60,6 @@ fn lex_if() {
         TokenPos { line: 2, pos: 5, token: Token::Id(String::from("b")) },
         TokenPos { line: 2, pos: 6, token: Token::NL },
         TokenPos { line: 3, pos: 1, token: Token::Dedent },
-        TokenPos { line: 3, pos: 1, token: Token::NL },
         TokenPos { line: 3, pos: 1, token: Token::Else },
         TokenPos { line: 3, pos: 5, token: Token::NL },
         TokenPos { line: 4, pos: 5, token: Token::Indent },

--- a/tests/lexer/lexer.rs
+++ b/tests/lexer/lexer.rs
@@ -56,20 +56,21 @@ fn lex_if() {
         TokenPos { line: 1, pos: 4, token: Token::Id(String::from("a")) },
         TokenPos { line: 1, pos: 6, token: Token::Then },
         TokenPos { line: 1, pos: 10, token: Token::NL },
-        TokenPos { line: 2, pos: 1, token: Token::Indent },
+        TokenPos { line: 2, pos: 5, token: Token::Indent },
         TokenPos { line: 2, pos: 5, token: Token::Id(String::from("b")) },
         TokenPos { line: 2, pos: 6, token: Token::NL },
         TokenPos { line: 3, pos: 1, token: Token::Dedent },
+        TokenPos { line: 3, pos: 1, token: Token::NL },
         TokenPos { line: 3, pos: 1, token: Token::Else },
         TokenPos { line: 3, pos: 5, token: Token::NL },
-        TokenPos { line: 4, pos: 1, token: Token::Indent },
+        TokenPos { line: 4, pos: 5, token: Token::Indent },
         TokenPos { line: 4, pos: 5, token: Token::Id(String::from("c")) }
     ]);
 }
 
 #[test]
 fn numbers_and_strings() {
-    let source = String::from("1 2.0 3e10 5e 2 \"hello\" True False i");
+    let source = String::from("1 2.0 3E10 5E 2 \"hello\" True False i");
     let tokens = tokenize(&source).unwrap();
     assert_eq!(tokens, vec![
         TokenPos { line: 1, pos: 1, token: Token::Int(String::from("1")) },

--- a/tests/output/syntax.rs
+++ b/tests/output/syntax.rs
@@ -1,6 +1,9 @@
 use crate::common::*;
 use crate::output::common::PYTHON;
 use mamba::command::mamba_to_python_direct;
+use mamba::lexer::tokenize;
+use std::fs::OpenOptions;
+use std::io::Read;
 use std::path::Path;
 use std::process::Command;
 
@@ -17,7 +20,6 @@ fn output_tuple_valid_syntax() {
 }
 
 #[test]
-#[ignore]
 fn output_class_valid_syntax() {
     let source = valid_resource_path(&["class"], "class.mamba");
     let path = mamba_to_python_direct(Path::new(&source)).unwrap();
@@ -26,5 +28,5 @@ fn output_class_valid_syntax() {
     if cmd.status.code().unwrap() != 0 {
         panic!("{}", String::from_utf8(cmd.stderr).unwrap());
     }
-    //    check_valid_resource_exists_and_delete(&["class"], "class.py");
+    check_valid_resource_exists_and_delete(&["class"], "class.py");
 }

--- a/tests/output/syntax.rs
+++ b/tests/output/syntax.rs
@@ -1,9 +1,6 @@
 use crate::common::*;
 use crate::output::common::PYTHON;
 use mamba::command::mamba_to_python_direct;
-use mamba::lexer::tokenize;
-use std::fs::OpenOptions;
-use std::io::Read;
 use std::path::Path;
 use std::process::Command;
 

--- a/tests/output/syntax.rs
+++ b/tests/output/syntax.rs
@@ -17,6 +17,7 @@ fn output_tuple_valid_syntax() {
 }
 
 #[test]
+#[ignore]
 fn output_class_valid_syntax() {
     let source = valid_resource_path(&["class"], "class.mamba");
     let path = mamba_to_python_direct(Path::new(&source)).unwrap();

--- a/tests/parser/valid/control_flow.rs
+++ b/tests/parser/valid/control_flow.rs
@@ -59,7 +59,7 @@ fn foreach_tuple_statement_verify() {
 #[test]
 fn if_stmt() {
     let source = valid_resource_content(&["control_flow"], "if.mamba");
-    parse(&tokenize(&source).unwrap()).unwrap();
+    assert!(parse(&tokenize(&source).unwrap()).is_ok());
 }
 
 #[test]

--- a/tests/parser/valid/error.rs
+++ b/tests/parser/valid/error.rs
@@ -5,11 +5,11 @@ use mamba::parser::parse;
 #[test]
 fn handle_verify() {
     let source = valid_resource_content(&["error"], "handle.mamba");
-    parse(&tokenize(&source).unwrap());
+    assert!(parse(&tokenize(&source).unwrap()).is_ok());
 }
 
 #[test]
 fn raises_verify() {
     let source = valid_resource_content(&["error"], "raise.mamba");
-    parse(&tokenize(&source).unwrap());
+    assert!(parse(&tokenize(&source).unwrap()).is_ok());
 }

--- a/tests/parser/valid/operation.rs
+++ b/tests/parser/valid/operation.rs
@@ -101,7 +101,7 @@ fn power_verify() {
 
 #[test]
 fn mod_verify() {
-    let source = String::from("chopin mod 3e10");
+    let source = String::from("chopin mod 3E10");
     let ast_tree = parse_direct(&tokenize(&source).unwrap()).unwrap();
 
     let (left, right) = verify_is_operation!(Mod, ast_tree);

--- a/tests/resources/valid/control_flow/if.mamba
+++ b/tests/resources/valid/control_flow/if.mamba
@@ -12,6 +12,10 @@ if cond, cond2 then
         bbb
     else
         ccc
+
+    if ggg then
+        hhh
+    else iii
 else
     other
     print "hello \"world\""

--- a/tests/resources/valid/control_flow/if.mamba
+++ b/tests/resources/valid/control_flow/if.mamba
@@ -12,7 +12,7 @@ if cond, cond2 then
         bbb
     else
         ccc
-else # this is the else
+else
     other
     print "hello \"world\""
 
@@ -20,5 +20,5 @@ else # this is the else
         bbb
     else
         ccc
-# if we don't have this empty line here the above is still not newline terminated!
+
 if c then d <- 4 else asdf


### PR DESCRIPTION
### Relevant issues
#25 

### Summary
Rewrite lexer to make it more readable.
Add comments to language, so that these are preserved when converting to Python.

Indentation is now 4 spaces. Tabs are no longer recognized as valid characters.
Furthermore, a bug has been fixed with regards to indentation. 
When we wish to exit an `if`, it no longer needs to be immediately be followed by a dedented line. We can have empty lines in between now.
This was caused by the complex application logic of the lexer, was has been simplified somewhat.

E-numbers now have to use `E`, and no longer allow `e`, reducing inconsistency.

### Added Tests
...

### Additional Context
...
