### PR TITLE
`id : type` is now an expression 

### DIFF
--- a/src/parser/_type.rs
+++ b/src/parser/_type.rs
@@ -42,6 +42,15 @@ pub fn parse_id_maybe_call(it: &mut TPIterator) -> ParseResult {
         Some(TokenPos { token: Token::Point, .. })
         | Some(TokenPos { token: Token::LRBrack, .. }) => parse_call(id, it),
         Some(&tp) if is_start_expression_exclude_unary(tp) => parse_call(id, it),
+        Some(TokenPos { token: Token::DoublePoint, .. }) => {
+            it.next();
+            let _type = get_or_err!(it, parse_type, "type");
+            let (st_line, st_pos) = (id.st_line, id.st_pos);
+            let (en_line, en_pos) = (_type.en_line, _type.en_pos);
+            let node =
+                ASTNode::IdType { id: Box::from(id), mutable: false, _type: Some(_type) };
+            Ok(ASTNodePos { st_line, st_pos, en_line, en_pos, node })
+        }
         _ => Ok(id)
     }
 }

--- a/src/parser/control_flow_expr.rs
+++ b/src/parser/control_flow_expr.rs
@@ -49,7 +49,6 @@ fn parse_if(it: &mut TPIterator) -> ParseResult {
 
     let (en_line, en_pos) = (then.en_line, then.en_pos);
     let node = ASTNode::IfElse { cond, then, _else };
-
     Ok(ASTNodePos { st_line, st_pos, en_line, en_pos, node })
 }
 
@@ -67,7 +66,6 @@ fn parse_match(it: &mut TPIterator) -> ParseResult {
         (Some(cond), _) => (cond.en_line, cond.en_pos),
         _ => (st_line, st_pos)
     };
-
     Ok(ASTNodePos { st_line, st_pos, en_line, en_pos, node: ASTNode::Match { cond, cases } })
 }
 
@@ -84,7 +82,7 @@ pub fn parse_match_cases(it: &mut TPIterator) -> ParseResult<Vec<ASTNodePos>> {
                 it.next();
                 break;
             }
-            _ => cases.push(get_or_err_direct!(it, parse_match_case, "when case"))
+            _ => cases.push(get_or_err_direct!(it, parse_match_case, "match case"))
         }
     }
 
@@ -96,13 +94,9 @@ fn parse_match_case(it: &mut TPIterator) -> ParseResult {
 
     let cond: Box<ASTNodePos> = get_or_err!(it, parse_expression, "match case");
     check_next_is!(it, Token::BTo);
-    let expr_or_stmt: Box<ASTNodePos> = get_or_err!(it, parse_expr_or_stmt, "then");
+    let body: Box<ASTNodePos> = get_or_err!(it, parse_expr_or_stmt, "then");
 
-    Ok(ASTNodePos {
-        st_line,
-        st_pos,
-        en_line: expr_or_stmt.en_line,
-        en_pos: expr_or_stmt.en_pos,
-        node: ASTNode::Case { cond, body: expr_or_stmt }
-    })
+    let (en_line, en_pos) = (body.en_line, body.en_pos);
+    let node = ASTNode::Case { cond, body };
+    Ok(ASTNodePos { st_line, st_pos, en_line, en_pos, node })
 }

--- a/tests/resources/valid/error/handle.mamba
+++ b/tests/resources/valid/error/handle.mamba
@@ -1,2 +1,3 @@
 def a <- f(10) handle
     err => print "Something went wrong"
+    err2: MyErr => print "Something else went wrong"


### PR DESCRIPTION
### Relevant issues
...

### Summary
This allows us to use `id : types` in matches for instance. Therefore, `id : type` is now an expression.
However, another bug was uncovered. 
If we nest matches, the dedent after the nested is consumed, meaning that the expression of the next match arm comes immediately after (without a dedent in between), meaning that is is interpreted as a call (left is match, right is expression of next arm).

One fix to this was always following dedents by a newline. 
However, this resulted in the issue where the parser had no way of detecting for instance an else in an if statement after a block, as this was hiding behind a newline, as opposed to immediately following a dedent.
Therefore, it might be time to reconsider the grammar and how if statements operate.

### Added Tests
...

### Additional Context
...