### PR TITLE
Add step to ranges

### DIFF
--- a/src/core/construct.rs
+++ b/src/core/construct.rs
@@ -193,6 +193,11 @@ pub enum Core {
         collection: Box<Core>,
         body:       Box<Core>
     },
+    Range {
+        from: Box<Core>,
+        to:   Box<Core>,
+        step: Box<Core>
+    },
     If {
         cond: Vec<Core>,
         then: Box<Core>

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -182,6 +182,12 @@ fn to_py(core: &Core, ind: usize) -> String {
             to_py(collection.as_ref(), ind),
             to_py(body.as_ref(), ind + 1)
         ),
+        Core::Range { from, to, step } => format!(
+            "range({}, {}, {})",
+            to_py(from.as_ref(), ind),
+            to_py(to.as_ref(), ind),
+            to_py(step.as_ref(), ind),
+        ),
         Core::If { cond, then } =>
             format!("if {}: {}", comma_delimited(cond.as_ref(), ind), to_py(then.as_ref(), ind + 1)),
         Core::IfElse { cond, then, _else } => format!(

--- a/src/lexer/mod.rs
+++ b/src/lexer/mod.rs
@@ -233,6 +233,7 @@ fn as_op_or_id(string: String) -> Token {
         "sqrt" => Token::Sqrt,
         "while" => Token::While,
         "for" => Token::For,
+        "step" => Token::Step,
 
         "if" => Token::If,
         "else" => Token::Else,

--- a/src/lexer/token.rs
+++ b/src/lexer/token.rs
@@ -85,7 +85,7 @@ pub enum Token {
 
     While,
     For,
-    Map,
+    Step,
     In,
     If,
     Then,
@@ -184,7 +184,7 @@ impl fmt::Display for Token {
 
             Token::While => String::from("while"),
             Token::For => String::from("for"),
-            Token::Map => String::from("map"),
+            Token::Step => String::from("step"),
             Token::In => String::from("in"),
             Token::If => String::from("if"),
             Token::Then => String::from("then"),

--- a/src/parser/ast.rs
+++ b/src/parser/ast.rs
@@ -159,12 +159,10 @@ pub enum ASTNode {
     },
 
     Range {
-        from: Box<ASTNodePos>,
-        to:   Box<ASTNodePos>
-    },
-    RangeIncl {
-        from: Box<ASTNodePos>,
-        to:   Box<ASTNodePos>
+        from:      Box<ASTNodePos>,
+        to:        Box<ASTNodePos>,
+        inclusive: bool,
+        step:      Option<Box<ASTNodePos>>
     },
 
     Block {
@@ -291,6 +289,9 @@ pub enum ASTNode {
         expr:       Vec<ASTNodePos>,
         collection: Box<ASTNodePos>,
         body:       Box<ASTNodePos>
+    },
+    Step {
+        amount: Box<ASTNodePos>
     },
     While {
         cond: Vec<ASTNodePos>,

--- a/src/parser/expression.rs
+++ b/src/parser/expression.rs
@@ -71,17 +71,29 @@ fn parse_post_expr(pre: ASTNodePos, it: &mut TPIterator) -> ParseResult {
         Some(TokenPos { token: Token::Range, .. }) => {
             it.next();
             let to: Box<ASTNodePos> = get_or_err!(it, parse_expression, "..");
+            let step = if let Some(&TokenPos { token: Token::Step, .. }) = it.peek() {
+                it.next();
+                Some(get_or_err!(it, parse_expression, "step"))
+            } else {
+                None
+            };
 
             let (en_line, en_pos) = (to.en_line, to.en_pos);
-            let node = ASTNode::Range { from: Box::from(pre), to };
+            let node = ASTNode::Range { from: Box::from(pre), to, inclusive: false, step };
             Ok(ASTNodePos { st_line, st_pos, en_line, en_pos, node })
         }
         Some(TokenPos { token: Token::RangeIncl, .. }) => {
             it.next();
             let to: Box<ASTNodePos> = get_or_err!(it, parse_expression, "..=");
+            let step = if let Some(&TokenPos { token: Token::Step, .. }) = it.peek() {
+                it.next();
+                Some(get_or_err!(it, parse_expression, "step"))
+            } else {
+                None
+            };
 
             let (en_line, en_pos) = (to.en_line, to.en_pos);
-            let node = ASTNode::RangeIncl { from: Box::from(pre), to };
+            let node = ASTNode::Range { from: Box::from(pre), to, inclusive: true, step };
             Ok(ASTNodePos { st_line, st_pos, en_line, en_pos, node })
         }
 

--- a/tests/desugar/control_flow.rs
+++ b/tests/desugar/control_flow.rs
@@ -95,7 +95,7 @@ fn for_verify() {
 
     let (core_exprs, core_collection, core_body) = match desugar(&for_stmt) {
         Core::For { exprs, collection, body } => (exprs, collection, body),
-        other => panic!("Expected reassign but was {:?}", other)
+        other => panic!("Expected for but was {:?}", other)
     };
 
     assert_eq!(core_exprs.len(), 2);
@@ -104,3 +104,6 @@ fn for_verify() {
     assert_eq!(*core_collection, Core::Id { lit: String::from("collection") });
     assert_eq!(*core_body, Core::Id { lit: String::from("body") });
 }
+
+#[test]
+fn range_verify() {}

--- a/tests/desugar/control_flow.rs
+++ b/tests/desugar/control_flow.rs
@@ -106,4 +106,53 @@ fn for_verify() {
 }
 
 #[test]
-fn range_verify() {}
+fn range_verify() {
+    let from = to_pos!(ASTNode::Id { lit: String::from("a") });
+    let to = to_pos!(ASTNode::Id { lit: String::from("b") });
+    let range = to_pos!(ASTNode::Range { from, to, inclusive: false, step: None });
+
+    let (from, to, step) = match desugar(&range) {
+        Core::Range { from, to, step } => (from, to, step),
+        other => panic!("Expected range but was {:?}", other)
+    };
+
+    assert_eq!(*from, Core::Id { lit: String::from("a") });
+    assert_eq!(*to, Core::Id { lit: String::from("b") });
+    assert_eq!(*step, Core::Int { int: String::from("1") });
+}
+
+#[test]
+fn range_incl_verify() {
+    let from = to_pos!(ASTNode::Id { lit: String::from("a") });
+    let to = to_pos!(ASTNode::Id { lit: String::from("b") });
+    let range = to_pos!(ASTNode::Range { from, to, inclusive: true, step: None });
+
+    let (from, to, step) = match desugar(&range) {
+        Core::Range { from, to, step } => (from, to, step),
+        other => panic!("Expected range but was {:?}", other)
+    };
+
+    assert_eq!(*from, Core::Id { lit: String::from("a") });
+    assert_eq!(*to, Core::Add {
+        left:  Box::from(Core::Id { lit: String::from("b") }),
+        right: Box::from(Core::Int { int: String::from("1") })
+    });
+    assert_eq!(*step, Core::Int { int: String::from("1") });
+}
+
+#[test]
+fn range_step_verify() {
+    let from = to_pos!(ASTNode::Id { lit: String::from("a") });
+    let to = to_pos!(ASTNode::Id { lit: String::from("b") });
+    let step = Some(to_pos!(ASTNode::Id { lit: String::from("c") }));
+    let range = to_pos!(ASTNode::Range { from, to, inclusive: false, step });
+
+    let (from, to, step) = match desugar(&range) {
+        Core::Range { from, to, step } => (from, to, step),
+        other => panic!("Expected range but was {:?}", other)
+    };
+
+    assert_eq!(*from, Core::Id { lit: String::from("a") });
+    assert_eq!(*to, Core::Id { lit: String::from("b") });
+    assert_eq!(*step, Core::Id { lit: String::from("c") });
+}

--- a/tests/parser/valid/control_flow.rs
+++ b/tests/parser/valid/control_flow.rs
@@ -57,8 +57,8 @@ fn for_tuple_statement_verify() {
 }
 
 #[test]
-fn foreach_range_step_verify() {
-    let source = String::from("foreach a in c .. d step e do f");
+fn for_range_step_verify() {
+    let source = String::from("for a in c .. d step e do f");
     let ast_tree = parse_direct(&tokenize(&source).unwrap()).unwrap();
 
     let _statements;
@@ -86,8 +86,8 @@ fn foreach_range_step_verify() {
 }
 
 #[test]
-fn foreach_range_incl_verify() {
-    let source = String::from("foreach a in c ..= d do f");
+fn for_range_incl_verify() {
+    let source = String::from("for a in c ..= d do f");
     let ast_tree = parse_direct(&tokenize(&source).unwrap()).unwrap();
 
     let _statements;

--- a/tests/parser/valid/control_flow.rs
+++ b/tests/parser/valid/control_flow.rs
@@ -57,6 +57,64 @@ fn for_tuple_statement_verify() {
 }
 
 #[test]
+fn foreach_range_step_verify() {
+    let source = String::from("foreach a in c .. d step e do f");
+    let ast_tree = parse_direct(&tokenize(&source).unwrap()).unwrap();
+
+    let _statements;
+    let (expr, from, to, step, inclusive, body) = match ast_tree.node {
+        ASTNode::Script { statements, .. } => {
+            _statements = statements;
+            match &_statements.first().expect("script empty.").node {
+                ASTNode::For { expr, collection, body } => match &collection.node {
+                    ASTNode::Range { from, to, inclusive, step } =>
+                        (expr, from, to, step.clone(), inclusive, body),
+                    _ => panic!("Expected range")
+                },
+                _ => panic!("first element script was not foreach.")
+            }
+        }
+        _ => panic!("ast_tree was not script.")
+    };
+
+    assert_eq!(expr[0].node, ASTNode::Id { lit: String::from("a") });
+    assert_eq!(from.node, ASTNode::Id { lit: String::from("c") });
+    assert_eq!(to.node, ASTNode::Id { lit: String::from("d") });
+    assert!(!inclusive);
+    assert_eq!(step.unwrap().node, ASTNode::Id { lit: String::from("e") });
+    assert_eq!(body.node, ASTNode::Id { lit: String::from("f") });
+}
+
+#[test]
+fn foreach_range_incl_verify() {
+    let source = String::from("foreach a in c ..= d do f");
+    let ast_tree = parse_direct(&tokenize(&source).unwrap()).unwrap();
+
+    let _statements;
+    let (expr, from, to, step, inclusive, body) = match ast_tree.node {
+        ASTNode::Script { statements, .. } => {
+            _statements = statements;
+            match &_statements.first().expect("script empty.").node {
+                ASTNode::For { expr, collection, body } => match &collection.node {
+                    ASTNode::Range { from, to, inclusive, step } =>
+                        (expr, from, to, step.clone(), inclusive, body),
+                    _ => panic!("Expected range")
+                },
+                _ => panic!("first element script was not foreach.")
+            }
+        }
+        _ => panic!("ast_tree was not script.")
+    };
+
+    assert_eq!(expr[0].node, ASTNode::Id { lit: String::from("a") });
+    assert_eq!(from.node, ASTNode::Id { lit: String::from("c") });
+    assert_eq!(to.node, ASTNode::Id { lit: String::from("d") });
+    assert!(inclusive);
+    assert!(step.is_none());
+    assert_eq!(body.node, ASTNode::Id { lit: String::from("f") });
+}
+
+#[test]
 fn if_stmt() {
     let source = valid_resource_content(&["control_flow"], "if.mamba");
     assert!(parse(&tokenize(&source).unwrap()).is_ok());

--- a/tests/parser/valid/expression_and_statement.rs
+++ b/tests/parser/valid/expression_and_statement.rs
@@ -39,10 +39,11 @@ fn range_verify() {
     let source = String::from("hello .. world");
     let ast_tree = parse_direct(&tokenize(&source).unwrap()).unwrap();
 
-    let (from, to) = match ast_tree.node {
+    let (from, to, inclusive, step) = match ast_tree.node {
         ASTNode::Script { statements, .. } =>
             match &statements.first().expect("script empty.").node {
-                ASTNode::Range { from, to } => (from.clone(), to.clone()),
+                ASTNode::Range { from, to, inclusive, step } =>
+                    (from.clone(), to.clone(), inclusive.clone(), step.clone()),
                 _ => panic!("first element script was not range.")
             },
         _ => panic!("ast_tree was not script.")
@@ -50,6 +51,29 @@ fn range_verify() {
 
     assert_eq!(from.node, ASTNode::Id { lit: String::from("hello") });
     assert_eq!(to.node, ASTNode::Id { lit: String::from("world") });
+    assert!(!inclusive);
+    assert_eq!(step, None);
+}
+
+#[test]
+fn range_step_verify() {
+    let source = String::from("hello .. world step 2");
+    let ast_tree = parse_direct(&tokenize(&source).unwrap()).unwrap();
+
+    let (from, to, inclusive, step) = match ast_tree.node {
+        ASTNode::Script { statements, .. } =>
+            match &statements.first().expect("script empty.").node {
+                ASTNode::Range { from, to, inclusive, step } =>
+                    (from.clone(), to.clone(), inclusive.clone(), step.clone()),
+                _ => panic!("first element script was not range.")
+            },
+        _ => panic!("ast_tree was not script.")
+    };
+
+    assert_eq!(from.node, ASTNode::Id { lit: String::from("hello") });
+    assert_eq!(to.node, ASTNode::Id { lit: String::from("world") });
+    assert!(!inclusive);
+    assert_eq!(step.unwrap().node, ASTNode::Int { lit: String::from("2") });
 }
 
 #[test]
@@ -57,10 +81,11 @@ fn range_incl_verify() {
     let source = String::from("foo ..= bar");
     let ast_tree = parse_direct(&tokenize(&source).unwrap()).unwrap();
 
-    let (from, to) = match ast_tree.node {
+    let (from, to, inclusive, step) = match ast_tree.node {
         ASTNode::Script { statements, .. } =>
             match &statements.first().expect("script empty.").node {
-                ASTNode::RangeIncl { from, to } => (from.clone(), to.clone()),
+                ASTNode::Range { from, to, inclusive, step } =>
+                    (from.clone(), to.clone(), inclusive.clone(), step.clone()),
                 _ => panic!("first element script was not range inclusive.")
             },
         _ => panic!("ast_tree was not script.")
@@ -68,6 +93,8 @@ fn range_incl_verify() {
 
     assert_eq!(from.node, ASTNode::Id { lit: String::from("foo") });
     assert_eq!(to.node, ASTNode::Id { lit: String::from("bar") });
+    assert!(inclusive);
+    assert_eq!(step, None);
 }
 
 #[test]

--- a/tests/resources/valid/control_flow/for_statements.mamba
+++ b/tests/resources/valid/control_flow/for_statements.mamba
@@ -17,8 +17,8 @@ for i in ty .. 34 do
 for i in ty2 ..= 345 do
     print asdfg
 
-foreach i in a .. b step 1 do
+for i in a .. b step 1 do
     print "hello"
 
-foreach i in a ..= c step 20 do
+for i in a ..= c step 20 do
     print "world"

--- a/tests/resources/valid/control_flow/for_statements.mamba
+++ b/tests/resources/valid/control_flow/for_statements.mamba
@@ -16,3 +16,9 @@ for i in ty .. 34 do
 
 for i in ty2 ..= 345 do
     print asdfg
+
+foreach i in a .. b step 1 do
+    print "hello"
+
+foreach i in a ..= c step 20 do
+    print "world"


### PR DESCRIPTION
### Relevant issues
#89 

### Summary
Update range syntax so we can have steps in ranges, akin to Kotlin.
Also change range structure to whether it is inclusive is a boolean stored within `ASTNode::Range`.

### Added Tests
Tests for the new types or ranges:
- When parsing them
- When desugaring them
