### PR TITLE
Change stateless to pure

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,8 @@ In short, Mamba is like Python, but with a few key features:
 -   Strict typing rules, but with type inference so it doesn't get in the way too much, and type refinement features.
 -   Null safety features.
 -   More explicit error handling.
--   Clear distinction between state and mutability, and immutability and pureness.
+-   Clear distinction between state and mutability.
+-   Pure, or injective, functions.
 
 This is a transpiler, written in [Rust](https://www.rust-lang.org/), which converts Mamba source code to Python source files.
 Mamba code should therefore, in theory, be interoperable with Python code.

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ def factorial(x: Int) => match x with
 def num <- input "Compute factorial: "
 if num.is_digit then
     def result <- factorial int num
-    print "Factorial [num] is: [result]."
+    print "Factorial {num} is: {result}."
 else
     print "Input was not an integer."
 ```
@@ -97,7 +97,7 @@ def my_server <- MyServer(some_ip)
 http_server connect
 if my_server.connected then http_server send "Hello World!"
 
-print "last message sent before disconnect: \"[my_server.last_sent]\"."
+print "last message sent before disconnect: \"{my_server.last_sent}\"."
 my_server.disconnect
 ```
 
@@ -158,13 +158,13 @@ if my_server isa ConnectedMyServer then
     # http_server is a Connected Server if the above is true
     my_server.send "Hello World!"
 
-print "last message sent before disconnect: \"[my_server.last_sent]\"."
+print "last message sent before disconnect: \"{my_server.last_sent}\"."
 if my_server isa ConnectedMyServer then my_server.disconnect
 ```
 
 Type refinement also allows us to specify the domain and co-domain of a function, say, one that only takes and returns positive integers:
 ```mamba
-type PositiveInt isa Int where self >= 0 else Err("Expected positive Int but was [self].")
+type PositiveInt isa Int where self >= 0 else Err("Expected positive Int but was {self}.")
 
 def factorial (x: PositiveInt) => match x with
     0 => 1
@@ -245,7 +245,7 @@ def my_server <- MyServer(some_ip)
 def message <- "Hello World!"
 my_server.send message handle
     err: ServerErr => 
-        print "Error while sending message: \"[message]\": [err]"
+        print "Error while sending message: \"{message}\": {err}"
         # We must now return to halt execution
         return
 
@@ -263,11 +263,11 @@ This is shown below:
 ```mamba
 def a <- function_may_throw_err() handle
     err : MyErr => 
-        print "We have a problem: [err.message]."
+        print "We have a problem: {err.message}."
         # we return, halting execution
         return
     err : MyOtherErr => 
-        print "We have another problem: [err.message]."
+        print "We have another problem: {err.message}."
         # or if we don't return, return a default value
         0
         

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ In short, Mamba is like Python, but with a few key features:
 -   Strict typing rules, but with type inference so it doesn't get in the way too much, and type refinement features.
 -   Null safety features.
 -   More explicit error handling.
--   Clear distinction between state and mutability.
+-   Clear distinction between mutability and immutability.
 -   Pure, or injective, functions.
 
 This is a transpiler, written in [Rust](https://www.rust-lang.org/), which converts Mamba source code to Python source files.
@@ -201,10 +201,10 @@ def taylor <- 7
 
 # the sinus function is injective, its output depends solely on the input
 def pure sin(x: Int) =>
-    def mut res <- x
+    def mut ans <- x
     for i in 1 ..= taylor step 2 do
-        res <- (x ^ (i + 2)) / (factorial (i + 2))
-    res
+        ans <- (x ^ (i + 2)) / (factorial (i + 2))
+    ans
 ```
 
 We can add `pure` to the top of a file, which ensures all functions in said file are pure.
@@ -212,6 +212,7 @@ This is useful when we want to write multiple pure functions.
 
 ```mamba
 pure
+
 def taylor <- 7
 
 def sin(x: Int): Real =>

--- a/README.md
+++ b/README.md
@@ -271,7 +271,7 @@ def a <- function_may_throw_err() handle
         # or if we don't return, return a default value
         0
         
-print ""
+print "a has value [a]."
 ```
 
 ## 👥 Contributing

--- a/src/lexer/mod.rs
+++ b/src/lexer/mod.rs
@@ -209,7 +209,7 @@ fn as_op_or_id(string: String) -> Token {
         "from" => Token::From,
         "type" => Token::Type,
         "class" => Token::Class,
-        "stateless" => Token::Stateless,
+        "pure" => Token::Pure,
         "as" => Token::As,
         "private" => Token::Private,
 

--- a/src/lexer/token.rs
+++ b/src/lexer/token.rs
@@ -12,7 +12,7 @@ pub enum Token {
     From,
     Type,
     Class,
-    Stateless,
+    Pure,
     IsA,
     IsNA,
     Private,
@@ -113,7 +113,7 @@ impl fmt::Display for Token {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", match self.clone() {
             Token::From => String::from("from"),
-            Token::Stateless => String::from("stateless"),
+            Token::Pure => String::from("pure"),
             Token::Type => String::from("type"),
             Token::Class => String::from("class"),
             Token::IsA => String::from("isa"),

--- a/src/parser/ast.rs
+++ b/src/parser/ast.rs
@@ -12,7 +12,7 @@ pub struct ASTNodePos {
 #[derive(PartialEq, Eq, Hash, Debug, Clone)]
 pub enum ASTNode {
     File {
-        stateless: bool,
+        pure:      bool,
         imports:   Vec<ASTNodePos>,
         modules:   Vec<ASTNodePos>,
         type_defs: Vec<ASTNodePos>
@@ -53,12 +53,12 @@ pub enum ASTNode {
         forward:       Vec<ASTNodePos>
     },
     FunDef {
-        stateless: bool,
-        id:        Box<ASTNodePos>,
-        fun_args:  Vec<ASTNodePos>,
-        ret_ty:    Option<Box<ASTNodePos>>,
-        raises:    Option<Vec<ASTNodePos>>,
-        body:      Option<Box<ASTNodePos>>
+        pure:     bool,
+        id:       Box<ASTNodePos>,
+        fun_args: Vec<ASTNodePos>,
+        ret_ty:   Option<Box<ASTNodePos>>,
+        raises:   Option<Vec<ASTNodePos>>,
+        body:     Option<Box<ASTNodePos>>
     },
 
     AnonFun {

--- a/src/parser/file.rs
+++ b/src/parser/file.rs
@@ -163,8 +163,8 @@ pub fn parse_file(it: &mut TPIterator) -> ParseResult {
     let mut modules = Vec::new();
     let mut type_defs = Vec::new();
 
-    let stateless = it.peek().is_some() && it.peek().unwrap().token == Token::Stateless;
-    if stateless {
+    let pure = it.peek().is_some() && it.peek().unwrap().token == Token::Pure;
+    if pure {
         it.next();
     }
 
@@ -191,7 +191,7 @@ pub fn parse_file(it: &mut TPIterator) -> ParseResult {
         }
     }
 
-    let node = ASTNode::File { stateless, imports, modules, type_defs };
+    let node = ASTNode::File { pure, imports, modules, type_defs };
     Ok(ASTNodePos { st_line: 0, st_pos: 0, en_line: 0, en_pos: 0, node })
 }
 

--- a/tests/desugar/definition.rs
+++ b/tests/desugar/definition.rs
@@ -183,9 +183,9 @@ fn tuple_def_none_verify() {
 #[test]
 fn fun_def_verify() {
     let definition = to_pos!(ASTNode::FunDef {
-        id:        to_pos!(ASTNode::Id { lit: String::from("fun") }),
-        stateless: false,
-        fun_args:  vec![
+        id:       to_pos!(ASTNode::Id { lit: String::from("fun") }),
+        pure:     false,
+        fun_args: vec![
             to_pos_unboxed!(ASTNode::FunArg {
                 vararg:        false,
                 id_maybe_type: to_pos!(ASTNode::Id { lit: String::from("arg1") }),
@@ -197,9 +197,9 @@ fn fun_def_verify() {
                 default:       None
             })
         ],
-        ret_ty:    None,
-        raises:    None,
-        body:      None
+        ret_ty:   None,
+        raises:   None,
+        body:     None
     });
     let def = to_pos!(ASTNode::Def { private: false, definition });
 
@@ -228,16 +228,16 @@ fn fun_def_verify() {
 #[test]
 fn fun_def_default_arg_verify() {
     let definition = to_pos!(ASTNode::FunDef {
-        id:        to_pos!(ASTNode::Id { lit: String::from("fun") }),
-        stateless: false,
-        fun_args:  vec![to_pos_unboxed!(ASTNode::FunArg {
+        id:       to_pos!(ASTNode::Id { lit: String::from("fun") }),
+        pure:     false,
+        fun_args: vec![to_pos_unboxed!(ASTNode::FunArg {
             vararg:        false,
             id_maybe_type: to_pos!(ASTNode::Id { lit: String::from("arg1") }),
             default:       Some(to_pos!(ASTNode::Str { lit: String::from("asdf") }))
         })],
-        ret_ty:    None,
-        raises:    None,
-        body:      None
+        ret_ty:   None,
+        raises:   None,
+        body:     None
     });
     let def = to_pos!(ASTNode::Def { private: false, definition });
 
@@ -261,15 +261,15 @@ fn fun_def_default_arg_verify() {
 #[test]
 fn fun_def_with_body_verify() {
     let definition = to_pos!(ASTNode::FunDef {
-        id:        to_pos!(ASTNode::Id { lit: String::from("fun") }),
-        stateless: false,
-        fun_args:  vec![
+        id:       to_pos!(ASTNode::Id { lit: String::from("fun") }),
+        pure:     false,
+        fun_args: vec![
             to_pos_unboxed!(ASTNode::Id { lit: String::from("arg1") }),
             to_pos_unboxed!(ASTNode::Id { lit: String::from("arg2") })
         ],
-        ret_ty:    None,
-        raises:    None,
-        body:      Some(to_pos!(ASTNode::Real { lit: String::from("2.4") }))
+        ret_ty:   None,
+        raises:   None,
+        body:     Some(to_pos!(ASTNode::Real { lit: String::from("2.4") }))
     });
     let def = to_pos!(ASTNode::Def { private: false, definition });
 
@@ -325,12 +325,12 @@ fn top_level_var_def_panic_verify() {
 #[test]
 fn top_level_fun_def_panic_verify() {
     let var_def = to_pos!(ASTNode::FunDef {
-        id:        Box::from(to_pos!(ASTNode::Pass)),
-        stateless: false,
-        fun_args:  vec![],
-        ret_ty:    None,
-        raises:    None,
-        body:      None
+        id:       Box::from(to_pos!(ASTNode::Pass)),
+        pure:     false,
+        fun_args: vec![],
+        ret_ty:   None,
+        raises:   None,
+        body:     None
     });
 
     panic::set_hook(Box::new(|_info| {}));

--- a/tests/parser/valid/definition.rs
+++ b/tests/parser/valid/definition.rs
@@ -13,13 +13,13 @@ macro_rules! unwrap_func_definition {
             _ => panic!("ast_tree was not script.")
         };
 
-        let (id, stateless, fun_args, ret_ty, raises, body) = match definition.node {
-            ASTNode::FunDef { id, stateless, fun_args, ret_ty, raises, body } =>
-                (id, stateless, fun_args, ret_ty, raises, body),
+        let (id, pure, fun_args, ret_ty, raises, body) = match definition.node {
+            ASTNode::FunDef { id, pure, fun_args, ret_ty, raises, body } =>
+                (id, pure, fun_args, ret_ty, raises, body),
             other => panic!("Expected variabledef but was {:?}.", other)
         };
 
-        (private, stateless, id, fun_args, ret_ty, raises, body)
+        (private, pure, id, fun_args, ret_ty, raises, body)
     }};
 }
 
@@ -202,11 +202,10 @@ fn forward_definition_verify() {
 fn function_definition_verify() {
     let source = String::from("def f(b: Something, vararg c) => d");
     let ast_tree = parse_direct(&tokenize(&source).unwrap()).unwrap();
-    let (private, stateless, id, fun_args, ret_ty, raises, body) =
-        unwrap_func_definition!(ast_tree);
+    let (private, pure, id, fun_args, ret_ty, raises, body) = unwrap_func_definition!(ast_tree);
 
     assert_eq!(private, false);
-    assert!(!stateless);
+    assert!(!pure);
     assert_eq!(id.node, ASTNode::Id { lit: String::from("f") });
     assert_eq!(fun_args.len(), 2);
     assert_eq!(ret_ty, None);
@@ -255,10 +254,10 @@ fn function_definition_verify() {
 fn function_no_args_definition_verify() {
     let source = String::from("def f() => d");
     let ast_tree = parse_direct(&tokenize(&source).unwrap()).unwrap();
-    let (private, stateless, id, fun_args, ret_ty, _, body) = unwrap_func_definition!(ast_tree);
+    let (private, pure, id, fun_args, ret_ty, _, body) = unwrap_func_definition!(ast_tree);
 
     assert_eq!(private, false);
-    assert!(!stateless);
+    assert!(!pure);
     assert_eq!(id.node, ASTNode::Id { lit: String::from("f") });
     assert_eq!(fun_args.len(), 0);
     assert_eq!(ret_ty, None);
@@ -270,13 +269,13 @@ fn function_no_args_definition_verify() {
 }
 
 #[test]
-fn function_stateless_definition_verify() {
-    let source = String::from("def stateless f() => d");
+fn function_pure_definition_verify() {
+    let source = String::from("def pure f() => d");
     let ast_tree = parse_direct(&tokenize(&source).unwrap()).unwrap();
-    let (private, stateless, id, fun_args, ret_ty, _, body) = unwrap_func_definition!(ast_tree);
+    let (private, pure, id, fun_args, ret_ty, _, body) = unwrap_func_definition!(ast_tree);
 
     assert_eq!(private, false);
-    assert!(stateless);
+    assert!(pure);
     assert_eq!(id.node, ASTNode::Id { lit: String::from("f") });
     assert_eq!(fun_args.len(), 0);
     assert_eq!(ret_ty, None);
@@ -291,10 +290,10 @@ fn function_stateless_definition_verify() {
 fn function_definition_with_literal_verify() {
     let source = String::from("def f(x, vararg b: Something) => d");
     let ast_tree = parse_direct(&tokenize(&source).unwrap()).unwrap();
-    let (private, stateless, id, fun_args, ret_ty, _, body) = unwrap_func_definition!(ast_tree);
+    let (private, pure, id, fun_args, ret_ty, _, body) = unwrap_func_definition!(ast_tree);
 
     assert_eq!(private, false);
-    assert!(!stateless);
+    assert!(!pure);
     assert_eq!(id.node, ASTNode::Id { lit: String::from("f") });
     assert_eq!(fun_args.len(), 2);
     assert_eq!(ret_ty, None);

--- a/tests/parser/valid/expression_and_statement.rs
+++ b/tests/parser/valid/expression_and_statement.rs
@@ -22,16 +22,16 @@ fn quest_or_verify() {
 }
 
 #[test]
-fn stateless_file() {
-    let source = String::from("stateless");
+fn pure_file() {
+    let source = String::from("pure");
     let ast_tree = parse(&tokenize(&source).unwrap()).unwrap();
 
-    let stateless = match ast_tree.node {
-        ASTNode::File { stateless, .. } => stateless,
+    let pure = match ast_tree.node {
+        ASTNode::File { pure, .. } => pure,
         _ => panic!("ast_tree was not file.")
     };
 
-    assert!(stateless);
+    assert!(pure);
 }
 
 #[test]


### PR DESCRIPTION
### Relevant issues
modified README to showcase #102 (yet to be implemented)
modified README to showcase #101 (to be implemented in type check) 
modified README to showcase #104 (yet to be implemented)

### Summary
Change the stateless keyword to pure, since it now denotes pure functions.

Also, use the new notation where property access is done using dot notation.
Postfix notation, for the sake of readability, can only be done when passing arguments to functions.