### PR TITLE
Add desugar rule for handle statement

### DIFF
--- a/src/core/construct.rs
+++ b/src/core/construct.rs
@@ -235,5 +235,15 @@ pub enum Core {
     Empty,
     Comment {
         comment: String
+    },
+
+    TryExcept {
+        _try:   Box<Core>,
+        except: Vec<Core>
+    },
+    Except {
+        id:    Box<Core>,
+        class: Box<Core>,
+        body:  Box<Core>
     }
 }

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -217,11 +217,40 @@ fn to_py(core: &Core, ind: usize) -> String {
         Core::Empty => String::new(),
         Core::Comment { comment } => format!("#{}", comment),
 
+        Core::TryExcept { _try, except } => format!(
+            "try:\n{}{}\n{}",
+            indent(ind + 1),
+            to_py(_try, ind + 1),
+            except_unwrap(except, ind)
+        ),
+
         other => panic!("To python not implemented yet for: {:?}", other)
     }
 }
 
 fn indent(amount: usize) -> String { " ".repeat(4 * amount) }
+
+fn except_unwrap(items: &[Core], ind: usize) -> String {
+    let mut result = String::new();
+
+    for item in items {
+        match item {
+            Core::Except { id, class, body } => result.push_str(
+                format!(
+                    "{}except {} as {}: {}\n",
+                    indent(ind),
+                    to_py(class, ind),
+                    to_py(id, ind),
+                    to_py(body, ind + 1)
+                )
+                .as_ref()
+            ),
+            other => panic!("Expected two id's but was: {:?}", other)
+        }
+    }
+
+    result
+}
 
 fn newline_delimited(items: &[Core], ind: usize) -> String {
     let mut result = String::new();

--- a/tests/desugar/error.rs
+++ b/tests/desugar/error.rs
@@ -1,0 +1,51 @@
+use mamba::core::construct::Core;
+use mamba::desugar::desugar;
+use mamba::parser::ast::ASTNode;
+use mamba::parser::ast::ASTNodePos;
+use std::panic;
+
+#[test]
+fn handle_empty_verify() {
+    let expr_or_stmt = to_pos!(ASTNode::Id { lit: String::from("my_fun") });
+    let handle = to_pos!(ASTNode::Handle { expr_or_stmt, cases: vec![] });
+
+    let (_try, except) = match desugar(&handle) {
+        Core::TryExcept { _try, except } => (_try, except),
+        other => panic!("Expected reassign but was {:?}", other)
+    };
+
+    assert_eq!(*_try, Core::Id { lit: String::from("my_fun") });
+    assert!(except.is_empty());
+}
+
+#[test]
+fn handle_verify() {
+    let expr_or_stmt = to_pos!(ASTNode::Id { lit: String::from("my_fun") });
+    let cond = to_pos!(ASTNode::IdType {
+        id:      to_pos!(ASTNode::Id { lit: String::from("err") }),
+        mutable: false,
+        _type:   Some(to_pos!(ASTNode::Type {
+            id:       to_pos!(ASTNode::Id { lit: String::from("my_type") }),
+            generics: vec![]
+        }))
+    });
+    let body = to_pos!(ASTNode::Int { lit: String::from("9999") });
+    let case = to_pos_unboxed!(ASTNode::Case { cond, body });
+    let handle = to_pos!(ASTNode::Handle { expr_or_stmt, cases: vec![case] });
+
+    let (_try, except) = match desugar(&handle) {
+        Core::TryExcept { _try, except } => (_try, except),
+        other => panic!("Expected reassign but was {:?}", other)
+    };
+
+    assert_eq!(*_try, Core::Id { lit: String::from("my_fun") });
+    assert_eq!(except.len(), 1);
+    match &except[0] {
+        Core::Except { id, class, body } => {
+            assert_eq!(**id, Core::Id { lit: String::from("err") });
+            assert_eq!(**class, Core::Id { lit: String::from("my_type") });
+            assert_eq!(**body, Core::Int { int: String::from("9999") });
+        }
+        other => panic!("Expected except case but was {:?}", other)
+    }
+}

--- a/tests/desugar/mod.rs
+++ b/tests/desugar/mod.rs
@@ -4,6 +4,7 @@ mod util;
 pub mod collection;
 pub mod control_flow;
 pub mod definition;
+pub mod error;
 pub mod expression_and_statements;
 pub mod operation;
 pub mod types;

--- a/tests/parser/invalid/error.rs
+++ b/tests/parser/invalid/error.rs
@@ -1,0 +1,14 @@
+use mamba::lexer::tokenize;
+use mamba::parser::parse_direct;
+
+#[test]
+fn handle_no_branches() {
+    let source = String::from("def a handle");
+    parse_direct(&tokenize(&source).unwrap()).unwrap_err();
+}
+
+#[test]
+fn handle_no_indentation() {
+    let source = String::from("def a handle\nerr: Err => b");
+    parse_direct(&tokenize(&source).unwrap()).unwrap_err();
+}

--- a/tests/parser/invalid/mod.rs
+++ b/tests/parser/invalid/mod.rs
@@ -1,6 +1,7 @@
 pub mod compound;
 pub mod control_flow;
 pub mod definition;
+pub mod error;
 pub mod expression_and_statement;
 pub mod function;
 pub mod operation;

--- a/tests/resources/valid/class/class.mamba
+++ b/tests/resources/valid/class/class.mamba
@@ -28,6 +28,11 @@ class MyClass isa MyType
     def init(mut self, my_field: Int, z: Int) =>
         if z > 10 then return Err("Something is wrong!")
         self.z_modified <- z * SOME_CONSTANT
+        def a <- self.z_modified handle
+            err1: MyErr =>
+                print "hey"
+                print "there"
+            err2: MyErr => print "hoi"
 
     def connect(mut self: SomeState) => self.other_field <- 200
 


### PR DESCRIPTION
### Relevant issues
#97 

### Summary
Desugar `handle` statement to a `try` `except`.

### Added Tests
- [x] Modified smoke class test for handle statement.
- [x] Add tests to check that desugaring invalid handle statements results in a panic.