### PR TITLE
Add in construct for in operation

### DIFF
--- a/src/core/construct.rs
+++ b/src/core/construct.rs
@@ -217,10 +217,13 @@ pub enum Core {
         right: Box<Core>
     },
 
+    In {
+        expr:       Box<Core>,
+        collection: Box<Core>
+    },
     For {
-        exprs:      Vec<Core>,
-        collection: Box<Core>,
-        body:       Box<Core>
+        expr: Box<Core>,
+        body: Box<Core>
     },
     Range {
         from: Box<Core>,

--- a/src/core/construct.rs
+++ b/src/core/construct.rs
@@ -218,8 +218,8 @@ pub enum Core {
     },
 
     In {
-        expr:       Box<Core>,
-        collection: Box<Core>
+        left:  Box<Core>,
+        right: Box<Core>
     },
     For {
         expr: Box<Core>,

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -193,11 +193,7 @@ fn to_py(core: &Core, ind: usize) -> String {
 
         Core::For { expr, body } =>
             format!("for {}: {}", to_py(expr.as_ref(), ind), to_py(body.as_ref(), ind + 1)),
-        Core::In { expr, collection } => format! {
-            "{} in {}",
-            to_py(expr, ind),
-            to_py(collection, ind)
-        },
+        Core::In { left, right } => format! {"{} in {}", to_py(left, ind), to_py(right, ind)},
         Core::Range { from, to, step } => format!(
             "range({}, {}, {})",
             to_py(from.as_ref(), ind),

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -191,12 +191,13 @@ fn to_py(core: &Core, ind: usize) -> String {
         Core::Return { expr } => format!("return {}", to_py(expr.as_ref(), ind)),
         Core::Print { expr } => format!("print({})", to_py(expr.as_ref(), ind)),
 
-        Core::For { exprs, collection, body } => format!(
-            "for {} in {}: {}",
-            comma_delimited(exprs.as_ref(), ind),
-            to_py(collection.as_ref(), ind),
-            to_py(body.as_ref(), ind + 1)
-        ),
+        Core::For { expr, body } =>
+            format!("for {}: {}", to_py(expr.as_ref(), ind), to_py(body.as_ref(), ind + 1)),
+        Core::In { expr, collection } => format! {
+            "{} in {}",
+            to_py(expr, ind),
+            to_py(collection, ind)
+        },
         Core::Range { from, to, step } => format!(
             "range({}, {}, {})",
             to_py(from.as_ref(), ind),

--- a/src/desugar/control_flow.rs
+++ b/src/desugar/control_flow.rs
@@ -30,10 +30,9 @@ pub fn desugar_control_flow(node: &ASTNode, ctx: &Context, state: &State) -> Cor
             cond: desugar_vec(cond, ctx, state),
             body: Box::from(desugar_node(body, ctx, state))
         },
-        ASTNode::For { expr, collection, body } => Core::For {
-            exprs:      desugar_vec(expr, ctx, state),
-            collection: Box::from(desugar_node(collection, ctx, state)),
-            body:       Box::from(desugar_node(body, ctx, state))
+        ASTNode::For { expr, body } => Core::For {
+            expr: Box::from(desugar_node(expr, ctx, state)),
+            body: Box::from(desugar_node(body, ctx, state))
         },
 
         ASTNode::Break => Core::Break,

--- a/src/desugar/node.rs
+++ b/src/desugar/node.rs
@@ -217,9 +217,9 @@ pub fn desugar_node(node_pos: &ASTNodePos, ctx: &Context, state: &State) -> Core
             body: Box::from(desugar_node(body, ctx, state))
         },
 
-        ASTNode::In { expr, collection } => Core::In {
-            expr:       Box::from(desugar_node(expr, ctx, state)),
-            collection: Box::from(desugar_node(collection, ctx, state))
+        ASTNode::In { left, right } => Core::In {
+            left:  Box::from(desugar_node(left, ctx, state)),
+            right: Box::from(desugar_node(right, ctx, state))
         },
         ASTNode::Range { from, to, inclusive, step } => Core::Range {
             from: Box::from(desugar_node(from, ctx, state)),

--- a/src/desugar/node.rs
+++ b/src/desugar/node.rs
@@ -217,6 +217,10 @@ pub fn desugar_node(node_pos: &ASTNodePos, ctx: &Context, state: &State) -> Core
             body: Box::from(desugar_node(body, ctx, state))
         },
 
+        ASTNode::In { expr, collection } => Core::In {
+            expr:       Box::from(desugar_node(expr, ctx, state)),
+            collection: Box::from(desugar_node(collection, ctx, state))
+        },
         ASTNode::Range { from, to, inclusive, step } => Core::Range {
             from: Box::from(desugar_node(from, ctx, state)),
             to:   Box::from(if *inclusive {

--- a/src/parser/ast.rs
+++ b/src/parser/ast.rs
@@ -319,9 +319,12 @@ pub enum ASTNode {
         body: Box<ASTNodePos>
     },
     For {
-        expr:       Vec<ASTNodePos>,
-        collection: Box<ASTNodePos>,
-        body:       Box<ASTNodePos>
+        expr: Box<ASTNodePos>,
+        body: Box<ASTNodePos>
+    },
+    In {
+        expr:       Box<ASTNodePos>,
+        collection: Box<ASTNodePos>
     },
     Step {
         amount: Box<ASTNodePos>

--- a/src/parser/ast.rs
+++ b/src/parser/ast.rs
@@ -323,8 +323,8 @@ pub enum ASTNode {
         body: Box<ASTNodePos>
     },
     In {
-        expr:       Box<ASTNodePos>,
-        collection: Box<ASTNodePos>
+        left:  Box<ASTNodePos>,
+        right: Box<ASTNodePos>
     },
     Step {
         amount: Box<ASTNodePos>

--- a/src/parser/control_flow_stmt.rs
+++ b/src/parser/control_flow_stmt.rs
@@ -63,14 +63,12 @@ fn parse_for(it: &mut TPIterator) -> ParseResult {
     let (st_line, st_pos) = start_pos(it);
 
     check_next_is!(it, Token::For);
-    let expr: Vec<ASTNodePos> = get_one_or_more!(it, "for expression");
-    check_next_is!(it, Token::In);
-    let collection: Box<ASTNodePos> = get_or_err!(it, parse_expression, "for collection");
+    let expr: Box<ASTNodePos> = get_or_err!(it, parse_expression, "for expression");
     check_next_is!(it, Token::Do);
     let body: Box<ASTNodePos> = get_or_err!(it, parse_expr_or_stmt, "for body");
 
     let (en_line, en_pos) = (body.en_line, body.en_pos);
-    let node = ASTNode::For { expr, collection, body };
+    let node = ASTNode::For { expr, body };
 
     Ok(ASTNodePos { st_line, st_pos, en_line, en_pos, node })
 }

--- a/src/parser/expression.rs
+++ b/src/parser/expression.rs
@@ -77,34 +77,6 @@ fn parse_post_expr(pre: ASTNodePos, it: &mut TPIterator) -> ParseResult {
             let node = ASTNode::In { left: Box::new(pre), right: collection };
             Ok(ASTNodePos { st_line, st_pos, en_line, en_pos, node })
         }
-        Some(TokenPos { token: Token::Range, .. }) => {
-            it.next();
-            let to: Box<ASTNodePos> = get_or_err!(it, parse_expression, "..");
-            let step = if let Some(&TokenPos { token: Token::Step, .. }) = it.peek() {
-                it.next();
-                Some(get_or_err!(it, parse_expression, "step"))
-            } else {
-                None
-            };
-
-            let (en_line, en_pos) = (to.en_line, to.en_pos);
-            let node = ASTNode::Range { from: Box::from(pre), to, inclusive: false, step };
-            Ok(ASTNodePos { st_line, st_pos, en_line, en_pos, node })
-        }
-        Some(TokenPos { token: Token::RangeIncl, .. }) => {
-            it.next();
-            let to: Box<ASTNodePos> = get_or_err!(it, parse_expression, "..=");
-            let step = if let Some(&TokenPos { token: Token::Step, .. }) = it.peek() {
-                it.next();
-                Some(get_or_err!(it, parse_expression, "step"))
-            } else {
-                None
-            };
-
-            let (en_line, en_pos) = (to.en_line, to.en_pos);
-            let node = ASTNode::Range { from: Box::from(pre), to, inclusive: true, step };
-            Ok(ASTNodePos { st_line, st_pos, en_line, en_pos, node })
-        }
 
         Some(TokenPos { token: Token::Assign, .. }) => parse_reassignment(pre, it),
 

--- a/src/parser/expression.rs
+++ b/src/parser/expression.rs
@@ -69,6 +69,14 @@ fn parse_post_expr(pre: ASTNodePos, it: &mut TPIterator) -> ParseResult {
             let node = ASTNode::QuestOr { _do: Box::new(pre), _default: _def };
             Ok(ASTNodePos { st_line, st_pos, en_line, en_pos, node })
         }
+        Some(TokenPos { token: Token::In, .. }) => {
+            it.next();
+            let collection: Box<ASTNodePos> = get_or_err!(it, parse_expression, "?or");
+
+            let (en_line, en_pos) = (collection.en_line, collection.en_pos);
+            let node = ASTNode::In { expr: Box::new(pre), collection };
+            Ok(ASTNodePos { st_line, st_pos, en_line, en_pos, node })
+        }
         Some(TokenPos { token: Token::Range, .. }) => {
             it.next();
             let to: Box<ASTNodePos> = get_or_err!(it, parse_expression, "..");

--- a/src/parser/expression.rs
+++ b/src/parser/expression.rs
@@ -74,7 +74,7 @@ fn parse_post_expr(pre: ASTNodePos, it: &mut TPIterator) -> ParseResult {
             let collection: Box<ASTNodePos> = get_or_err!(it, parse_expression, "?or");
 
             let (en_line, en_pos) = (collection.en_line, collection.en_pos);
-            let node = ASTNode::In { expr: Box::new(pre), collection };
+            let node = ASTNode::In { left: Box::new(pre), right: collection };
             Ok(ASTNodePos { st_line, st_pos, en_line, en_pos, node })
         }
         Some(TokenPos { token: Token::Range, .. }) => {

--- a/src/parser/operation.rs
+++ b/src/parser/operation.rs
@@ -85,6 +85,7 @@ fn parse_level_6(it: &mut TPIterator) -> ParseResult {
         Some(TokenPos { token: Token::IsN, .. }) => bin_op!(parse_level_6, IsN, "is not"),
         Some(TokenPos { token: Token::IsA, .. }) => bin_op!(parse_level_6, IsA, "is a"),
         Some(TokenPos { token: Token::IsNA, .. }) => bin_op!(parse_level_6, IsNA, "is not a"),
+        Some(TokenPos { token: Token::In, .. }) => bin_op!(parse_level_6, In, "in"),
         _ => Ok(*arithmetic)
     }
 }

--- a/src/parser/operation.rs
+++ b/src/parser/operation.rs
@@ -26,7 +26,6 @@ macro_rules! inner_bin_op {
     }};
 }
 
-// TODO add `in` operator
 /// Parse an operation.
 ///
 /// Precedence is as follows, from top to bottom:
@@ -35,8 +34,8 @@ macro_rules! inner_bin_op {
 /// 3. multiplication, division, floor division, modulus
 /// 4. addition, subtraction
 /// 5. binary left shift, binary right shift, binary and, binary or, binary xor
-/// 6. greater, greater or equal, less, less or equal, equal, not equal, is, is
-/// not, is a, is not a 7. and, or
+/// 6. greater, greater or equal, less, less or equal, equal, not equal, is, is,
+/// in not, is a, is not a 7. and, or
 /// 8. postfix calls
 pub fn parse_operation(it: &mut TPIterator) -> ParseResult { parse_level_8(it) }
 

--- a/tests/desugar/control_flow.rs
+++ b/tests/desugar/control_flow.rs
@@ -87,21 +87,16 @@ fn match_verify() {
 
 #[test]
 fn for_verify() {
-    let expr_1 = to_pos_unboxed!(ASTNode::Id { lit: String::from("expr_1") });
-    let expr_2 = to_pos_unboxed!(ASTNode::Id { lit: String::from("expr_2") });
-    let collection = to_pos!(ASTNode::Id { lit: String::from("collection") });
+    let expr = to_pos!(ASTNode::Id { lit: String::from("expr_1") });
     let body = to_pos!(ASTNode::Id { lit: String::from("body") });
-    let for_stmt = to_pos!(ASTNode::For { expr: vec![expr_1, expr_2], collection, body });
+    let for_stmt = to_pos!(ASTNode::For { expr, body });
 
-    let (core_exprs, core_collection, core_body) = match desugar(&for_stmt) {
-        Core::For { exprs, collection, body } => (exprs, collection, body),
+    let (core_expr, core_body) = match desugar(&for_stmt) {
+        Core::For { expr, body } => (expr, body),
         other => panic!("Expected for but was {:?}", other)
     };
 
-    assert_eq!(core_exprs.len(), 2);
-    assert_eq!(core_exprs[0], Core::Id { lit: String::from("expr_1") });
-    assert_eq!(core_exprs[1], Core::Id { lit: String::from("expr_2") });
-    assert_eq!(*core_collection, Core::Id { lit: String::from("collection") });
+    assert_eq!(*core_expr, Core::Id { lit: String::from("expr_1") });
     assert_eq!(*core_body, Core::Id { lit: String::from("body") });
 }
 

--- a/tests/desugar/error.rs
+++ b/tests/desugar/error.rs
@@ -37,6 +37,7 @@ fn with_no_as_verify() {
     assert_eq!(*expr, Core::Int { int: String::from("2341") });
 }
 
+#[test]
 fn handle_empty_verify() {
     let expr_or_stmt = to_pos!(ASTNode::Id { lit: String::from("my_fun") });
     let handle = to_pos!(ASTNode::Handle { expr_or_stmt, cases: vec![] });

--- a/tests/parser/invalid/control_flow.rs
+++ b/tests/parser/invalid/control_flow.rs
@@ -2,12 +2,6 @@ use mamba::lexer::tokenize;
 use mamba::parser::parse_direct;
 
 #[test]
-fn for_missing_in() {
-    let source = String::from("for a c do d");
-    parse_direct(&tokenize(&source).unwrap()).unwrap_err();
-}
-
-#[test]
 fn for_missing_do() {
     let source = String::from("for a in c d");
     parse_direct(&tokenize(&source).unwrap()).unwrap_err();

--- a/tests/parser/valid/control_flow.rs
+++ b/tests/parser/valid/control_flow.rs
@@ -110,7 +110,7 @@ fn for_range_incl_verify() {
                     assert_eq!(from.node, ASTNode::Id { lit: String::from("c") });
                     assert_eq!(to.node, ASTNode::Id { lit: String::from("d") });
                     assert!(inclusive);
-                    assert_eq!(step.clone().unwrap().node, ASTNode::Id { lit: String::from("e") });
+                    assert_eq!(*step, None);
                 }
                 _ => panic!("Expected range")
             }

--- a/tests/parser/valid/control_flow.rs
+++ b/tests/parser/valid/control_flow.rs
@@ -20,8 +20,7 @@ fn for_statement_verify() {
         ASTNode::Script { statements, .. } =>
             match &statements.first().expect("script empty.").node {
                 ASTNode::For { expr, body } => match &expr.node {
-                    ASTNode::In { expr, collection } =>
-                        (expr.clone(), collection.clone(), body.clone()),
+                    ASTNode::In { left, right } => (left.clone(), right.clone(), body.clone()),
                     other => panic!("Expected in but was {:?}", other)
                 },
                 _ => panic!("first element script was not for.")
@@ -43,8 +42,7 @@ fn for_tuple_statement_verify() {
         ASTNode::Script { statements, .. } =>
             match &statements.first().expect("script empty.").node {
                 ASTNode::For { expr, body } => match &expr.node {
-                    ASTNode::In { expr, collection } =>
-                        (expr.clone(), collection.clone(), body.clone()),
+                    ASTNode::In { left, right } => (left.clone(), right.clone(), body.clone()),
                     other => panic!("Expected in but was {:?}", other)
                 },
                 _ => panic!("first element script was not for.")
@@ -72,9 +70,9 @@ fn for_range_step_verify() {
     };
 
     match expr.node {
-        ASTNode::In { expr, collection } => {
-            assert_eq!(expr.node, ASTNode::Id { lit: String::from("a") });
-            match &collection.node {
+        ASTNode::In { left, right } => {
+            assert_eq!(left.node, ASTNode::Id { lit: String::from("a") });
+            match &right.node {
                 ASTNode::Range { from, to, inclusive, step } => {
                     assert_eq!(from.node, ASTNode::Id { lit: String::from("c") });
                     assert_eq!(to.node, ASTNode::Id { lit: String::from("d") });
@@ -105,9 +103,9 @@ fn for_range_incl_verify() {
     };
 
     match expr.node {
-        ASTNode::In { expr, collection } => {
-            assert_eq!(expr.node, ASTNode::Id { lit: String::from("a") });
-            match &collection.node {
+        ASTNode::In { left, right } => {
+            assert_eq!(left.node, ASTNode::Id { lit: String::from("a") });
+            match &right.node {
                 ASTNode::Range { from, to, inclusive, step } => {
                     assert_eq!(from.node, ASTNode::Id { lit: String::from("c") });
                     assert_eq!(to.node, ASTNode::Id { lit: String::from("d") });

--- a/tests/parser/valid/control_flow.rs
+++ b/tests/parser/valid/control_flow.rs
@@ -16,42 +16,43 @@ fn for_statement_verify() {
     let source = String::from("for a in c do d");
     let ast_tree = parse_direct(&tokenize(&source).unwrap()).unwrap();
 
-    let _statements;
     let (expr, collection, body) = match ast_tree.node {
-        ASTNode::Script { statements, .. } => {
-            _statements = statements;
-            match &_statements.first().expect("script empty.").node {
-                ASTNode::For { expr, collection, body } => (expr, collection, body),
+        ASTNode::Script { statements, .. } =>
+            match &statements.first().expect("script empty.").node {
+                ASTNode::For { expr, body } => match &expr.node {
+                    ASTNode::In { expr, collection } =>
+                        (expr.clone(), collection.clone(), body.clone()),
+                    other => panic!("Expected in but was {:?}", other)
+                },
                 _ => panic!("first element script was not for.")
-            }
-        }
+            },
         _ => panic!("ast_tree was not script.")
     };
 
-    assert_eq!(expr[0].node, ASTNode::Id { lit: String::from("a") });
+    assert_eq!(expr.node, ASTNode::Id { lit: String::from("a") });
     assert_eq!(collection.node, ASTNode::Id { lit: String::from("c") });
     assert_eq!(body.node, ASTNode::Id { lit: String::from("d") });
 }
 
 #[test]
 fn for_tuple_statement_verify() {
-    let source = String::from("for a,b in c do d");
+    let source = String::from("for a in c do d");
     let ast_tree = parse_direct(&tokenize(&source).unwrap()).unwrap();
 
-    let _statements;
     let (expr, collection, body) = match ast_tree.node {
-        ASTNode::Script { statements, .. } => {
-            _statements = statements;
-            match &_statements.first().expect("script empty.").node {
-                ASTNode::For { expr, collection, body } => (expr, collection, body),
+        ASTNode::Script { statements, .. } =>
+            match &statements.first().expect("script empty.").node {
+                ASTNode::For { expr, body } => match &expr.node {
+                    ASTNode::In { expr, collection } =>
+                        (expr.clone(), collection.clone(), body.clone()),
+                    other => panic!("Expected in but was {:?}", other)
+                },
                 _ => panic!("first element script was not for.")
-            }
-        }
+            },
         _ => panic!("ast_tree was not script.")
     };
 
-    assert_eq!(expr[0].node, ASTNode::Id { lit: String::from("a") });
-    assert_eq!(expr[1].node, ASTNode::Id { lit: String::from("b") });
+    assert_eq!(expr.node, ASTNode::Id { lit: String::from("a") });
     assert_eq!(collection.node, ASTNode::Id { lit: String::from("c") });
     assert_eq!(body.node, ASTNode::Id { lit: String::from("d") });
 }
@@ -61,27 +62,31 @@ fn for_range_step_verify() {
     let source = String::from("for a in c .. d step e do f");
     let ast_tree = parse_direct(&tokenize(&source).unwrap()).unwrap();
 
-    let _statements;
-    let (expr, from, to, step, inclusive, body) = match ast_tree.node {
-        ASTNode::Script { statements, .. } => {
-            _statements = statements;
-            match &_statements.first().expect("script empty.").node {
-                ASTNode::For { expr, collection, body } => match &collection.node {
-                    ASTNode::Range { from, to, inclusive, step } =>
-                        (expr, from, to, step.clone(), inclusive, body),
-                    _ => panic!("Expected range")
-                },
+    let (expr, body) = match ast_tree.node {
+        ASTNode::Script { statements, .. } =>
+            match &statements.first().expect("script empty.").node {
+                ASTNode::For { expr, body } => (expr.clone(), body.clone()),
                 _ => panic!("first element script was not foreach.")
-            }
-        }
+            },
         _ => panic!("ast_tree was not script.")
     };
 
-    assert_eq!(expr[0].node, ASTNode::Id { lit: String::from("a") });
-    assert_eq!(from.node, ASTNode::Id { lit: String::from("c") });
-    assert_eq!(to.node, ASTNode::Id { lit: String::from("d") });
-    assert!(!inclusive);
-    assert_eq!(step.unwrap().node, ASTNode::Id { lit: String::from("e") });
+    match expr.node {
+        ASTNode::In { expr, collection } => {
+            assert_eq!(expr.node, ASTNode::Id { lit: String::from("a") });
+            match &collection.node {
+                ASTNode::Range { from, to, inclusive, step } => {
+                    assert_eq!(from.node, ASTNode::Id { lit: String::from("c") });
+                    assert_eq!(to.node, ASTNode::Id { lit: String::from("d") });
+                    assert!(!inclusive);
+                    assert_eq!(step.clone().unwrap().node, ASTNode::Id { lit: String::from("e") });
+                }
+                _ => panic!("Expected range")
+            }
+        }
+        other => panic!("Expected in but was {:?}", other)
+    }
+
     assert_eq!(body.node, ASTNode::Id { lit: String::from("f") });
 }
 
@@ -90,27 +95,31 @@ fn for_range_incl_verify() {
     let source = String::from("for a in c ..= d do f");
     let ast_tree = parse_direct(&tokenize(&source).unwrap()).unwrap();
 
-    let _statements;
-    let (expr, from, to, step, inclusive, body) = match ast_tree.node {
-        ASTNode::Script { statements, .. } => {
-            _statements = statements;
-            match &_statements.first().expect("script empty.").node {
-                ASTNode::For { expr, collection, body } => match &collection.node {
-                    ASTNode::Range { from, to, inclusive, step } =>
-                        (expr, from, to, step.clone(), inclusive, body),
-                    _ => panic!("Expected range")
-                },
+    let (expr, body) = match ast_tree.node {
+        ASTNode::Script { statements, .. } =>
+            match &statements.first().expect("script empty.").node {
+                ASTNode::For { expr, body } => (expr.clone(), body.clone()),
                 _ => panic!("first element script was not foreach.")
-            }
-        }
+            },
         _ => panic!("ast_tree was not script.")
     };
 
-    assert_eq!(expr[0].node, ASTNode::Id { lit: String::from("a") });
-    assert_eq!(from.node, ASTNode::Id { lit: String::from("c") });
-    assert_eq!(to.node, ASTNode::Id { lit: String::from("d") });
-    assert!(inclusive);
-    assert!(step.is_none());
+    match expr.node {
+        ASTNode::In { expr, collection } => {
+            assert_eq!(expr.node, ASTNode::Id { lit: String::from("a") });
+            match &collection.node {
+                ASTNode::Range { from, to, inclusive, step } => {
+                    assert_eq!(from.node, ASTNode::Id { lit: String::from("c") });
+                    assert_eq!(to.node, ASTNode::Id { lit: String::from("d") });
+                    assert!(inclusive);
+                    assert_eq!(step.clone().unwrap().node, ASTNode::Id { lit: String::from("e") });
+                }
+                _ => panic!("Expected range")
+            }
+        }
+        other => panic!("Expected in but was {:?}", other)
+    }
+
     assert_eq!(body.node, ASTNode::Id { lit: String::from("f") });
 }
 

--- a/tests/parser/valid/operation.rs
+++ b/tests/parser/valid/operation.rs
@@ -210,6 +210,16 @@ fn geq_verify() {
 }
 
 #[test]
+fn in_verify() {
+    let source = String::from("one in my_set");
+    let ast_tree = parse_direct(&tokenize(&source).unwrap()).unwrap();
+
+    let (left, right) = verify_is_operation!(In, ast_tree);
+    assert_eq!(left.node, ASTNode::Id { lit: String::from("one") });
+    assert_eq!(right.node, ASTNode::Id { lit: String::from("my_set") });
+}
+
+#[test]
 fn and_verify() {
     let source = String::from("one and three");
     let ast_tree = parse_direct(&tokenize(&source).unwrap()).unwrap();

--- a/tests/resources/valid/control_flow/for_statements.mamba
+++ b/tests/resources/valid/control_flow/for_statements.mamba
@@ -7,7 +7,7 @@ for d in e do
 
     print h
 
-for aa, ab in bb do
+for (aa, ab) in bb do
     print cc
     print dd
 


### PR DESCRIPTION
### Relevant issues
Fixes #113 

### Summary
Allows us to use Python's `in` boolean operator.

### Added Tests
Check that `in` operator works as expected.
