### PR TITLE
Create readable syntax error messages

### DIFF
--- a/src/lexer/token.rs
+++ b/src/lexer/token.rs
@@ -173,12 +173,24 @@ impl fmt::Display for Token {
             Token::Assign => String::from("<-"),
             Token::Def => String::from("def"),
 
-            Token::Id(id) => format!("{} (identifier)", id),
-            Token::Real(real) => format!("{} (real)", real),
-            Token::Int(int) => format!("{} (integer)", int),
-            Token::ENum(int, exp) => format!("{}e{} (e-number)", int, exp),
-            Token::Str(string) => format!("{} (string)", string),
-            Token::Bool(boolean) => format!("{} (boolean)", boolean),
+            Token::Id(id) => format!("{}{}<identifier>", id, if id.is_empty() { "" } else { " " }),
+            Token::Real(real) =>
+                format!("{}{}<real>", real, if real.is_empty() { "" } else { " " }),
+            Token::Int(int) => format!("{}{}<integer>", int, if int.is_empty() { "" } else { " " }),
+            Token::ENum(int, exp) =>
+                if int.is_empty() && exp.is_empty() {
+                    String::from("<e-number>")
+                } else {
+                    format!("{}e{} <e-number>", int, exp)
+                },
+            Token::Str(string) =>
+                if string.is_empty() {
+                    String::from("<string>")
+                } else {
+                    format!("\"{}\"", string)
+                },
+            Token::Bool(boolean) => format!("{}", boolean),
+
             Token::Range => String::from(".."),
             Token::RangeIncl => String::from("..="),
 

--- a/src/parser/_type.rs
+++ b/src/parser/_type.rs
@@ -171,10 +171,11 @@ pub fn parse_type_tuple(it: &mut TPIterator) -> ParseResult {
 }
 
 pub fn parse_id_maybe_type(it: &mut TPIterator) -> ParseResult {
-    let (st_line, st_pos) = it.start_pos("id maybe type")?;
+    let (st_line, st_pos) = it.start_pos("identifier maybe type")?;
     let mutable = it.eat_if(&Token::Mut).is_some();
-    let id = it.parse(&parse_id, "id maybe type", st_line, st_pos)?;
-    let _type = it.parse_if(&Token::DoublePoint, &parse_type, "id maybe type", st_line, st_pos)?;
+    let id = it.parse(&parse_id, "identifier maybe type", st_line, st_pos)?;
+    let _type =
+        it.parse_if(&Token::DoublePoint, &parse_type, "identifier maybe type", st_line, st_pos)?;
     let (en_line, en_pos) = match &_type {
         Some(ast_node_pos) => (ast_node_pos.en_line, ast_node_pos.en_pos),
         _ => (id.en_line, id.en_pos)

--- a/src/parser/_type.rs
+++ b/src/parser/_type.rs
@@ -41,7 +41,7 @@ pub fn parse_id(it: &mut TPIterator) -> ParseResult {
 pub fn parse_generics(it: &mut TPIterator) -> ParseResult<Vec<ASTNodePos>> {
     let mut generics: Vec<ASTNodePos> = Vec::new();
     it.peek_while_not_token(&Token::RSBrack, &mut |it, _| {
-        generics.push(*it.parse(&parse_generic)?);
+        generics.push(*it.parse(&parse_generic, "generics")?);
         it.eat_if(&Token::Comma);
         Ok(())
     })?;
@@ -49,8 +49,8 @@ pub fn parse_generics(it: &mut TPIterator) -> ParseResult<Vec<ASTNodePos>> {
 }
 
 fn parse_generic(it: &mut TPIterator) -> ParseResult {
-    let id = it.parse(&parse_id)?;
-    let isa = it.parse_if(&Token::IsA, &parse_id, "generic isa")?;
+    let id = it.parse(&parse_id, "generic")?;
+    let isa = it.parse_if(&Token::IsA, &parse_id, "generic")?;
 
     let (st_line, st_pos) = it.start_pos("generic")?;
     let (en_line, en_pos) = match isa.as_ref() {
@@ -68,7 +68,7 @@ pub fn parse_type(it: &mut TPIterator) -> ParseResult {
     let _type = it.peek_or_err(
         &|it, token_pos| match token_pos.token {
             Token::Id(_) => {
-                let id = it.parse(&parse_id)?;
+                let id = it.parse(&parse_id, "type")?;
                 let generics = it.parse_vec_if(&Token::LSBrack, &parse_generics, "type generic")?;
                 it.eat_if(&Token::RSBrack);
 
@@ -80,7 +80,7 @@ pub fn parse_type(it: &mut TPIterator) -> ParseResult {
                 let node = ASTNode::Type { id, generics };
                 Ok(Box::from(ASTNodePos { st_line, st_pos, en_line, en_pos, node }))
             }
-            Token::LRBrack => it.parse(&parse_type_tuple),
+            Token::LRBrack => it.parse(&parse_type_tuple, "type"),
             _ => Err(expected_one_of(
                 &[Token::Id(String::new()), Token::LRBrack],
                 &token_pos.clone(),
@@ -94,7 +94,7 @@ pub fn parse_type(it: &mut TPIterator) -> ParseResult {
     let res = it.parse_if(
         &Token::To,
         &|it| {
-            let body = it.parse(&parse_type)?;
+            let body = it.parse(&parse_type, "type")?;
             let (en_line, en_pos) = (body.en_line, body.en_pos);
             let node = ASTNode::TypeFun { _type: _type.clone(), body };
             Ok(Box::from(ASTNodePos { st_line, st_pos, en_line, en_pos, node }))
@@ -113,13 +113,13 @@ pub fn parse_conditions(it: &mut TPIterator) -> ParseResult<Vec<ASTNodePos>> {
     if it.eat_if(&Token::NL).is_some() {
         it.eat(&Token::Indent, "conditions")?;
         it.peek_while_not_token(&Token::Dedent, &mut |it, _| {
-            conditions.push(*it.parse(&parse_condition)?);
+            conditions.push(*it.parse(&parse_condition, "conditions")?);
             it.eat_if(&Token::NL);
             Ok(())
         })?;
         it.eat(&Token::Dedent, "conditions")?;
     } else {
-        conditions.push(*it.parse(&parse_condition)?);
+        conditions.push(*it.parse(&parse_condition, "conditions")?);
     }
 
     Ok(conditions)
@@ -127,7 +127,7 @@ pub fn parse_conditions(it: &mut TPIterator) -> ParseResult<Vec<ASTNodePos>> {
 
 fn parse_condition(it: &mut TPIterator) -> ParseResult {
     let (st_line, st_pos) = it.start_pos("condition")?;
-    let cond = it.parse(&parse_expression)?;
+    let cond = it.parse(&parse_expression, "condition")?;
     let _else = it.parse_if(&Token::Else, &parse_expression, "condition else")?;
 
     let (en_line, en_pos) = if let Some(ast_pos) = _else.clone() {
@@ -146,7 +146,7 @@ pub fn parse_type_tuple(it: &mut TPIterator) -> ParseResult {
 
     let mut types = vec![];
     it.peek_while_not_token(&Token::RRBrack, &mut |it, _| {
-        types.push(*it.parse(&parse_type)?);
+        types.push(*it.parse(&parse_type, "type tuple")?);
         it.eat_if(&Token::Comma);
         Ok(())
     })?;
@@ -159,7 +159,7 @@ pub fn parse_type_tuple(it: &mut TPIterator) -> ParseResult {
 pub fn parse_id_maybe_type(it: &mut TPIterator) -> ParseResult {
     let (st_line, st_pos) = it.start_pos("id maybe type")?;
     let mutable = it.eat_if(&Token::Mut).is_some();
-    let id = it.parse(&parse_id)?;
+    let id = it.parse(&parse_id, "id maybe type")?;
     let _type = it.parse_if(&Token::DoublePoint, &parse_type, "id maybe type")?;
     let (en_line, en_pos) = match &_type {
         Some(ast_node_pos) => (ast_node_pos.en_line, ast_node_pos.en_pos),

--- a/src/parser/_type.rs
+++ b/src/parser/_type.rs
@@ -4,7 +4,8 @@ use crate::parser::ast::ASTNode;
 use crate::parser::ast::ASTNodePos;
 use crate::parser::expression::parse_expression;
 use crate::parser::iterator::TPIterator;
-use crate::parser::parse_result::ParseErr::*;
+use crate::parser::parse_result::expected;
+use crate::parser::parse_result::expected_construct;
 use crate::parser::parse_result::ParseResult;
 
 pub fn parse_id(it: &mut TPIterator) -> ParseResult {
@@ -28,8 +29,7 @@ pub fn parse_id(it: &mut TPIterator) -> ParseResult {
                 let node = ASTNode::Id { lit: id.clone() };
                 Ok(Box::from(ASTNodePos { st_line, st_pos, en_line, en_pos, node }))
             }
-            _ =>
-                Err(CustomErr { expected: String::from("identifier"), actual: token_pos.clone() }),
+            _ => Err(expected_construct("identifier", token_pos))
         },
         "identifier"
     )
@@ -37,8 +37,8 @@ pub fn parse_id(it: &mut TPIterator) -> ParseResult {
 
 pub fn parse_generics(it: &mut TPIterator) -> ParseResult<Vec<ASTNodePos>> {
     let mut generics: Vec<ASTNodePos> = Vec::new();
-    it.peek_while_not_token(&Token::RSBrack, &mut |it, _, no| {
-        generics.push(*it.parse(&parse_generic, format!("generic {}", no).as_str())?);
+    it.peek_while_not_token(&Token::RSBrack, &mut |it, _| {
+        generics.push(*it.parse(&parse_generic)?);
         it.eat_if(&Token::Comma);
         Ok(())
     })?;
@@ -46,7 +46,7 @@ pub fn parse_generics(it: &mut TPIterator) -> ParseResult<Vec<ASTNodePos>> {
 }
 
 fn parse_generic(it: &mut TPIterator) -> ParseResult {
-    let id = it.parse(&parse_id, "generic id")?;
+    let id = it.parse(&parse_id)?;
     let isa = it.parse_if(&Token::IsA, &parse_id, "generic isa")?;
 
     let (st_line, st_pos) = it.start_pos()?;
@@ -65,7 +65,7 @@ pub fn parse_type(it: &mut TPIterator) -> ParseResult {
     let _type = it.peek_or_err(
         &|it, token_pos| match token_pos {
             TokenPos { token: Token::Id(_), .. } => {
-                let id = it.parse(&parse_id, "type")?;
+                let id = it.parse(&parse_id)?;
                 let generics = it.parse_vec_if(&Token::LSBrack, &parse_generics, "type generic")?;
                 it.eat_if(&Token::RSBrack);
 
@@ -77,12 +77,8 @@ pub fn parse_type(it: &mut TPIterator) -> ParseResult {
                 let node = ASTNode::Type { id, generics };
                 Ok(Box::from(ASTNodePos { st_line, st_pos, en_line, en_pos, node }))
             }
-            TokenPos { token: Token::LRBrack, .. } => it.parse(&parse_type_tuple, "type"),
-            other => Err(TokenErr {
-                expected: Token::LRBrack,
-                actual:   other.clone(),
-                message:  String::from("type")
-            })
+            TokenPos { token: Token::LRBrack, .. } => it.parse(&parse_type_tuple),
+            other => Err(expected(&Token::LRBrack, &other.clone(), "type"))
         },
         "type"
     )?;
@@ -90,7 +86,7 @@ pub fn parse_type(it: &mut TPIterator) -> ParseResult {
     let res = it.parse_if(
         &Token::To,
         &|it| {
-            let body = it.parse(&parse_type, "type")?;
+            let body = it.parse(&parse_type)?;
             let (en_line, en_pos) = (body.en_line, body.en_pos);
             let node = ASTNode::TypeFun { _type: _type.clone(), body };
             Ok(Box::from(ASTNodePos { st_line, st_pos, en_line, en_pos, node }))
@@ -108,14 +104,14 @@ pub fn parse_conditions(it: &mut TPIterator) -> ParseResult<Vec<ASTNodePos>> {
     let mut conditions = vec![];
     if it.eat_if(&Token::NL).is_some() {
         it.eat(&Token::Indent, "conditions")?;
-        it.peek_while_not_token(&Token::Dedent, &mut |it, _, no| {
-            conditions.push(*it.parse(&parse_condition, format!("condition {}", no).as_str())?);
+        it.peek_while_not_token(&Token::Dedent, &mut |it, _| {
+            conditions.push(*it.parse(&parse_condition)?);
             it.eat_if(&Token::NL);
             Ok(())
         })?;
         it.eat(&Token::Dedent, "conditions")?;
     } else {
-        conditions.push(*it.parse(&parse_condition, "condition 1")?);
+        conditions.push(*it.parse(&parse_condition)?);
     }
 
     Ok(conditions)
@@ -123,7 +119,7 @@ pub fn parse_conditions(it: &mut TPIterator) -> ParseResult<Vec<ASTNodePos>> {
 
 fn parse_condition(it: &mut TPIterator) -> ParseResult {
     let (st_line, st_pos) = it.start_pos()?;
-    let cond = it.parse(&parse_expression, "condition")?;
+    let cond = it.parse(&parse_expression)?;
     let _else = it.parse_if(&Token::Else, &parse_expression, "condition else")?;
 
     let (en_line, en_pos) = if let Some(ast_pos) = _else.clone() {
@@ -141,8 +137,8 @@ pub fn parse_type_tuple(it: &mut TPIterator) -> ParseResult {
     it.eat(&Token::LRBrack, "type tuple")?;
 
     let mut types = vec![];
-    it.peek_while_not_token(&Token::RRBrack, &mut |it, _, no| {
-        types.push(*it.parse(&parse_type, format!("type tuple {}", no).as_str())?);
+    it.peek_while_not_token(&Token::RRBrack, &mut |it, _| {
+        types.push(*it.parse(&parse_type)?);
         it.eat_if(&Token::Comma);
         Ok(())
     })?;
@@ -155,7 +151,7 @@ pub fn parse_type_tuple(it: &mut TPIterator) -> ParseResult {
 pub fn parse_id_maybe_type(it: &mut TPIterator) -> ParseResult {
     let (st_line, st_pos) = it.start_pos()?;
     let mutable = it.eat_if(&Token::Mut).is_some();
-    let id = it.parse(&parse_id, "id maybe type")?;
+    let id = it.parse(&parse_id)?;
     let _type = it.parse_if(&Token::DoublePoint, &parse_type, "id maybe type")?;
     let (en_line, en_pos) = match &_type {
         Some(ast_node_pos) => (ast_node_pos.en_line, ast_node_pos.en_pos),

--- a/src/parser/block.rs
+++ b/src/parser/block.rs
@@ -4,19 +4,19 @@ use crate::parser::ast::ASTNode;
 use crate::parser::ast::ASTNodePos;
 use crate::parser::expr_or_stmt::parse_expr_or_stmt;
 use crate::parser::iterator::TPIterator;
-use crate::parser::parse_result::expected_construct;
+use crate::parser::parse_result::expected;
 use crate::parser::parse_result::ParseResult;
 
 pub fn parse_statements(it: &mut TPIterator) -> ParseResult<Vec<ASTNodePos>> {
     let mut statements: Vec<ASTNodePos> = Vec::new();
     it.peek_while_not_token(&Token::Dedent, &mut |it, token_pos| match &token_pos.token {
         Token::NL => {
-            it.eat(&Token::NL, "statements")?;
+            it.eat(&Token::NL, "block")?;
             Ok(())
         }
         Token::Comment(comment) => {
             let (st_line, st_pos) = (token_pos.st_line, token_pos.st_pos);
-            it.eat(&Token::Comment(comment.clone()), "statements")?;
+            it.eat(&Token::Comment(comment.clone()), "block")?;
             let (en_line, en_pos) = (st_line, Token::Comment(comment.clone()).width());
             let node = ASTNode::Comment { comment: comment.clone() };
             statements.push(ASTNodePos { st_line, st_pos, en_line, en_pos, node });
@@ -28,7 +28,7 @@ pub fn parse_statements(it: &mut TPIterator) -> ParseResult<Vec<ASTNodePos>> {
                 token_pos.token != Token::NL && token_pos.token != Token::Dedent
             };
             if it.peak_if_fn(&invalid) {
-                return Err(expected_construct("statement or expression", &token_pos.clone()));
+                return Err(expected(&Token::NL, &token_pos.clone(), "block"));
             }
             Ok(())
         }
@@ -38,7 +38,7 @@ pub fn parse_statements(it: &mut TPIterator) -> ParseResult<Vec<ASTNodePos>> {
 }
 
 pub fn parse_block(it: &mut TPIterator) -> ParseResult {
-    let (st_line, st_pos) = it.start_pos()?;
+    let (st_line, st_pos) = it.start_pos("block")?;
     it.eat(&Token::Indent, "block")?;
 
     let statements = it.parse_vec(&parse_statements)?;

--- a/src/parser/block.rs
+++ b/src/parser/block.rs
@@ -23,7 +23,7 @@ pub fn parse_statements(it: &mut TPIterator) -> ParseResult<Vec<ASTNodePos>> {
             Ok(())
         }
         _ => {
-            statements.push(*it.parse(&parse_expr_or_stmt)?);
+            statements.push(*it.parse(&parse_expr_or_stmt, "block")?);
             let invalid = |token_pos: &TokenPos| {
                 token_pos.token != Token::NL && token_pos.token != Token::Dedent
             };
@@ -41,7 +41,7 @@ pub fn parse_block(it: &mut TPIterator) -> ParseResult {
     let (st_line, st_pos) = it.start_pos("block")?;
     it.eat(&Token::Indent, "block")?;
 
-    let statements = it.parse_vec(&parse_statements)?;
+    let statements = it.parse_vec(&parse_statements, "block")?;
     let (en_line, en_pos) = match statements.last() {
         Some(stmt) => (stmt.en_line, stmt.en_pos),
         None => (st_line, st_pos)

--- a/src/parser/block.rs
+++ b/src/parser/block.rs
@@ -8,7 +8,9 @@ use crate::parser::parse_result::expected;
 use crate::parser::parse_result::ParseResult;
 
 pub fn parse_statements(it: &mut TPIterator) -> ParseResult<Vec<ASTNodePos>> {
+    let (st_line, st_pos) = it.start_pos("block")?;
     let mut statements: Vec<ASTNodePos> = Vec::new();
+
     it.peek_while_not_token(&Token::Dedent, &mut |it, token_pos| match &token_pos.token {
         Token::NL => {
             it.eat(&Token::NL, "block")?;
@@ -23,7 +25,7 @@ pub fn parse_statements(it: &mut TPIterator) -> ParseResult<Vec<ASTNodePos>> {
             Ok(())
         }
         _ => {
-            statements.push(*it.parse(&parse_expr_or_stmt, "block")?);
+            statements.push(*it.parse(&parse_expr_or_stmt, "block", st_line, st_pos)?);
             let invalid = |token_pos: &TokenPos| {
                 token_pos.token != Token::NL && token_pos.token != Token::Dedent
             };
@@ -41,7 +43,7 @@ pub fn parse_block(it: &mut TPIterator) -> ParseResult {
     let (st_line, st_pos) = it.start_pos("block")?;
     it.eat(&Token::Indent, "block")?;
 
-    let statements = it.parse_vec(&parse_statements, "block")?;
+    let statements = it.parse_vec(&parse_statements, "block", st_line, st_pos)?;
     let (en_line, en_pos) = match statements.last() {
         Some(stmt) => (stmt.en_line, stmt.en_pos),
         None => (st_line, st_pos)

--- a/src/parser/block.rs
+++ b/src/parser/block.rs
@@ -4,12 +4,12 @@ use crate::parser::ast::ASTNode;
 use crate::parser::ast::ASTNodePos;
 use crate::parser::expr_or_stmt::parse_expr_or_stmt;
 use crate::parser::iterator::TPIterator;
-use crate::parser::parse_result::ParseErr::CustomErr;
+use crate::parser::parse_result::expected_construct;
 use crate::parser::parse_result::ParseResult;
 
 pub fn parse_statements(it: &mut TPIterator) -> ParseResult<Vec<ASTNodePos>> {
     let mut statements: Vec<ASTNodePos> = Vec::new();
-    it.peek_while_not_token(&Token::Dedent, &mut |it, token_pos, _| match &token_pos.token {
+    it.peek_while_not_token(&Token::Dedent, &mut |it, token_pos| match &token_pos.token {
         Token::NL => {
             it.eat(&Token::NL, "statements")?;
             Ok(())
@@ -23,15 +23,12 @@ pub fn parse_statements(it: &mut TPIterator) -> ParseResult<Vec<ASTNodePos>> {
             Ok(())
         }
         _ => {
-            statements.push(*it.parse(&parse_expr_or_stmt, "block")?);
+            statements.push(*it.parse(&parse_expr_or_stmt)?);
             let invalid = |token_pos: &TokenPos| {
                 token_pos.token != Token::NL && token_pos.token != Token::Dedent
             };
             if it.peak_if_fn(&invalid) {
-                return Err(CustomErr {
-                    expected: String::from("statement or expression"),
-                    actual:   token_pos.clone()
-                });
+                return Err(expected_construct("statement or expression", &token_pos.clone()));
             }
             Ok(())
         }
@@ -44,7 +41,7 @@ pub fn parse_block(it: &mut TPIterator) -> ParseResult {
     let (st_line, st_pos) = it.start_pos()?;
     it.eat(&Token::Indent, "block")?;
 
-    let statements = it.parse_vec(&parse_statements, "block")?;
+    let statements = it.parse_vec(&parse_statements)?;
     let (en_line, en_pos) = match statements.last() {
         Some(stmt) => (stmt.en_line, stmt.en_pos),
         None => (st_line, st_pos)

--- a/src/parser/call.rs
+++ b/src/parser/call.rs
@@ -5,11 +5,11 @@ use crate::parser::ast::ASTNodePos;
 use crate::parser::expression::is_start_expression_exclude_unary;
 use crate::parser::expression::parse_expression;
 use crate::parser::iterator::TPIterator;
-use crate::parser::parse_result::expected_construct;
+use crate::parser::parse_result::expected_one_of;
 use crate::parser::parse_result::ParseResult;
 
 pub fn parse_reassignment(pre: &ASTNodePos, it: &mut TPIterator) -> ParseResult {
-    let (st_line, st_pos) = it.start_pos()?;
+    let (st_line, st_pos) = it.start_pos("reassignment")?;
     it.eat(&Token::Assign, "reassignment")?;
 
     let right = it.parse(&parse_expression)?;
@@ -20,7 +20,7 @@ pub fn parse_reassignment(pre: &ASTNodePos, it: &mut TPIterator) -> ParseResult 
 }
 
 pub fn parse_anon_fun(it: &mut TPIterator) -> ParseResult {
-    let (st_line, st_pos) = it.start_pos()?;
+    let (st_line, st_pos) = it.start_pos("anonymous function")?;
     it.eat(&Token::BSlash, "anonymous function")?;
 
     let mut args: Vec<ASTNodePos> = vec![];
@@ -66,8 +66,9 @@ pub fn parse_call(pre: &ASTNodePos, it: &mut TPIterator) -> ParseResult {
                 let node = ASTNode::FunctionCall { name: Box::from(pre.clone()), args: vec![*arg] };
                 Ok(Box::from(ASTNodePos { st_line, st_pos, en_line, en_pos, node }))
             }
-            _ => Err(expected_construct("function call", token_pos))
+            _ => Err(expected_one_of(&[Token::Point, Token::LRBrack], token_pos, "function call"))
         },
+        &[Token::Point, Token::LRBrack],
         "function call"
     )
 }

--- a/src/parser/call.rs
+++ b/src/parser/call.rs
@@ -12,7 +12,7 @@ pub fn parse_reassignment(pre: &ASTNodePos, it: &mut TPIterator) -> ParseResult 
     let (st_line, st_pos) = it.start_pos("reassignment")?;
     it.eat(&Token::Assign, "reassignment")?;
 
-    let right = it.parse(&parse_expression)?;
+    let right = it.parse(&parse_expression, "reassignment")?;
 
     let (en_line, en_pos) = (right.en_line, right.en_pos);
     let node = ASTNode::Reassign { left: Box::new(pre.clone()), right };
@@ -25,14 +25,14 @@ pub fn parse_anon_fun(it: &mut TPIterator) -> ParseResult {
 
     let mut args: Vec<ASTNodePos> = vec![];
     it.peek_while_not_token(&Token::BTo, &mut |it, _| {
-        args.push(*it.parse(&parse_id_maybe_type)?);
+        args.push(*it.parse(&parse_id_maybe_type, "anonymous function")?);
         it.eat_if(&Token::Comma);
         Ok(())
     })?;
 
     it.eat(&Token::BTo, "anonymous function")?;
 
-    let body = it.parse(&parse_expression)?;
+    let body = it.parse(&parse_expression, "anonymous function")?;
     let (en_line, en_pos) = (body.en_line, body.en_pos);
     let node = ASTNode::AnonFun { args, body };
     Ok(Box::from(ASTNodePos { st_line, st_pos, en_line, en_pos, node }))
@@ -45,7 +45,7 @@ pub fn parse_call(pre: &ASTNodePos, it: &mut TPIterator) -> ParseResult {
         &|it, token_pos| match token_pos.token {
             Token::Point => {
                 it.eat(&Token::Point, "call")?;
-                let property = it.parse(&parse_expression)?;
+                let property = it.parse(&parse_expression, "call")?;
                 let (en_line, en_pos) = (property.en_line, property.en_pos);
 
                 let node = ASTNode::PropertyCall { instance: Box::from(pre.clone()), property };
@@ -53,14 +53,14 @@ pub fn parse_call(pre: &ASTNodePos, it: &mut TPIterator) -> ParseResult {
             }
             Token::LRBrack => {
                 it.eat(&Token::LRBrack, "direct call")?;
-                let args = it.parse_vec(&parse_arguments)?;
+                let args = it.parse_vec(&parse_arguments, "direct call")?;
                 let (en_line, en_pos) = it.eat(&Token::RRBrack, "direct call")?;
 
                 let node = ASTNode::FunctionCall { name: Box::from(pre.clone()), args };
                 Ok(Box::from(ASTNodePos { st_line, st_pos, en_line, en_pos, node }))
             }
             _ if is_start_expression_exclude_unary(token_pos) => {
-                let arg = it.parse(&parse_expression)?;
+                let arg = it.parse(&parse_expression, "call")?;
                 let (en_line, en_pos) = (arg.en_line, arg.en_pos);
 
                 let node = ASTNode::FunctionCall { name: Box::from(pre.clone()), args: vec![*arg] };
@@ -76,7 +76,7 @@ pub fn parse_call(pre: &ASTNodePos, it: &mut TPIterator) -> ParseResult {
 fn parse_arguments(it: &mut TPIterator) -> ParseResult<Vec<ASTNodePos>> {
     let mut arguments = Vec::new();
     it.peek_while_not_token(&Token::RRBrack, &mut |it, _| {
-        arguments.push(*it.parse(&parse_expression)?);
+        arguments.push(*it.parse(&parse_expression, "arguments")?);
         it.eat_if(&Token::Comma);
         Ok(())
     })?;

--- a/src/parser/call.rs
+++ b/src/parser/call.rs
@@ -5,14 +5,14 @@ use crate::parser::ast::ASTNodePos;
 use crate::parser::expression::is_start_expression_exclude_unary;
 use crate::parser::expression::parse_expression;
 use crate::parser::iterator::TPIterator;
-use crate::parser::parse_result::ParseErr::*;
+use crate::parser::parse_result::expected_construct;
 use crate::parser::parse_result::ParseResult;
 
 pub fn parse_reassignment(pre: &ASTNodePos, it: &mut TPIterator) -> ParseResult {
     let (st_line, st_pos) = it.start_pos()?;
     it.eat(&Token::Assign, "reassignment")?;
 
-    let right = it.parse(&parse_expression, "reassignment")?;
+    let right = it.parse(&parse_expression)?;
 
     let (en_line, en_pos) = (right.en_line, right.en_pos);
     let node = ASTNode::Reassign { left: Box::new(pre.clone()), right };
@@ -24,19 +24,15 @@ pub fn parse_anon_fun(it: &mut TPIterator) -> ParseResult {
     it.eat(&Token::BSlash, "anonymous function")?;
 
     let mut args: Vec<ASTNodePos> = vec![];
-    it.peek_while_not_token(&Token::BTo, &mut |it, _, no| {
-        args.push(*it.parse(
-            &parse_id_maybe_type,
-            format!("anonymous function arg (pos {})", no).as_str()
-        )?);
-
+    it.peek_while_not_token(&Token::BTo, &mut |it, _| {
+        args.push(*it.parse(&parse_id_maybe_type)?);
         it.eat_if(&Token::Comma);
         Ok(())
     })?;
 
     it.eat(&Token::BTo, "anonymous function")?;
 
-    let body = it.parse(&parse_expression, "anonymous function body")?;
+    let body = it.parse(&parse_expression)?;
     let (en_line, en_pos) = (body.en_line, body.en_pos);
     let node = ASTNode::AnonFun { args, body };
     Ok(Box::from(ASTNodePos { st_line, st_pos, en_line, en_pos, node }))
@@ -49,7 +45,7 @@ pub fn parse_call(pre: &ASTNodePos, it: &mut TPIterator) -> ParseResult {
         &|it, token_pos| match token_pos.token {
             Token::Point => {
                 it.eat(&Token::Point, "call")?;
-                let property = it.parse(&parse_expression, "call")?;
+                let property = it.parse(&parse_expression)?;
                 let (en_line, en_pos) = (property.en_line, property.en_pos);
 
                 let node = ASTNode::PropertyCall { instance: Box::from(pre.clone()), property };
@@ -57,23 +53,20 @@ pub fn parse_call(pre: &ASTNodePos, it: &mut TPIterator) -> ParseResult {
             }
             Token::LRBrack => {
                 it.eat(&Token::LRBrack, "direct call")?;
-                let args = it.parse_vec(&parse_arguments, "arguments")?;
+                let args = it.parse_vec(&parse_arguments)?;
                 let (en_line, en_pos) = it.eat(&Token::RRBrack, "direct call")?;
 
                 let node = ASTNode::FunctionCall { name: Box::from(pre.clone()), args };
                 Ok(Box::from(ASTNodePos { st_line, st_pos, en_line, en_pos, node }))
             }
             _ if is_start_expression_exclude_unary(token_pos) => {
-                let arg = it.parse(&parse_expression, "call")?;
+                let arg = it.parse(&parse_expression)?;
                 let (en_line, en_pos) = (arg.en_line, arg.en_pos);
 
                 let node = ASTNode::FunctionCall { name: Box::from(pre.clone()), args: vec![*arg] };
                 Ok(Box::from(ASTNodePos { st_line, st_pos, en_line, en_pos, node }))
             }
-            _ => Err(CustomErr {
-                expected: String::from("function call"),
-                actual:   token_pos.clone()
-            })
+            _ => Err(expected_construct("function call", token_pos))
         },
         "function call"
     )
@@ -81,8 +74,8 @@ pub fn parse_call(pre: &ASTNodePos, it: &mut TPIterator) -> ParseResult {
 
 fn parse_arguments(it: &mut TPIterator) -> ParseResult<Vec<ASTNodePos>> {
     let mut arguments = Vec::new();
-    it.peek_while_not_token(&Token::RRBrack, &mut |it, _, no| {
-        arguments.push(*it.parse(&parse_expression, format!("argument {}", no).as_str())?);
+    it.peek_while_not_token(&Token::RRBrack, &mut |it, _| {
+        arguments.push(*it.parse(&parse_expression)?);
         it.eat_if(&Token::Comma);
         Ok(())
     })?;

--- a/src/parser/class.rs
+++ b/src/parser/class.rs
@@ -8,52 +8,42 @@ use crate::parser::block::parse_block;
 use crate::parser::definition::parse_fun_arg;
 use crate::parser::expression::parse_expression;
 use crate::parser::iterator::TPIterator;
-use crate::parser::parse_result::ParseErr::*;
+use crate::parser::parse_result::expected;
 use crate::parser::parse_result::ParseResult;
 
 pub fn parse_class(it: &mut TPIterator) -> ParseResult {
     let (st_line, st_pos) = it.start_pos()?;
     it.eat(&Token::Class, "class")?;
-    let _type = it.parse(&parse_type, "name")?;
+    let _type = it.parse(&parse_type)?;
 
     let mut args = vec![];
     if it.eat_if(&Token::LRBrack).is_some() {
-        it.peek_while_not_token(&Token::RRBrack, &mut |it, token_pos, no| match token_pos.token {
+        it.peek_while_not_token(&Token::RRBrack, &mut |it, token_pos| match token_pos.token {
             Token::Def => {
-                it.eat(&Token::Def, format!("constructor argument {}", no).as_str())?;
-                args.push(
-                    *it.parse(&parse_fun_arg, format!("constructor argument {}", no).as_str())?
-                );
+                it.eat(&Token::Def, "constructor argument")?;
+                args.push(*it.parse(&parse_fun_arg)?);
                 it.eat_if(&Token::Comma);
                 Ok(())
             }
-            _ => Err(TokenErr {
-                expected: Token::Def,
-                actual:   token_pos.clone(),
-                message:  String::from("class")
-            })
+            _ => Err(expected(&Token::Def, &token_pos.clone(), "class"))
         })?;
         it.eat(&Token::RRBrack, "class arguments")?;
     }
 
     let mut parents = vec![];
     if it.eat_if(&Token::IsA).is_some() {
-        it.peek_while_not_token(&Token::NL, &mut |it, token_pos, no| match token_pos.token {
+        it.peek_while_not_token(&Token::NL, &mut |it, token_pos| match token_pos.token {
             Token::Id(_) => {
-                parents.push(*it.parse(&parse_parent, format!("parent {}", no).as_str())?);
+                parents.push(*it.parse(&parse_parent)?);
                 it.eat_if(&Token::Comma);
                 Ok(())
             }
-            _ => Err(TokenErr {
-                expected: Token::Id(String::new()),
-                actual:   token_pos.clone(),
-                message:  format!("parent {}", no)
-            })
+            _ => Err(expected(&Token::Id(String::new()), &token_pos.clone(), "parent"))
         })?;
     }
 
     it.eat(&Token::NL, "class")?;
-    let body = it.parse(&parse_block, "class body")?;
+    let body = it.parse(&parse_block)?;
     let (en_line, en_pos) = (body.en_line, body.en_pos);
     let node = ASTNode::Class { _type, args, parents, body };
     Ok(Box::from(ASTNodePos { st_line, st_pos, en_line, en_pos, node }))
@@ -62,13 +52,13 @@ pub fn parse_class(it: &mut TPIterator) -> ParseResult {
 pub fn parse_parent(it: &mut TPIterator) -> ParseResult {
     let (st_line, st_pos) = it.start_pos()?;
 
-    let id = it.parse(&parse_id, "parent id")?;
+    let id = it.parse(&parse_id)?;
     let generics = it.parse_vec_if(&Token::LSBrack, &parse_generics, "parent generics")?;
     it.eat_if(&Token::RSBrack);
     let mut args = vec![];
     if it.eat_if(&Token::LRBrack).is_some() {
-        it.peek_while_not_token(&Token::RRBrack, &mut |it, _, no| {
-            args.push(*it.parse(&parse_expression, format!("parent argument {}", no).as_str())?);
+        it.peek_while_not_token(&Token::RRBrack, &mut |it, _| {
+            args.push(*it.parse(&parse_expression)?);
             it.eat_if(&Token::Comma);
             Ok(())
         })?;

--- a/src/parser/class.rs
+++ b/src/parser/class.rs
@@ -12,7 +12,7 @@ use crate::parser::parse_result::expected;
 use crate::parser::parse_result::ParseResult;
 
 pub fn parse_class(it: &mut TPIterator) -> ParseResult {
-    let (st_line, st_pos) = it.start_pos()?;
+    let (st_line, st_pos) = it.start_pos("class")?;
     it.eat(&Token::Class, "class")?;
     let _type = it.parse(&parse_type)?;
 
@@ -50,7 +50,7 @@ pub fn parse_class(it: &mut TPIterator) -> ParseResult {
 }
 
 pub fn parse_parent(it: &mut TPIterator) -> ParseResult {
-    let (st_line, st_pos) = it.start_pos()?;
+    let (st_line, st_pos) = it.start_pos("parent")?;
 
     let id = it.parse(&parse_id)?;
     let generics = it.parse_vec_if(&Token::LSBrack, &parse_generics, "parent generics")?;

--- a/src/parser/collection.rs
+++ b/src/parser/collection.rs
@@ -4,7 +4,7 @@ use crate::parser::ast::ASTNodePos;
 use crate::parser::expression::is_start_expression;
 use crate::parser::expression::parse_expression;
 use crate::parser::iterator::TPIterator;
-use crate::parser::parse_result::ParseErr::*;
+use crate::parser::parse_result::expected_construct;
 use crate::parser::parse_result::ParseResult;
 
 pub fn parse_collection(it: &mut TPIterator) -> ParseResult {
@@ -13,7 +13,7 @@ pub fn parse_collection(it: &mut TPIterator) -> ParseResult {
             Token::LRBrack => parse_tuple(it),
             Token::LSBrack => parse_list(it),
             Token::LCBrack => parse_set(it),
-            _ => Err(CustomErr { expected: "collection".to_string(), actual: token_pos.clone() })
+            _ => Err(expected_construct("collection", token_pos))
         },
         "collection"
     )
@@ -23,7 +23,7 @@ pub fn parse_tuple(it: &mut TPIterator) -> ParseResult {
     let (st_line, st_pos) = it.start_pos()?;
     it.eat(&Token::LRBrack, "tuple")?;
 
-    let elements = it.parse_vec(&parse_expressions, "tuple")?;
+    let elements = it.parse_vec(&parse_expressions)?;
     let (en_line, en_pos) = it.eat(&Token::RRBrack, "tuple")?;
 
     Ok(Box::from(if elements.len() == 1 {
@@ -42,9 +42,9 @@ fn parse_set(it: &mut TPIterator) -> ParseResult {
         return Ok(Box::from(ASTNodePos { st_line, st_pos, en_line, en_pos, node }));
     }
 
-    let item = it.parse(&parse_expression, "set")?;
+    let item = it.parse(&parse_expression)?;
     if it.eat_if(&Token::Ver).is_some() {
-        let conditions = it.parse_vec(&parse_expressions, "set conditions")?;
+        let conditions = it.parse_vec(&parse_expressions)?;
         let (en_line, en_pos) = it.eat(&Token::RCBrack, "set")?;
         let node = ASTNode::SetBuilder { item, conditions };
         return Ok(Box::from(ASTNodePos { st_line, st_pos, en_line, en_pos, node }));
@@ -67,9 +67,9 @@ fn parse_list(it: &mut TPIterator) -> ParseResult {
         return Ok(Box::from(ASTNodePos { st_line, st_pos, en_line, en_pos, node }));
     }
 
-    let item = it.parse(&parse_expression, "list")?;
+    let item = it.parse(&parse_expression)?;
     if it.eat_if(&Token::Ver).is_some() {
-        let conditions = it.parse_vec(&parse_expressions, "list conditions")?;
+        let conditions = it.parse_vec(&parse_expressions)?;
         let (en_line, en_pos) = it.eat(&Token::RSBrack, "list")?;
         let node = ASTNode::ListBuilder { item, conditions };
         return Ok(Box::from(ASTNodePos { st_line, st_pos, en_line, en_pos, node }));
@@ -85,8 +85,8 @@ fn parse_list(it: &mut TPIterator) -> ParseResult {
 
 pub fn parse_expressions(it: &mut TPIterator) -> ParseResult<Vec<ASTNodePos>> {
     let mut expressions = vec![];
-    it.peek_while_fn(&is_start_expression, &mut |it, _, no| {
-        expressions.push(*it.parse(&parse_expression, format!("expression {}", no).as_str())?);
+    it.peek_while_fn(&is_start_expression, &mut |it, _| {
+        expressions.push(*it.parse(&parse_expression)?);
         it.eat_if(&Token::Comma);
         Ok(())
     })?;

--- a/src/parser/collection.rs
+++ b/src/parser/collection.rs
@@ -4,7 +4,7 @@ use crate::parser::ast::ASTNodePos;
 use crate::parser::expression::is_start_expression;
 use crate::parser::expression::parse_expression;
 use crate::parser::iterator::TPIterator;
-use crate::parser::parse_result::expected_construct;
+use crate::parser::parse_result::expected_one_of;
 use crate::parser::parse_result::ParseResult;
 
 pub fn parse_collection(it: &mut TPIterator) -> ParseResult {
@@ -13,14 +13,19 @@ pub fn parse_collection(it: &mut TPIterator) -> ParseResult {
             Token::LRBrack => parse_tuple(it),
             Token::LSBrack => parse_list(it),
             Token::LCBrack => parse_set(it),
-            _ => Err(expected_construct("collection", token_pos))
+            _ => Err(expected_one_of(
+                &[Token::LRBrack, Token::LSBrack, Token::LCBrack],
+                token_pos,
+                "collection"
+            ))
         },
+        &[Token::LRBrack, Token::LSBrack, Token::LCBrack],
         "collection"
     )
 }
 
 pub fn parse_tuple(it: &mut TPIterator) -> ParseResult {
-    let (st_line, st_pos) = it.start_pos()?;
+    let (st_line, st_pos) = it.start_pos("tuple")?;
     it.eat(&Token::LRBrack, "tuple")?;
 
     let elements = it.parse_vec(&parse_expressions)?;
@@ -34,7 +39,7 @@ pub fn parse_tuple(it: &mut TPIterator) -> ParseResult {
 }
 
 fn parse_set(it: &mut TPIterator) -> ParseResult {
-    let (st_line, st_pos) = it.start_pos()?;
+    let (st_line, st_pos) = it.start_pos("set")?;
     it.eat(&Token::LCBrack, "set")?;
 
     if let Some((en_line, en_pos)) = it.eat_if(&Token::RCBrack) {
@@ -59,7 +64,7 @@ fn parse_set(it: &mut TPIterator) -> ParseResult {
 }
 
 fn parse_list(it: &mut TPIterator) -> ParseResult {
-    let (st_line, st_pos) = it.start_pos()?;
+    let (st_line, st_pos) = it.start_pos("list")?;
     it.eat(&Token::LSBrack, "list")?;
 
     if let Some((en_line, en_pos)) = it.eat_if(&Token::RSBrack) {

--- a/src/parser/collection.rs
+++ b/src/parser/collection.rs
@@ -28,7 +28,7 @@ pub fn parse_tuple(it: &mut TPIterator) -> ParseResult {
     let (st_line, st_pos) = it.start_pos("tuple")?;
     it.eat(&Token::LRBrack, "tuple")?;
 
-    let elements = it.parse_vec(&parse_expressions)?;
+    let elements = it.parse_vec(&parse_expressions, "tuple")?;
     let (en_line, en_pos) = it.eat(&Token::RRBrack, "tuple")?;
 
     Ok(Box::from(if elements.len() == 1 {
@@ -47,9 +47,9 @@ fn parse_set(it: &mut TPIterator) -> ParseResult {
         return Ok(Box::from(ASTNodePos { st_line, st_pos, en_line, en_pos, node }));
     }
 
-    let item = it.parse(&parse_expression)?;
+    let item = it.parse(&parse_expression, "set")?;
     if it.eat_if(&Token::Ver).is_some() {
-        let conditions = it.parse_vec(&parse_expressions)?;
+        let conditions = it.parse_vec(&parse_expressions, "set")?;
         let (en_line, en_pos) = it.eat(&Token::RCBrack, "set")?;
         let node = ASTNode::SetBuilder { item, conditions };
         return Ok(Box::from(ASTNodePos { st_line, st_pos, en_line, en_pos, node }));
@@ -72,9 +72,9 @@ fn parse_list(it: &mut TPIterator) -> ParseResult {
         return Ok(Box::from(ASTNodePos { st_line, st_pos, en_line, en_pos, node }));
     }
 
-    let item = it.parse(&parse_expression)?;
+    let item = it.parse(&parse_expression, "list")?;
     if it.eat_if(&Token::Ver).is_some() {
-        let conditions = it.parse_vec(&parse_expressions)?;
+        let conditions = it.parse_vec(&parse_expressions, "list")?;
         let (en_line, en_pos) = it.eat(&Token::RSBrack, "list")?;
         let node = ASTNode::ListBuilder { item, conditions };
         return Ok(Box::from(ASTNodePos { st_line, st_pos, en_line, en_pos, node }));
@@ -91,7 +91,7 @@ fn parse_list(it: &mut TPIterator) -> ParseResult {
 pub fn parse_expressions(it: &mut TPIterator) -> ParseResult<Vec<ASTNodePos>> {
     let mut expressions = vec![];
     it.peek_while_fn(&is_start_expression, &mut |it, _| {
-        expressions.push(*it.parse(&parse_expression)?);
+        expressions.push(*it.parse(&parse_expression, "expressions")?);
         it.eat_if(&Token::Comma);
         Ok(())
     })?;

--- a/src/parser/control_flow_expr.rs
+++ b/src/parser/control_flow_expr.rs
@@ -28,10 +28,11 @@ fn parse_if(it: &mut TPIterator) -> ParseResult {
     let (st_line, st_pos) = it.start_pos("if expression")?;
 
     it.eat(&Token::If, "if expressions")?;
-    let cond = it.parse(&parse_expression, "if expression")?;
+    let cond = it.parse(&parse_expression, "if expression", st_line, st_pos)?;
     it.eat(&Token::Then, "if expression")?;
-    let then = it.parse(&parse_expr_or_stmt, "if expression")?;
-    let _else = it.parse_if(&Token::Else, &parse_expr_or_stmt, "if else branch")?;
+    let then = it.parse(&parse_expr_or_stmt, "if expression", st_line, st_pos)?;
+    let _else =
+        it.parse_if(&Token::Else, &parse_expr_or_stmt, "if else branch", st_line, st_pos)?;
 
     let (en_line, en_pos) = (then.en_line, then.en_pos);
     let node = ASTNode::IfElse { cond, then, _else };
@@ -42,9 +43,9 @@ fn parse_match(it: &mut TPIterator) -> ParseResult {
     let (st_line, st_pos) = it.start_pos("match")?;
     it.eat(&Token::Match, "match")?;
 
-    let cond = it.parse(&parse_expression, "match")?;
+    let cond = it.parse(&parse_expression, "match", st_line, st_pos)?;
     it.eat(&Token::NL, "match")?;
-    let cases = it.parse_vec(&parse_match_cases, "match")?;
+    let cases = it.parse_vec(&parse_match_cases, "match", st_line, st_pos)?;
 
     let (en_line, en_pos) = match (&cond, cases.last()) {
         (_, Some(ast_node_pos)) => (ast_node_pos.en_line, ast_node_pos.en_pos),
@@ -56,11 +57,11 @@ fn parse_match(it: &mut TPIterator) -> ParseResult {
 }
 
 pub fn parse_match_cases(it: &mut TPIterator) -> ParseResult<Vec<ASTNodePos>> {
-    it.eat(&Token::Indent, "match cases")?;
-
+    let (st_line, st_pos) = it.eat(&Token::Indent, "match cases")?;
     let mut cases = Vec::new();
+
     it.peek_while_not_token(&Token::Dedent, &mut |it, _| {
-        cases.push(*it.parse(&parse_match_case, "match cases")?);
+        cases.push(*it.parse(&parse_match_case, "match cases", st_line, st_pos)?);
         it.eat_if(&Token::NL);
         Ok(())
     })?;
@@ -72,9 +73,9 @@ pub fn parse_match_cases(it: &mut TPIterator) -> ParseResult<Vec<ASTNodePos>> {
 fn parse_match_case(it: &mut TPIterator) -> ParseResult {
     let (st_line, st_pos) = it.start_pos("match case")?;
 
-    let cond = it.parse(&parse_expression_maybe_type, "match case")?;
+    let cond = it.parse(&parse_expression_maybe_type, "match case", st_line, st_pos)?;
     it.eat(&Token::BTo, "match case")?;
-    let body = it.parse(&parse_expr_or_stmt, "match case")?;
+    let body = it.parse(&parse_expr_or_stmt, "match case", st_line, st_pos)?;
 
     let (en_line, en_pos) = (body.en_line, body.en_pos);
     let node = ASTNode::Case { cond, body };
@@ -85,8 +86,8 @@ pub fn parse_expression_maybe_type(it: &mut TPIterator) -> ParseResult {
     let (st_line, st_pos) = it.start_pos("expression maybe type")?;
     let mutable = it.eat_if(&Token::Mut).is_some();
 
-    let id = it.parse(&parse_expression, "expression maybe type")?;
-    let _type = it.parse_if(&Token::DoublePoint, &parse_type, "id type")?;
+    let id = it.parse(&parse_expression, "expression maybe type", st_line, st_pos)?;
+    let _type = it.parse_if(&Token::DoublePoint, &parse_type, "id type", st_line, st_pos)?;
 
     let (en_line, en_pos) = match &_type {
         Some(_type) => (_type.en_line, _type.en_pos),

--- a/src/parser/control_flow_expr.rs
+++ b/src/parser/control_flow_expr.rs
@@ -5,7 +5,7 @@ use crate::parser::ast::ASTNodePos;
 use crate::parser::expr_or_stmt::parse_expr_or_stmt;
 use crate::parser::expression::parse_expression;
 use crate::parser::iterator::TPIterator;
-use crate::parser::parse_result::ParseErr::*;
+use crate::parser::parse_result::expected_construct;
 use crate::parser::parse_result::ParseResult;
 
 pub fn parse_cntrl_flow_expr(it: &mut TPIterator) -> ParseResult {
@@ -13,10 +13,7 @@ pub fn parse_cntrl_flow_expr(it: &mut TPIterator) -> ParseResult {
         &|it, token_pos| match token_pos.token {
             Token::If => parse_if(it),
             Token::Match => parse_match(it),
-            _ => Err(CustomErr {
-                expected: "control flow expression".to_string(),
-                actual:   token_pos.clone()
-            })
+            _ => Err(expected_construct("control flow expression", token_pos))
         },
         "control flow expression"
     )
@@ -26,9 +23,9 @@ fn parse_if(it: &mut TPIterator) -> ParseResult {
     let (st_line, st_pos) = it.start_pos()?;
 
     it.eat(&Token::If, "if")?;
-    let cond = it.parse(&parse_expression, "if condition")?;
+    let cond = it.parse(&parse_expression)?;
     it.eat(&Token::Then, "if")?;
-    let then = it.parse(&parse_expr_or_stmt, "if then branch")?;
+    let then = it.parse(&parse_expr_or_stmt)?;
     let _else = it.parse_if(&Token::Else, &parse_expr_or_stmt, "if else branch")?;
 
     let (en_line, en_pos) = (then.en_line, then.en_pos);
@@ -40,9 +37,9 @@ fn parse_match(it: &mut TPIterator) -> ParseResult {
     let (st_line, st_pos) = it.start_pos()?;
     it.eat(&Token::Match, "match")?;
 
-    let cond = it.parse(&parse_expression, "match expression")?;
+    let cond = it.parse(&parse_expression)?;
     it.eat(&Token::NL, "match")?;
-    let cases = it.parse_vec(&parse_match_cases, "match cases")?;
+    let cases = it.parse_vec(&parse_match_cases)?;
 
     let (en_line, en_pos) = match (&cond, cases.last()) {
         (_, Some(ast_node_pos)) => (ast_node_pos.en_line, ast_node_pos.en_pos),
@@ -57,8 +54,8 @@ pub fn parse_match_cases(it: &mut TPIterator) -> ParseResult<Vec<ASTNodePos>> {
     it.eat(&Token::Indent, "match case")?;
 
     let mut cases = Vec::new();
-    it.peek_while_not_token(&Token::Dedent, &mut |it, _, no| {
-        cases.push(*it.parse(&parse_match_case, format!("match case {}", no).as_str())?);
+    it.peek_while_not_token(&Token::Dedent, &mut |it, _| {
+        cases.push(*it.parse(&parse_match_case)?);
         it.eat_if(&Token::NL);
         Ok(())
     })?;
@@ -70,9 +67,9 @@ pub fn parse_match_cases(it: &mut TPIterator) -> ParseResult<Vec<ASTNodePos>> {
 fn parse_match_case(it: &mut TPIterator) -> ParseResult {
     let (st_line, st_pos) = it.start_pos()?;
 
-    let cond = it.parse(&parse_expression_maybe_type, "match case")?;
+    let cond = it.parse(&parse_expression_maybe_type)?;
     it.eat(&Token::BTo, "match case")?;
-    let body = it.parse(&parse_expr_or_stmt, "then")?;
+    let body = it.parse(&parse_expr_or_stmt)?;
 
     let (en_line, en_pos) = (body.en_line, body.en_pos);
     let node = ASTNode::Case { cond, body };
@@ -83,7 +80,7 @@ pub fn parse_expression_maybe_type(it: &mut TPIterator) -> ParseResult {
     let (st_line, st_pos) = it.start_pos()?;
     let mutable = it.eat_if(&Token::Mut).is_some();
 
-    let id = it.parse(&parse_expression, "id maybe type")?;
+    let id = it.parse(&parse_expression)?;
     let _type = it.parse_if(&Token::DoublePoint, &parse_type, "id type")?;
 
     let (en_line, en_pos) = match &_type {

--- a/src/parser/control_flow_expr.rs
+++ b/src/parser/control_flow_expr.rs
@@ -61,7 +61,7 @@ pub fn parse_match_cases(it: &mut TPIterator) -> ParseResult<Vec<ASTNodePos>> {
     let mut cases = Vec::new();
 
     it.peek_while_not_token(&Token::Dedent, &mut |it, _| {
-        cases.push(*it.parse(&parse_match_case, "match cases", st_line, st_pos)?);
+        cases.push(*it.parse(&parse_match_case, "match case", st_line, st_pos)?);
         it.eat_if(&Token::NL);
         Ok(())
     })?;

--- a/src/parser/control_flow_stmt.rs
+++ b/src/parser/control_flow_stmt.rs
@@ -37,9 +37,9 @@ pub fn parse_cntrl_flow_stmt(it: &mut TPIterator) -> ParseResult {
 fn parse_while(it: &mut TPIterator) -> ParseResult {
     let (st_line, st_pos) = it.start_pos("while statement")?;
     it.eat(&Token::While, "while statement")?;
-    let cond = it.parse(&parse_expression, "while statement")?;
+    let cond = it.parse(&parse_expression, "while statement", st_line, st_pos)?;
     it.eat(&Token::Do, "while")?;
-    let body = it.parse(&parse_expr_or_stmt, "while statement")?;
+    let body = it.parse(&parse_expr_or_stmt, "while statement", st_line, st_pos)?;
 
     let (en_line, en_pos) = (body.en_line, body.en_pos);
     let node = ASTNode::While { cond, body };
@@ -49,9 +49,9 @@ fn parse_while(it: &mut TPIterator) -> ParseResult {
 fn parse_for(it: &mut TPIterator) -> ParseResult {
     let (st_line, st_pos) = it.start_pos("for statement")?;
     it.eat(&Token::For, "for statement")?;
-    let expr = it.parse(&parse_expression, "for statement")?;
+    let expr = it.parse(&parse_expression, "for statement", st_line, st_pos)?;
     it.eat(&Token::Do, "for statement")?;
-    let body = it.parse(&parse_expr_or_stmt, "for statement")?;
+    let body = it.parse(&parse_expr_or_stmt, "for statement", st_line, st_pos)?;
 
     let (en_line, en_pos) = (body.en_line, body.en_pos);
     let node = ASTNode::For { expr, body };

--- a/src/parser/control_flow_stmt.rs
+++ b/src/parser/control_flow_stmt.rs
@@ -35,11 +35,11 @@ pub fn parse_cntrl_flow_stmt(it: &mut TPIterator) -> ParseResult {
 }
 
 fn parse_while(it: &mut TPIterator) -> ParseResult {
-    let (st_line, st_pos) = it.start_pos("while")?;
-    it.eat(&Token::While, "while")?;
-    let cond = it.parse(&parse_expression)?;
+    let (st_line, st_pos) = it.start_pos("while statement")?;
+    it.eat(&Token::While, "while statement")?;
+    let cond = it.parse(&parse_expression, "while statement")?;
     it.eat(&Token::Do, "while")?;
-    let body = it.parse(&parse_expr_or_stmt)?;
+    let body = it.parse(&parse_expr_or_stmt, "while statement")?;
 
     let (en_line, en_pos) = (body.en_line, body.en_pos);
     let node = ASTNode::While { cond, body };
@@ -47,11 +47,11 @@ fn parse_while(it: &mut TPIterator) -> ParseResult {
 }
 
 fn parse_for(it: &mut TPIterator) -> ParseResult {
-    let (st_line, st_pos) = it.start_pos("for")?;
-    it.eat(&Token::For, "for")?;
-    let expr = it.parse(&parse_expression)?;
-    it.eat(&Token::Do, "for")?;
-    let body = it.parse(&parse_expr_or_stmt)?;
+    let (st_line, st_pos) = it.start_pos("for statement")?;
+    it.eat(&Token::For, "for statement")?;
+    let expr = it.parse(&parse_expression, "for statement")?;
+    it.eat(&Token::Do, "for statement")?;
+    let body = it.parse(&parse_expr_or_stmt, "for statement")?;
 
     let (en_line, en_pos) = (body.en_line, body.en_pos);
     let node = ASTNode::For { expr, body };

--- a/src/parser/control_flow_stmt.rs
+++ b/src/parser/control_flow_stmt.rs
@@ -1,37 +1,41 @@
 use crate::lexer::token::Token;
-use crate::lexer::token::TokenPos;
 use crate::parser::ast::ASTNode;
 use crate::parser::ast::ASTNodePos;
 use crate::parser::expr_or_stmt::parse_expr_or_stmt;
 use crate::parser::expression::parse_expression;
 use crate::parser::iterator::TPIterator;
-use crate::parser::parse_result::expected_construct;
+use crate::parser::parse_result::expected_one_of;
 use crate::parser::parse_result::ParseResult;
 
 pub fn parse_cntrl_flow_stmt(it: &mut TPIterator) -> ParseResult {
     it.peek_or_err(
-        &|it, token_pos| match token_pos {
-            TokenPos { token: Token::While, .. } => parse_while(it),
-            TokenPos { token: Token::For, .. } => parse_for(it),
-            TokenPos { token: Token::Break, st_line, st_pos } => {
-                let (st_line, st_pos) = (*st_line, *st_pos);
+        &|it, token_pos| match token_pos.token {
+            Token::While => parse_while(it),
+            Token::For => parse_for(it),
+            Token::Break => {
+                let (st_line, st_pos) = (token_pos.st_line, token_pos.st_pos);
                 let (en_line, en_pos) = it.eat(&Token::Break, "control flow statement")?;
                 Ok(Box::from(ASTNodePos { st_line, st_pos, en_line, en_pos, node: ASTNode::Break }))
             }
-            TokenPos { token: Token::Continue, st_line, st_pos } => {
-                let (st_line, st_pos) = (*st_line, *st_pos);
+            Token::Continue => {
+                let (st_line, st_pos) = (token_pos.st_line, token_pos.st_pos);
                 let (en_line, en_pos) = it.eat(&Token::Continue, "control flow statement")?;
                 let node = ASTNode::Continue;
                 Ok(Box::from(ASTNodePos { st_line, st_pos, en_line, en_pos, node }))
             }
-            _ => Err(expected_construct("control flow statement", token_pos))
+            _ => Err(expected_one_of(
+                &[Token::While, Token::For, Token::Break, Token::Continue],
+                token_pos,
+                "control flow statement"
+            ))
         },
+        &[Token::While, Token::For, Token::Break, Token::Continue],
         "control flow statement"
     )
 }
 
 fn parse_while(it: &mut TPIterator) -> ParseResult {
-    let (st_line, st_pos) = it.start_pos()?;
+    let (st_line, st_pos) = it.start_pos("while")?;
     it.eat(&Token::While, "while")?;
     let cond = it.parse(&parse_expression)?;
     it.eat(&Token::Do, "while")?;
@@ -43,7 +47,7 @@ fn parse_while(it: &mut TPIterator) -> ParseResult {
 }
 
 fn parse_for(it: &mut TPIterator) -> ParseResult {
-    let (st_line, st_pos) = it.start_pos()?;
+    let (st_line, st_pos) = it.start_pos("for")?;
     it.eat(&Token::For, "for")?;
     let expr = it.parse(&parse_expression)?;
     it.eat(&Token::Do, "for")?;

--- a/src/parser/control_flow_stmt.rs
+++ b/src/parser/control_flow_stmt.rs
@@ -5,7 +5,7 @@ use crate::parser::ast::ASTNodePos;
 use crate::parser::expr_or_stmt::parse_expr_or_stmt;
 use crate::parser::expression::parse_expression;
 use crate::parser::iterator::TPIterator;
-use crate::parser::parse_result::ParseErr::*;
+use crate::parser::parse_result::expected_construct;
 use crate::parser::parse_result::ParseResult;
 
 pub fn parse_cntrl_flow_stmt(it: &mut TPIterator) -> ParseResult {
@@ -24,10 +24,7 @@ pub fn parse_cntrl_flow_stmt(it: &mut TPIterator) -> ParseResult {
                 let node = ASTNode::Continue;
                 Ok(Box::from(ASTNodePos { st_line, st_pos, en_line, en_pos, node }))
             }
-            _ => Err(CustomErr {
-                expected: "control flow statement".to_string(),
-                actual:   token_pos.clone()
-            })
+            _ => Err(expected_construct("control flow statement", token_pos))
         },
         "control flow statement"
     )
@@ -36,9 +33,9 @@ pub fn parse_cntrl_flow_stmt(it: &mut TPIterator) -> ParseResult {
 fn parse_while(it: &mut TPIterator) -> ParseResult {
     let (st_line, st_pos) = it.start_pos()?;
     it.eat(&Token::While, "while")?;
-    let cond = it.parse(&parse_expression, "while condition")?;
+    let cond = it.parse(&parse_expression)?;
     it.eat(&Token::Do, "while")?;
-    let body = it.parse(&parse_expr_or_stmt, "while body")?;
+    let body = it.parse(&parse_expr_or_stmt)?;
 
     let (en_line, en_pos) = (body.en_line, body.en_pos);
     let node = ASTNode::While { cond, body };
@@ -48,9 +45,9 @@ fn parse_while(it: &mut TPIterator) -> ParseResult {
 fn parse_for(it: &mut TPIterator) -> ParseResult {
     let (st_line, st_pos) = it.start_pos()?;
     it.eat(&Token::For, "for")?;
-    let expr = it.parse(&parse_expression, "for expression")?;
+    let expr = it.parse(&parse_expression)?;
     it.eat(&Token::Do, "for")?;
-    let body = it.parse(&parse_expr_or_stmt, "for body")?;
+    let body = it.parse(&parse_expr_or_stmt)?;
 
     let (en_line, en_pos) = (body.en_line, body.en_pos);
     let node = ASTNode::For { expr, body };

--- a/src/parser/definition.rs
+++ b/src/parser/definition.rs
@@ -13,7 +13,7 @@ use crate::parser::parse_result::custom;
 use crate::parser::parse_result::ParseResult;
 
 pub fn parse_definition(it: &mut TPIterator) -> ParseResult {
-    let (st_line, st_pos) = it.start_pos()?;
+    let (st_line, st_pos) = it.start_pos("definition")?;
     it.eat(&Token::Def, "definition")?;
     let private = it.eat_if(&Token::Private).is_some();
     let pure = it.eat_if(&Token::Pure).is_some();
@@ -47,6 +47,23 @@ pub fn parse_definition(it: &mut TPIterator) -> ParseResult {
                 Token::Le => op!(it, Le, LeOp),
                 _ => parse_var_or_fun_def(it)
             },
+            &[
+                Token::Id(String::new()),
+                Token::LRBrack,
+                Token::LCBrack,
+                Token::LSBrack,
+                Token::Add,
+                Token::Sub,
+                Token::Sqrt,
+                Token::Mul,
+                Token::FDiv,
+                Token::Div,
+                Token::Pow,
+                Token::Mod,
+                Token::Eq,
+                Token::Ge,
+                Token::Le
+            ],
             "definition"
         )
     }?;
@@ -96,7 +113,7 @@ fn parse_var_or_fun_def(it: &mut TPIterator) -> ParseResult {
 }
 
 fn parse_fun_def(id_type: &ASTNodePos, pure: bool, it: &mut TPIterator) -> ParseResult {
-    let (st_line, st_pos) = it.start_pos()?;
+    let (st_line, st_pos) = it.start_pos("function definition")?;
     let fun_args = it.parse_vec(&parse_fun_args)?;
 
     let id = match id_type {
@@ -173,11 +190,11 @@ pub fn parse_fun_args(it: &mut TPIterator) -> ParseResult<Vec<ASTNodePos>> {
 }
 
 pub fn parse_fun_arg(it: &mut TPIterator) -> ParseResult {
-    let (st_line, st_pos) = it.start_pos()?;
+    let (st_line, st_pos) = it.start_pos("function argument")?;
     let vararg = it.eat_if(&Token::Vararg).is_some();
 
     let id_maybe_type = it.parse(&parse_id_maybe_type)?;
-    let default = it.parse_if(&Token::Assign, &parse_expression, "argument default")?;
+    let default = it.parse_if(&Token::Assign, &parse_expression, "function argument default")?;
 
     let (en_line, en_pos) = match &default {
         Some(ast_node_pos) => (ast_node_pos.en_line, ast_node_pos.en_pos),
@@ -221,8 +238,8 @@ fn parse_variable_def(it: &mut TPIterator) -> ParseResult {
             Token::LRBrack | Token::LCBrack | Token::LSBrack => it.parse(&parse_collection),
             _ => it.parse(&parse_id_maybe_type)
         },
+        &[Token::LRBrack, Token::LCBrack, Token::LSBrack],
         "variable definition"
     )?;
-
     parse_variable_def_id(&id, it)
 }

--- a/src/parser/expr_or_stmt.rs
+++ b/src/parser/expr_or_stmt.rs
@@ -15,7 +15,12 @@ pub fn parse_expr_or_stmt(it: &mut TPIterator) -> ParseResult {
         &|it, token_pos| match &token_pos.token {
             Token::NL => {
                 it.eat(&Token::NL, "expression or statement")?;
-                it.parse(&parse_block, "expression or statement")
+                it.parse(
+                    &parse_block,
+                    "expression or statement",
+                    token_pos.st_line,
+                    token_pos.st_pos
+                )
             }
             token =>
                 if is_start_statement(token) {
@@ -43,7 +48,7 @@ pub fn parse_raise(expr_or_stmt: ASTNodePos, it: &mut TPIterator) -> ParseResult
     it.eat(&Token::Raises, "raise")?;
 
     it.eat(&Token::LSBrack, "raise")?;
-    let errors = it.parse_vec(&parse_generics, "raise")?;
+    let errors = it.parse_vec(&parse_generics, "raise", st_line, st_pos)?;
     it.eat(&Token::RSBrack, "raise")?;
     it.eat_if(&Token::RSBrack);
     let (en_line, en_pos) = match errors.last() {
@@ -60,7 +65,7 @@ pub fn parse_handle(expr_or_stmt: ASTNodePos, it: &mut TPIterator) -> ParseResul
     it.eat(&Token::Handle, "handle")?;
     it.eat(&Token::NL, "handle")?;
 
-    let cases = it.parse_vec(&parse_match_cases, "handle")?;
+    let cases = it.parse_vec(&parse_match_cases, "handle", st_line, st_pos)?;
     let (en_line, en_pos) = match cases.last() {
         Some(stmt) => (stmt.en_line, stmt.en_pos),
         None => (st_line, st_pos)

--- a/src/parser/expr_or_stmt.rs
+++ b/src/parser/expr_or_stmt.rs
@@ -24,6 +24,7 @@ pub fn parse_expr_or_stmt(it: &mut TPIterator) -> ParseResult {
                     parse_expression(it)
                 },
         },
+        &[],
         "expression or statement"
     )?;
 
@@ -38,7 +39,7 @@ pub fn parse_expr_or_stmt(it: &mut TPIterator) -> ParseResult {
 }
 
 pub fn parse_raise(expr_or_stmt: ASTNodePos, it: &mut TPIterator) -> ParseResult {
-    let (st_line, st_pos) = it.start_pos()?;
+    let (st_line, st_pos) = it.start_pos("raise")?;
     it.eat(&Token::Raises, "raise")?;
 
     it.eat(&Token::LSBrack, "raise")?;
@@ -55,7 +56,7 @@ pub fn parse_raise(expr_or_stmt: ASTNodePos, it: &mut TPIterator) -> ParseResult
 }
 
 pub fn parse_handle(expr_or_stmt: ASTNodePos, it: &mut TPIterator) -> ParseResult {
-    let (st_line, st_pos) = it.start_pos()?;
+    let (st_line, st_pos) = it.start_pos("handle")?;
     it.eat(&Token::Handle, "handle")?;
     it.eat(&Token::NL, "handle")?;
 

--- a/src/parser/expr_or_stmt.rs
+++ b/src/parser/expr_or_stmt.rs
@@ -15,7 +15,7 @@ pub fn parse_expr_or_stmt(it: &mut TPIterator) -> ParseResult {
         &|it, token_pos| match &token_pos.token {
             Token::NL => {
                 it.eat(&Token::NL, "expression or statement")?;
-                it.parse(&parse_block, "expression or statement")
+                it.parse(&parse_block)
             }
             token =>
                 if is_start_statement(token) {
@@ -33,8 +33,7 @@ pub fn parse_expr_or_stmt(it: &mut TPIterator) -> ParseResult {
             Token::Handle => parse_handle(*result.clone(), it),
             _ => Ok(result.clone())
         },
-        Ok(result.clone()),
-        "expression or statement"
+        Ok(result.clone())
     )
 }
 
@@ -43,7 +42,7 @@ pub fn parse_raise(expr_or_stmt: ASTNodePos, it: &mut TPIterator) -> ParseResult
     it.eat(&Token::Raises, "raise")?;
 
     it.eat(&Token::LSBrack, "raise")?;
-    let errors = it.parse_vec(&parse_generics, "raise generics")?;
+    let errors = it.parse_vec(&parse_generics)?;
     it.eat(&Token::RSBrack, "raise")?;
     it.eat_if(&Token::RSBrack);
     let (en_line, en_pos) = match errors.last() {
@@ -60,7 +59,7 @@ pub fn parse_handle(expr_or_stmt: ASTNodePos, it: &mut TPIterator) -> ParseResul
     it.eat(&Token::Handle, "handle")?;
     it.eat(&Token::NL, "handle")?;
 
-    let cases = it.parse_vec(&parse_match_cases, "handle cases")?;
+    let cases = it.parse_vec(&parse_match_cases)?;
     let (en_line, en_pos) = match cases.last() {
         Some(stmt) => (stmt.en_line, stmt.en_pos),
         None => (st_line, st_pos)

--- a/src/parser/expr_or_stmt.rs
+++ b/src/parser/expr_or_stmt.rs
@@ -15,7 +15,7 @@ pub fn parse_expr_or_stmt(it: &mut TPIterator) -> ParseResult {
         &|it, token_pos| match &token_pos.token {
             Token::NL => {
                 it.eat(&Token::NL, "expression or statement")?;
-                it.parse(&parse_block)
+                it.parse(&parse_block, "expression or statement")
             }
             token =>
                 if is_start_statement(token) {
@@ -43,7 +43,7 @@ pub fn parse_raise(expr_or_stmt: ASTNodePos, it: &mut TPIterator) -> ParseResult
     it.eat(&Token::Raises, "raise")?;
 
     it.eat(&Token::LSBrack, "raise")?;
-    let errors = it.parse_vec(&parse_generics)?;
+    let errors = it.parse_vec(&parse_generics, "raise")?;
     it.eat(&Token::RSBrack, "raise")?;
     it.eat_if(&Token::RSBrack);
     let (en_line, en_pos) = match errors.last() {
@@ -60,7 +60,7 @@ pub fn parse_handle(expr_or_stmt: ASTNodePos, it: &mut TPIterator) -> ParseResul
     it.eat(&Token::Handle, "handle")?;
     it.eat(&Token::NL, "handle")?;
 
-    let cases = it.parse_vec(&parse_match_cases)?;
+    let cases = it.parse_vec(&parse_match_cases, "handle")?;
     let (en_line, en_pos) = match cases.last() {
         Some(stmt) => (stmt.en_line, stmt.en_pos),
         None => (st_line, st_pos)

--- a/src/parser/expression.rs
+++ b/src/parser/expression.rs
@@ -9,7 +9,7 @@ use crate::parser::collection::parse_collection;
 use crate::parser::control_flow_expr::parse_cntrl_flow_expr;
 use crate::parser::iterator::TPIterator;
 use crate::parser::operation::parse_operation;
-use crate::parser::parse_result::ParseErr::*;
+use crate::parser::parse_result::expected_construct;
 use crate::parser::parse_result::ParseResult;
 
 pub fn parse_expression(it: &mut TPIterator) -> ParseResult {
@@ -35,7 +35,7 @@ pub fn parse_expression(it: &mut TPIterator) -> ParseResult {
 
             Token::BSlash => parse_anon_fun(it),
 
-            _ => Err(CustomErr { expected: "expression".to_string(), actual: token_pos.clone() })
+            _ => Err(expected_construct("expression", token_pos))
         },
         "expression"
     );
@@ -58,7 +58,7 @@ fn parse_post_expr(pre: &ASTNodePos, it: &mut TPIterator) -> ParseResult {
             Token::QuestOr => {
                 let (st_line, st_pos) = (token_pos.st_line, token_pos.st_pos);
                 it.eat(&Token::QuestOr, "postfix expression")?;
-                let right = it.parse(&parse_expression, "question or")?;
+                let right = it.parse(&parse_expression)?;
                 let (en_line, en_pos) = (right.en_line, right.en_pos);
                 let node = ASTNode::QuestOr { left: Box::new(pre.clone()), right };
                 let res = ASTNodePos { st_line, st_pos, en_line, en_pos, node };
@@ -80,8 +80,7 @@ fn parse_post_expr(pre: &ASTNodePos, it: &mut TPIterator) -> ParseResult {
                     Ok(Box::from(pre.clone()))
                 },
         },
-        Ok(Box::from(pre.clone())),
-        "postfix expression"
+        Ok(Box::from(pre.clone()))
     )
 }
 
@@ -94,7 +93,7 @@ fn parse_return(it: &mut TPIterator) -> ParseResult {
         return Ok(Box::from(ASTNodePos { st_line, st_pos, en_line, en_pos, node }));
     }
 
-    let expr = it.parse(&parse_expression, "return expression")?;
+    let expr = it.parse(&parse_expression)?;
     let (en_line, en_pos) = (expr.en_line, expr.en_pos);
     Ok(Box::from(ASTNodePos { st_line, st_pos, en_line, en_pos, node: ASTNode::Return { expr } }))
 }

--- a/src/parser/expression.rs
+++ b/src/parser/expression.rs
@@ -105,7 +105,7 @@ fn parse_post_expr(pre: &ASTNodePos, it: &mut TPIterator) -> ParseResult {
             Token::QuestOr => {
                 let (st_line, st_pos) = (token_pos.st_line, token_pos.st_pos);
                 it.eat(&Token::QuestOr, "postfix expression")?;
-                let right = it.parse(&parse_expression, "postfix expression")?;
+                let right = it.parse(&parse_expression, "postfix expression", st_line, st_pos)?;
                 let (en_line, en_pos) = (right.en_line, right.en_pos);
                 let node = ASTNode::QuestOr { left: Box::new(pre.clone()), right };
                 let res = ASTNodePos { st_line, st_pos, en_line, en_pos, node };
@@ -140,7 +140,7 @@ fn parse_return(it: &mut TPIterator) -> ParseResult {
         return Ok(Box::from(ASTNodePos { st_line, st_pos, en_line, en_pos, node }));
     }
 
-    let expr = it.parse(&parse_expression, "return")?;
+    let expr = it.parse(&parse_expression, "return", st_line, st_pos)?;
     let (en_line, en_pos) = (expr.en_line, expr.en_pos);
     Ok(Box::from(ASTNodePos { st_line, st_pos, en_line, en_pos, node: ASTNode::Return { expr } }))
 }

--- a/src/parser/expression.rs
+++ b/src/parser/expression.rs
@@ -105,7 +105,7 @@ fn parse_post_expr(pre: &ASTNodePos, it: &mut TPIterator) -> ParseResult {
             Token::QuestOr => {
                 let (st_line, st_pos) = (token_pos.st_line, token_pos.st_pos);
                 it.eat(&Token::QuestOr, "postfix expression")?;
-                let right = it.parse(&parse_expression)?;
+                let right = it.parse(&parse_expression, "postfix expression")?;
                 let (en_line, en_pos) = (right.en_line, right.en_pos);
                 let node = ASTNode::QuestOr { left: Box::new(pre.clone()), right };
                 let res = ASTNodePos { st_line, st_pos, en_line, en_pos, node };
@@ -140,7 +140,7 @@ fn parse_return(it: &mut TPIterator) -> ParseResult {
         return Ok(Box::from(ASTNodePos { st_line, st_pos, en_line, en_pos, node }));
     }
 
-    let expr = it.parse(&parse_expression)?;
+    let expr = it.parse(&parse_expression, "return")?;
     let (en_line, en_pos) = (expr.en_line, expr.en_pos);
     Ok(Box::from(ASTNodePos { st_line, st_pos, en_line, en_pos, node: ASTNode::Return { expr } }))
 }

--- a/src/parser/expression.rs
+++ b/src/parser/expression.rs
@@ -9,7 +9,7 @@ use crate::parser::collection::parse_collection;
 use crate::parser::control_flow_expr::parse_cntrl_flow_expr;
 use crate::parser::iterator::TPIterator;
 use crate::parser::operation::parse_operation;
-use crate::parser::parse_result::expected_construct;
+use crate::parser::parse_result::expected_one_of;
 use crate::parser::parse_result::ParseResult;
 
 pub fn parse_expression(it: &mut TPIterator) -> ParseResult {
@@ -35,8 +35,55 @@ pub fn parse_expression(it: &mut TPIterator) -> ParseResult {
 
             Token::BSlash => parse_anon_fun(it),
 
-            _ => Err(expected_construct("expression", token_pos))
+            _ => Err(expected_one_of(
+                &[
+                    Token::If,
+                    Token::Match,
+                    Token::LRBrack,
+                    Token::LSBrack,
+                    Token::LCBrack,
+                    Token::Ret,
+                    Token::Underscore,
+                    Token::_Self,
+                    Token::Real(String::new()),
+                    Token::Int(String::new()),
+                    Token::ENum(String::new(), String::new()),
+                    Token::Bool(true),
+                    Token::Bool(false),
+                    Token::Not,
+                    Token::Sqrt,
+                    Token::Add,
+                    Token::Id(String::new()),
+                    Token::Sub,
+                    Token::BOneCmpl,
+                    Token::BSlash
+                ],
+                token_pos,
+                "expression"
+            ))
         },
+        &[
+            Token::If,
+            Token::Match,
+            Token::LRBrack,
+            Token::LSBrack,
+            Token::LCBrack,
+            Token::Ret,
+            Token::Underscore,
+            Token::_Self,
+            Token::Real(String::new()),
+            Token::Int(String::new()),
+            Token::ENum(String::new(), String::new()),
+            Token::Bool(true),
+            Token::Bool(false),
+            Token::Not,
+            Token::Sqrt,
+            Token::Add,
+            Token::Id(String::new()),
+            Token::Sub,
+            Token::BOneCmpl,
+            Token::BSlash
+        ],
         "expression"
     );
 
@@ -47,7 +94,7 @@ pub fn parse_expression(it: &mut TPIterator) -> ParseResult {
 }
 
 fn parse_underscore(it: &mut TPIterator) -> ParseResult {
-    let (st_line, st_pos) = it.start_pos()?;
+    let (st_line, st_pos) = it.start_pos("underscore")?;
     let (en_line, en_pos) = it.eat(&Token::Underscore, "underscore")?;
     Ok(Box::from(ASTNodePos { st_line, st_pos, en_line, en_pos, node: ASTNode::Underscore }))
 }
@@ -85,7 +132,7 @@ fn parse_post_expr(pre: &ASTNodePos, it: &mut TPIterator) -> ParseResult {
 }
 
 fn parse_return(it: &mut TPIterator) -> ParseResult {
-    let (st_line, st_pos) = it.start_pos()?;
+    let (st_line, st_pos) = it.start_pos("return")?;
     it.eat(&Token::Ret, "return")?;
 
     if let Some((en_line, en_pos)) = it.eat_if(&Token::NL) {

--- a/src/parser/file.rs
+++ b/src/parser/file.rs
@@ -12,7 +12,7 @@ use crate::parser::parse_result::expected;
 use crate::parser::parse_result::ParseResult;
 
 pub fn parse_from_import(it: &mut TPIterator) -> ParseResult {
-    let (st_line, st_pos) = it.start_pos()?;
+    let (st_line, st_pos) = it.start_pos("from import")?;
     it.eat(&Token::From, "from import")?;
 
     let id = it.parse(&parse_id)?;
@@ -24,7 +24,7 @@ pub fn parse_from_import(it: &mut TPIterator) -> ParseResult {
 }
 
 pub fn parse_import(it: &mut TPIterator) -> ParseResult {
-    let (st_line, st_pos) = it.start_pos()?;
+    let (st_line, st_pos) = it.start_pos("import")?;
     it.eat(&Token::Import, "import")?;
 
     let mut import = vec![];
@@ -103,7 +103,7 @@ pub fn parse_file(it: &mut TPIterator) -> ParseResult {
             Ok(())
         }
         Token::Comment(comment) => {
-            let (st_line, st_pos) = it.start_pos()?;
+            let (st_line, st_pos) = it.start_pos("comment")?;
             let (en_line, en_pos) = it.eat(&Token::Comment(comment.clone()), "file")?;
             let node = ASTNode::Comment { comment: comment.clone() };
             modules.push(ASTNodePos { st_line, st_pos, en_line, en_pos, node });
@@ -120,8 +120,7 @@ pub fn parse_file(it: &mut TPIterator) -> ParseResult {
 }
 
 pub fn parse_type_def(it: &mut TPIterator) -> ParseResult {
-    let (st_line, st_pos) = it.start_pos()?;
-
+    let (st_line, st_pos) = it.start_pos("type definition")?;
     it.eat(&Token::Type, "type definition")?;
     let _type = it.parse(&parse_type)?;
 

--- a/src/parser/file.rs
+++ b/src/parser/file.rs
@@ -15,8 +15,8 @@ pub fn parse_from_import(it: &mut TPIterator) -> ParseResult {
     let (st_line, st_pos) = it.start_pos("from import")?;
     it.eat(&Token::From, "from import")?;
 
-    let id = it.parse(&parse_id)?;
-    let import = it.parse(&parse_import)?;
+    let id = it.parse(&parse_id, "from import")?;
+    let import = it.parse(&parse_import, "from import")?;
 
     let (en_line, en_pos) = (import.en_line, import.en_pos);
     let node = ASTNode::FromImport { id, import };
@@ -29,7 +29,7 @@ pub fn parse_import(it: &mut TPIterator) -> ParseResult {
 
     let mut import = vec![];
     it.peek_while_not_tokens(&[Token::As, Token::NL], &mut |it, _| {
-        import.push(*it.parse(&parse_id)?);
+        import.push(*it.parse(&parse_id, "import")?);
         it.eat_if(&Token::Comma);
         Ok(())
     })?;
@@ -48,18 +48,18 @@ fn parse_as(it: &mut TPIterator) -> ParseResult<Vec<ASTNodePos>> {
     let mut aliases = vec![];
     it.peek_while_not_token(&Token::NL, &mut |it, token_pos| match token_pos.token {
         Token::Id(_) => {
-            aliases.push(*it.parse(&parse_id)?);
+            aliases.push(*it.parse(&parse_id, "as")?);
             it.eat_if(&Token::Comma);
             Ok(())
         }
-        _ => Err(expected(&Token::Id(String::new()), token_pos, "import"))
+        _ => Err(expected(&Token::Id(String::new()), token_pos, "as"))
     })?;
 
     Ok(aliases)
 }
 
 pub fn parse_script(it: &mut TPIterator) -> ParseResult {
-    let statements = it.parse_vec(&parse_statements)?;
+    let statements = it.parse_vec(&parse_statements, "script")?;
 
     let (st_line, st_pos, en_line, en_pos) = match (statements.first(), statements.last()) {
         (Some(first), Some(last)) => (first.st_line, first.st_pos, last.en_line, last.en_pos),
@@ -91,15 +91,15 @@ pub fn parse_file(it: &mut TPIterator) -> ParseResult {
             Ok(())
         }
         Token::Import => {
-            imports.push(*it.parse(&parse_import)?);
+            imports.push(*it.parse(&parse_import, "file")?);
             Ok(())
         }
         Token::From => {
-            imports.push(*it.parse(&parse_from_import)?);
+            imports.push(*it.parse(&parse_from_import, "file")?);
             Ok(())
         }
         Token::Type => {
-            type_defs.push(*it.parse(&parse_type_def)?);
+            type_defs.push(*it.parse(&parse_type_def, "file")?);
             Ok(())
         }
         Token::Comment(comment) => {
@@ -110,7 +110,7 @@ pub fn parse_file(it: &mut TPIterator) -> ParseResult {
             Ok(())
         }
         _ => {
-            modules.push(*it.parse(&parse_module)?);
+            modules.push(*it.parse(&parse_module, "file")?);
             Ok(())
         }
     })?;
@@ -122,13 +122,13 @@ pub fn parse_file(it: &mut TPIterator) -> ParseResult {
 pub fn parse_type_def(it: &mut TPIterator) -> ParseResult {
     let (st_line, st_pos) = it.start_pos("type definition")?;
     it.eat(&Token::Type, "type definition")?;
-    let _type = it.parse(&parse_type)?;
+    let _type = it.parse(&parse_type, "type definition")?;
 
     it.peek(
         &|it, token_pos| match token_pos.token {
             Token::IsA => {
                 it.eat(&Token::IsA, "type definition")?;
-                let _type = it.parse(&parse_type)?;
+                let _type = it.parse(&parse_type, "type definition")?;
                 let conditions =
                     it.parse_vec_if(&Token::When, &parse_conditions, "type definition")?;
                 let (en_line, en_pos) = if let Some(token_pos) = conditions.last() {
@@ -142,7 +142,7 @@ pub fn parse_type_def(it: &mut TPIterator) -> ParseResult {
             }
             _ => {
                 it.eat_if(&Token::NL);
-                let body = it.parse(&parse_block)?;
+                let body = it.parse(&parse_block, "type definition")?;
                 let (en_line, en_pos) = (body.en_line, body.en_pos);
                 let node = ASTNode::TypeDef { _type: _type.clone(), body: Some(body) };
                 Ok(Box::from(ASTNodePos { st_line, st_pos, en_line, en_pos, node }))

--- a/src/parser/iterator.rs
+++ b/src/parser/iterator.rs
@@ -47,29 +47,35 @@ impl<'a> TPIterator<'a> {
     pub fn parse(
         &mut self,
         parse_fun: &Fn(&mut TPIterator) -> ParseResult,
-        cause: &str
+        cause: &str,
+        line: i32,
+        pos: i32
     ) -> ParseResult<Box<ASTNodePos>> {
-        parse_fun(self).map_err(|err| err.clone_with_cause(cause))
+        parse_fun(self).map_err(|err| err.clone_with_cause(cause, line, pos))
     }
 
     pub fn parse_vec(
         &mut self,
         parse_fun: &Fn(&mut TPIterator) -> ParseResult<Vec<ASTNodePos>>,
-        cause: &str
+        cause: &str,
+        line: i32,
+        pos: i32
     ) -> ParseResult<Vec<ASTNodePos>> {
-        parse_fun(self).map_err(|err| err.clone_with_cause(cause))
+        parse_fun(self).map_err(|err| err.clone_with_cause(cause, line, pos))
     }
 
     pub fn parse_if(
         &mut self,
         token: &Token,
         parse_fun: &Fn(&mut TPIterator) -> ParseResult,
-        err_msg: &str
+        err_msg: &str,
+        line: i32,
+        pos: i32
     ) -> ParseResult<Option<Box<ASTNodePos>>> {
         match self.it.peek() {
             Some(tp) if Token::same_type(&tp.token, token) => {
                 self.eat(token, err_msg)?;
-                Ok(Some(self.parse(parse_fun, err_msg)?))
+                Ok(Some(self.parse(parse_fun, err_msg, line, pos)?))
             }
             _ => Ok(None)
         }
@@ -79,12 +85,14 @@ impl<'a> TPIterator<'a> {
         &mut self,
         token: &Token,
         parse_fun: &Fn(&mut TPIterator) -> ParseResult<Vec<ASTNodePos>>,
-        err_msg: &str
+        err_msg: &str,
+        line: i32,
+        pos: i32
     ) -> ParseResult<Vec<ASTNodePos>> {
         match self.it.peek() {
             Some(tp) if Token::same_type(&tp.token, token) => {
                 self.eat(token, err_msg)?;
-                Ok(self.parse_vec(parse_fun, err_msg)?)
+                Ok(self.parse_vec(parse_fun, err_msg, line, pos)?)
             }
             _ => Ok(vec![])
         }

--- a/src/parser/iterator.rs
+++ b/src/parser/iterator.rs
@@ -1,10 +1,9 @@
 use crate::lexer::token::Token;
 use crate::lexer::token::TokenPos;
 use crate::parser::ast::ASTNodePos;
-use crate::parser::parse_result::ParseErr::Cause;
-use crate::parser::parse_result::ParseErr::CustomEOFErr;
-use crate::parser::parse_result::ParseErr::EOFErr;
-use crate::parser::parse_result::ParseErr::TokenErr;
+use crate::parser::parse_result::eof;
+use crate::parser::parse_result::eof_expected;
+use crate::parser::parse_result::expected;
 use crate::parser::parse_result::ParseResult;
 use std::iter::Peekable;
 use std::slice::Iter;
@@ -29,12 +28,8 @@ impl<'a> TPIterator<'a> {
             Some(TokenPos { token: actual, st_line, st_pos })
                 if Token::same_type(actual, token) =>
                 Ok((*st_line, *st_pos + actual.clone().width())),
-            Some(tp) => Err(TokenErr {
-                expected: token.clone(),
-                actual:   tp.clone(),
-                message:  String::from(err_msg)
-            }),
-            None => Err(EOFErr { expected: token.clone() })
+            Some(token_pos) => Err(expected(token, token_pos, err_msg)),
+            None => Err(eof_expected(token))
         }
     }
 
@@ -52,34 +47,16 @@ impl<'a> TPIterator<'a> {
 
     pub fn parse(
         &mut self,
-        parse_fun: &Fn(&mut TPIterator) -> ParseResult,
-        err_msg: &str
+        parse_fun: &Fn(&mut TPIterator) -> ParseResult
     ) -> ParseResult<Box<ASTNodePos>> {
-        let current = self.it.peek().cloned();
-        match parse_fun(self) {
-            Ok(node) => Ok(node),
-            Err(err) => Err(Cause {
-                parsing:  String::from(err_msg),
-                cause:    Box::new(err),
-                position: current.cloned()
-            })
-        }
+        parse_fun(self)
     }
 
     pub fn parse_vec(
         &mut self,
-        parse_fun: &Fn(&mut TPIterator) -> ParseResult<Vec<ASTNodePos>>,
-        err_msg: &str
+        parse_fun: &Fn(&mut TPIterator) -> ParseResult<Vec<ASTNodePos>>
     ) -> ParseResult<Vec<ASTNodePos>> {
-        let current = self.it.peek().cloned();
-        match parse_fun(self) {
-            Ok(node) => Ok(node),
-            Err(err) => Err(Cause {
-                parsing:  String::from(err_msg),
-                cause:    Box::new(err),
-                position: current.cloned()
-            })
-        }
+        parse_fun(self)
     }
 
     pub fn parse_if(
@@ -91,7 +68,7 @@ impl<'a> TPIterator<'a> {
         match self.it.peek() {
             Some(tp) if Token::same_type(&tp.token, token) => {
                 self.eat(token, err_msg)?;
-                Ok(Some(self.parse(parse_fun, err_msg)?))
+                Ok(Some(self.parse(parse_fun)?))
             }
             _ => Ok(None)
         }
@@ -106,7 +83,7 @@ impl<'a> TPIterator<'a> {
         match self.it.peek() {
             Some(tp) if Token::same_type(&tp.token, token) => {
                 self.eat(token, err_msg)?;
-                Ok(self.parse_vec(parse_fun, err_msg)?)
+                Ok(self.parse_vec(parse_fun)?)
             }
             _ => Ok(vec![])
         }
@@ -118,7 +95,7 @@ impl<'a> TPIterator<'a> {
         err_msg: &str
     ) -> ParseResult {
         match self.it.peek().cloned() {
-            None => Err(CustomEOFErr { expected: String::from(err_msg) }),
+            None => Err(eof(err_msg)),
             Some(token_pos) => match_fun(self, token_pos)
         }
     }
@@ -126,26 +103,18 @@ impl<'a> TPIterator<'a> {
     pub fn peek(
         &mut self,
         match_fun: &Fn(&mut TPIterator, &TokenPos) -> ParseResult,
-        default: ParseResult,
-        err_msg: &str
+        default: ParseResult
     ) -> ParseResult {
         match self.it.peek().cloned() {
             None => default,
-            Some(token_pos) => match match_fun(self, &token_pos.clone()) {
-                Ok(ok) => Ok(ok),
-                Err(err) => Err(Cause {
-                    parsing:  String::from(err_msg),
-                    cause:    Box::new(err),
-                    position: Some(token_pos.clone())
-                })
-            }
+            Some(token_pos) => match_fun(self, &token_pos.clone())
         }
     }
 
     pub fn peek_while_not_tokens(
         &mut self,
         tokens: &[Token],
-        loop_fn: &mut FnMut(&mut TPIterator, &TokenPos, i32) -> ParseResult<()>
+        loop_fn: &mut FnMut(&mut TPIterator, &TokenPos) -> ParseResult<()>
     ) -> ParseResult<()> {
         self.peek_while_fn(
             &|token_pos| {
@@ -158,7 +127,7 @@ impl<'a> TPIterator<'a> {
     pub fn peek_while_not_token(
         &mut self,
         token: &Token,
-        loop_fn: &mut FnMut(&mut TPIterator, &TokenPos, i32) -> ParseResult<()>
+        loop_fn: &mut FnMut(&mut TPIterator, &TokenPos) -> ParseResult<()>
     ) -> ParseResult<()> {
         self.peek_while_fn(&|token_pos| !Token::same_type(&token_pos.token, token), loop_fn)
     }
@@ -166,16 +135,13 @@ impl<'a> TPIterator<'a> {
     pub fn peek_while_fn(
         &mut self,
         check_fn: &Fn(&TokenPos) -> bool,
-        loop_fn: &mut FnMut(&mut TPIterator, &TokenPos, i32) -> ParseResult<()>
+        loop_fn: &mut FnMut(&mut TPIterator, &TokenPos) -> ParseResult<()>
     ) -> ParseResult<()> {
-        let mut no = 1;
         while let Some(&token_pos) = self.it.peek() {
             if !check_fn(token_pos) {
                 break;
             }
-
-            loop_fn(self, token_pos, no)?;
-            no += 1;
+            loop_fn(self, token_pos)?;
         }
         Ok(())
     }
@@ -183,7 +149,7 @@ impl<'a> TPIterator<'a> {
     pub fn start_pos(&mut self) -> ParseResult<(i32, i32)> {
         match self.it.peek() {
             Some(TokenPos { st_line, st_pos, .. }) => Ok((*st_line, *st_pos)),
-            None => Err(CustomEOFErr { expected: String::from("token.") })
+            None => Err(eof("token"))
         }
     }
 }

--- a/src/parser/iterator.rs
+++ b/src/parser/iterator.rs
@@ -46,16 +46,18 @@ impl<'a> TPIterator<'a> {
 
     pub fn parse(
         &mut self,
-        parse_fun: &Fn(&mut TPIterator) -> ParseResult
+        parse_fun: &Fn(&mut TPIterator) -> ParseResult,
+        cause: &str
     ) -> ParseResult<Box<ASTNodePos>> {
-        parse_fun(self)
+        parse_fun(self).map_err(|err| err.clone_with_cause(cause))
     }
 
     pub fn parse_vec(
         &mut self,
-        parse_fun: &Fn(&mut TPIterator) -> ParseResult<Vec<ASTNodePos>>
+        parse_fun: &Fn(&mut TPIterator) -> ParseResult<Vec<ASTNodePos>>,
+        cause: &str
     ) -> ParseResult<Vec<ASTNodePos>> {
-        parse_fun(self)
+        parse_fun(self).map_err(|err| err.clone_with_cause(cause))
     }
 
     pub fn parse_if(
@@ -67,7 +69,7 @@ impl<'a> TPIterator<'a> {
         match self.it.peek() {
             Some(tp) if Token::same_type(&tp.token, token) => {
                 self.eat(token, err_msg)?;
-                Ok(Some(self.parse(parse_fun)?))
+                Ok(Some(self.parse(parse_fun, err_msg)?))
             }
             _ => Ok(None)
         }
@@ -82,7 +84,7 @@ impl<'a> TPIterator<'a> {
         match self.it.peek() {
             Some(tp) if Token::same_type(&tp.token, token) => {
                 self.eat(token, err_msg)?;
-                Ok(self.parse_vec(parse_fun)?)
+                Ok(self.parse_vec(parse_fun, err_msg)?)
             }
             _ => Ok(vec![])
         }

--- a/src/parser/operation.rs
+++ b/src/parser/operation.rs
@@ -11,7 +11,7 @@ use crate::parser::parse_result::ParseResult;
 macro_rules! inner_bin_op {
     ($it:expr, $st_line:expr, $st_pos:expr, $fun:path, $ast:ident, $left:expr, $msg:expr) => {{
         $it.eat(&Token::$ast, "operation")?;
-        let right = $it.parse(&$fun)?;
+        let right = $it.parse(&$fun, $msg)?;
         let (en_line, en_pos) = (right.en_line, right.en_pos);
         let node = ASTNode::$ast { left: $left, right };
         Ok(Box::from(ASTNodePos { st_line: $st_line, st_pos: $st_pos, en_line, en_pos, node }))
@@ -33,7 +33,7 @@ macro_rules! inner_bin_op {
 pub fn parse_operation(it: &mut TPIterator) -> ParseResult { parse_level_8(it) }
 
 fn parse_level_8(it: &mut TPIterator) -> ParseResult {
-    let arithmetic = it.parse(&parse_level_7)?;
+    let arithmetic = it.parse(&parse_level_7, "operation")?;
     if it.peak_if_fn(&is_start_expression_exclude_unary) {
         parse_call(&arithmetic, it)
     } else {
@@ -43,7 +43,7 @@ fn parse_level_8(it: &mut TPIterator) -> ParseResult {
 
 fn parse_level_7(it: &mut TPIterator) -> ParseResult {
     let (st_line, st_pos) = it.start_pos("operation")?;
-    let arithmetic = it.parse(&parse_level_6)?;
+    let arithmetic = it.parse(&parse_level_6, "operation")?;
 
     macro_rules! bin_op {
         ($it:expr, $fun:path, $ast:ident, $arithmetic:expr, $msg:expr) => {{
@@ -64,7 +64,7 @@ fn parse_level_7(it: &mut TPIterator) -> ParseResult {
 
 fn parse_level_6(it: &mut TPIterator) -> ParseResult {
     let (st_line, st_pos) = it.start_pos("operation")?;
-    let arithmetic = it.parse(&parse_level_5)?;
+    let arithmetic = it.parse(&parse_level_5, "operation")?;
     macro_rules! bin_op {
         ($it:expr, $fun:path, $ast:ident, $arithmetic:expr, $msg:expr) => {{
             inner_bin_op!($it, st_line, st_pos, $fun, $ast, $arithmetic, $msg)
@@ -92,7 +92,7 @@ fn parse_level_6(it: &mut TPIterator) -> ParseResult {
 
 fn parse_level_5(it: &mut TPIterator) -> ParseResult {
     let (st_line, st_pos) = it.start_pos("operation")?;
-    let arithmetic = it.parse(&parse_level_4)?;
+    let arithmetic = it.parse(&parse_level_4, "operation")?;
     macro_rules! bin_op {
         ($it:expr, $fun:path, $ast:ident, $arithmetic:expr, $msg:expr) => {{
             inner_bin_op!($it, st_line, st_pos, $fun, $ast, $arithmetic, $msg)
@@ -116,7 +116,7 @@ fn parse_level_5(it: &mut TPIterator) -> ParseResult {
 
 fn parse_level_4(it: &mut TPIterator) -> ParseResult {
     let (st_line, st_pos) = it.start_pos("operation")?;
-    let arithmetic = it.parse(&parse_level_3)?;
+    let arithmetic = it.parse(&parse_level_3, "operation")?;
     macro_rules! bin_op {
         ($it:expr, $fun:path, $ast:ident, $arithmetic:expr, $msg:expr) => {{
             inner_bin_op!($it, st_line, st_pos, $fun, $ast, $arithmetic, $msg)
@@ -135,7 +135,7 @@ fn parse_level_4(it: &mut TPIterator) -> ParseResult {
 
 fn parse_level_3(it: &mut TPIterator) -> ParseResult {
     let (st_line, st_pos) = it.start_pos("operation")?;
-    let arithmetic = it.parse(&parse_level_2)?;
+    let arithmetic = it.parse(&parse_level_2, "operation")?;
     macro_rules! bin_op {
         ($it:expr, $fun:path, $ast:ident, $arithmetic:expr, $msg:expr) => {{
             inner_bin_op!($it, st_line, st_pos, $fun, $ast, $arithmetic, $msg)
@@ -150,7 +150,7 @@ fn parse_level_3(it: &mut TPIterator) -> ParseResult {
             Token::Mod => bin_op!(it, parse_level_3, Mod, arithmetic.clone(), "mod"),
             Token::Range => {
                 it.eat(&Token::Range, "operation")?;
-                let to = it.parse(&parse_operation)?;
+                let to = it.parse(&parse_operation, "operation")?;
                 let step = it.parse_if(&Token::Step, &parse_expression, "step")?;
                 let (en_line, en_pos) = (to.en_line, to.en_pos);
                 let node = ASTNode::Range { from: arithmetic.clone(), to, inclusive: false, step };
@@ -158,7 +158,7 @@ fn parse_level_3(it: &mut TPIterator) -> ParseResult {
             }
             Token::RangeIncl => {
                 it.eat(&Token::RangeIncl, "operation")?;
-                let to = it.parse(&parse_operation)?;
+                let to = it.parse(&parse_operation, "operation")?;
                 let step = it.parse_if(&Token::Step, &parse_expression, "step")?;
 
                 let (en_line, en_pos) = (to.en_line, to.en_pos);
@@ -175,7 +175,7 @@ fn parse_level_2(it: &mut TPIterator) -> ParseResult {
     let (st_line, st_pos) = it.start_pos("operation")?;
     macro_rules! un_op {
         ($it:expr, $fun:path, $tok:ident, $ast:ident, $msg:expr) => {{
-            let factor = $it.parse(&$fun)?;
+            let factor = $it.parse(&$fun, $msg)?;
             let (en_line, en_pos) = (factor.en_line, factor.en_pos);
             let node = ASTNode::$ast { expr: factor };
             Ok(Box::from(ASTNodePos { st_line, st_pos, en_line, en_pos, node }))
@@ -199,7 +199,7 @@ fn parse_level_2(it: &mut TPIterator) -> ParseResult {
 
 fn parse_level_1(it: &mut TPIterator) -> ParseResult {
     let (st_line, st_pos) = it.start_pos("operation")?;
-    let arithmetic = it.parse(&parse_factor)?;
+    let arithmetic = it.parse(&parse_factor, "operation")?;
     macro_rules! bin_op {
         ($it:expr, $fun:path, $ast:ident, $arithmetic:expr, $msg:expr) => {{
             inner_bin_op!($it, st_line, st_pos, $fun, $ast, $arithmetic, $msg)
@@ -238,7 +238,7 @@ fn parse_factor(it: &mut TPIterator) -> ParseResult {
                 let node = ASTNode::ENum { num: num.to_string(), exp: exp.to_string() };
                 Ok(Box::from(ASTNodePos { st_line, st_pos, en_line, en_pos, node }))
             }
-            _ => it.parse(&parse_expression)
+            _ => it.parse(&parse_expression, "operation")
         },
         // TODO add system to also allow us to say something should for instance be an expression
         &[

--- a/src/parser/operation.rs
+++ b/src/parser/operation.rs
@@ -11,7 +11,7 @@ use crate::parser::parse_result::ParseResult;
 macro_rules! inner_bin_op {
     ($it:expr, $st_line:expr, $st_pos:expr, $fun:path, $ast:ident, $left:expr, $msg:expr) => {{
         $it.eat(&Token::$ast, "operation")?;
-        let right = $it.parse(&$fun, $msg)?;
+        let right = $it.parse(&$fun)?;
         let (en_line, en_pos) = (right.en_line, right.en_pos);
         let node = ASTNode::$ast { left: $left, right };
         Ok(Box::from(ASTNodePos { st_line: $st_line, st_pos: $st_pos, en_line, en_pos, node }))
@@ -33,7 +33,7 @@ macro_rules! inner_bin_op {
 pub fn parse_operation(it: &mut TPIterator) -> ParseResult { parse_level_8(it) }
 
 fn parse_level_8(it: &mut TPIterator) -> ParseResult {
-    let arithmetic = it.parse(&parse_level_7, "comparison")?;
+    let arithmetic = it.parse(&parse_level_7)?;
     if it.peak_if_fn(&is_start_expression_exclude_unary) {
         parse_call(&arithmetic, it)
     } else {
@@ -43,7 +43,7 @@ fn parse_level_8(it: &mut TPIterator) -> ParseResult {
 
 fn parse_level_7(it: &mut TPIterator) -> ParseResult {
     let (st_line, st_pos) = it.start_pos()?;
-    let arithmetic = it.parse(&parse_level_6, "comparison")?;
+    let arithmetic = it.parse(&parse_level_6)?;
 
     macro_rules! bin_op {
         ($it:expr, $fun:path, $ast:ident, $arithmetic:expr, $msg:expr) => {{
@@ -58,14 +58,13 @@ fn parse_level_7(it: &mut TPIterator) -> ParseResult {
             Token::QuestOr => bin_op!(it, parse_level_7, QuestOr, arithmetic.clone(), "questionor"),
             _ => Ok(arithmetic.clone())
         },
-        Ok(arithmetic.clone()),
-        "operation"
+        Ok(arithmetic.clone())
     )
 }
 
 fn parse_level_6(it: &mut TPIterator) -> ParseResult {
     let (st_line, st_pos) = it.start_pos()?;
-    let arithmetic = it.parse(&parse_level_5, "comparison")?;
+    let arithmetic = it.parse(&parse_level_5)?;
     macro_rules! bin_op {
         ($it:expr, $fun:path, $ast:ident, $arithmetic:expr, $msg:expr) => {{
             inner_bin_op!($it, st_line, st_pos, $fun, $ast, $arithmetic, $msg)
@@ -87,14 +86,13 @@ fn parse_level_6(it: &mut TPIterator) -> ParseResult {
             Token::In => bin_op!(it, parse_level_6, In, arithmetic.clone(), "in"),
             _ => Ok(arithmetic.clone())
         },
-        Ok(arithmetic.clone()),
-        "operation"
+        Ok(arithmetic.clone())
     )
 }
 
 fn parse_level_5(it: &mut TPIterator) -> ParseResult {
     let (st_line, st_pos) = it.start_pos()?;
-    let arithmetic = it.parse(&parse_level_4, "comparison")?;
+    let arithmetic = it.parse(&parse_level_4)?;
     macro_rules! bin_op {
         ($it:expr, $fun:path, $ast:ident, $arithmetic:expr, $msg:expr) => {{
             inner_bin_op!($it, st_line, st_pos, $fun, $ast, $arithmetic, $msg)
@@ -112,14 +110,13 @@ fn parse_level_5(it: &mut TPIterator) -> ParseResult {
             Token::BXOr => bin_op!(it, parse_level_5, BXOr, arithmetic.clone(), "bitwise xor"),
             _ => Ok(arithmetic.clone())
         },
-        Ok(arithmetic.clone()),
-        "operation"
+        Ok(arithmetic.clone())
     )
 }
 
 fn parse_level_4(it: &mut TPIterator) -> ParseResult {
     let (st_line, st_pos) = it.start_pos()?;
-    let arithmetic = it.parse(&parse_level_3, "comparison")?;
+    let arithmetic = it.parse(&parse_level_3)?;
     macro_rules! bin_op {
         ($it:expr, $fun:path, $ast:ident, $arithmetic:expr, $msg:expr) => {{
             inner_bin_op!($it, st_line, st_pos, $fun, $ast, $arithmetic, $msg)
@@ -132,14 +129,13 @@ fn parse_level_4(it: &mut TPIterator) -> ParseResult {
             Token::Sub => bin_op!(it, parse_level_4, Sub, arithmetic.clone(), "sub"),
             _ => Ok(arithmetic.clone())
         },
-        Ok(arithmetic.clone()),
-        "operation"
+        Ok(arithmetic.clone())
     )
 }
 
 fn parse_level_3(it: &mut TPIterator) -> ParseResult {
     let (st_line, st_pos) = it.start_pos()?;
-    let arithmetic = it.parse(&parse_level_2, "comparison")?;
+    let arithmetic = it.parse(&parse_level_2)?;
     macro_rules! bin_op {
         ($it:expr, $fun:path, $ast:ident, $arithmetic:expr, $msg:expr) => {{
             inner_bin_op!($it, st_line, st_pos, $fun, $ast, $arithmetic, $msg)
@@ -154,7 +150,7 @@ fn parse_level_3(it: &mut TPIterator) -> ParseResult {
             Token::Mod => bin_op!(it, parse_level_3, Mod, arithmetic.clone(), "mod"),
             Token::Range => {
                 it.eat(&Token::Range, "operation")?;
-                let to = it.parse(&parse_operation, "range")?;
+                let to = it.parse(&parse_operation)?;
                 let step = it.parse_if(&Token::Step, &parse_expression, "step")?;
                 let (en_line, en_pos) = (to.en_line, to.en_pos);
                 let node = ASTNode::Range { from: arithmetic.clone(), to, inclusive: false, step };
@@ -162,7 +158,7 @@ fn parse_level_3(it: &mut TPIterator) -> ParseResult {
             }
             Token::RangeIncl => {
                 it.eat(&Token::RangeIncl, "operation")?;
-                let to = it.parse(&parse_operation, "range inclusive")?;
+                let to = it.parse(&parse_operation)?;
                 let step = it.parse_if(&Token::Step, &parse_expression, "step")?;
 
                 let (en_line, en_pos) = (to.en_line, to.en_pos);
@@ -171,8 +167,7 @@ fn parse_level_3(it: &mut TPIterator) -> ParseResult {
             }
             _ => Ok(arithmetic.clone())
         },
-        Ok(arithmetic.clone()),
-        "operation"
+        Ok(arithmetic.clone())
     )
 }
 
@@ -180,7 +175,7 @@ fn parse_level_2(it: &mut TPIterator) -> ParseResult {
     let (st_line, st_pos) = it.start_pos()?;
     macro_rules! un_op {
         ($it:expr, $fun:path, $tok:ident, $ast:ident, $msg:expr) => {{
-            let factor = $it.parse(&$fun, $msg)?;
+            let factor = $it.parse(&$fun)?;
             let (en_line, en_pos) = (factor.en_line, factor.en_pos);
             let node = ASTNode::$ast { expr: factor };
             Ok(Box::from(ASTNodePos { st_line, st_pos, en_line, en_pos, node }))
@@ -204,7 +199,7 @@ fn parse_level_2(it: &mut TPIterator) -> ParseResult {
 
 fn parse_level_1(it: &mut TPIterator) -> ParseResult {
     let (st_line, st_pos) = it.start_pos()?;
-    let arithmetic = it.parse(&parse_factor, "factor")?;
+    let arithmetic = it.parse(&parse_factor)?;
     macro_rules! bin_op {
         ($it:expr, $fun:path, $ast:ident, $arithmetic:expr, $msg:expr) => {{
             inner_bin_op!($it, st_line, st_pos, $fun, $ast, $arithmetic, $msg)
@@ -216,8 +211,7 @@ fn parse_level_1(it: &mut TPIterator) -> ParseResult {
             Token::Pow => bin_op!(it, parse_level_1, Pow, arithmetic.clone(), "exponent"),
             _ => Ok(arithmetic.clone())
         },
-        Ok(arithmetic.clone()),
-        "operation"
+        Ok(arithmetic.clone())
     )
 }
 
@@ -244,7 +238,7 @@ fn parse_factor(it: &mut TPIterator) -> ParseResult {
                 let node = ASTNode::ENum { num: num.to_string(), exp: exp.to_string() };
                 Ok(Box::from(ASTNodePos { st_line, st_pos, en_line, en_pos, node }))
             }
-            _ => it.parse(&parse_expression, "factor")
+            _ => it.parse(&parse_expression)
         },
         "factor"
     )

--- a/src/parser/operation.rs
+++ b/src/parser/operation.rs
@@ -42,7 +42,7 @@ fn parse_level_8(it: &mut TPIterator) -> ParseResult {
 }
 
 fn parse_level_7(it: &mut TPIterator) -> ParseResult {
-    let (st_line, st_pos) = it.start_pos()?;
+    let (st_line, st_pos) = it.start_pos("operation")?;
     let arithmetic = it.parse(&parse_level_6)?;
 
     macro_rules! bin_op {
@@ -63,7 +63,7 @@ fn parse_level_7(it: &mut TPIterator) -> ParseResult {
 }
 
 fn parse_level_6(it: &mut TPIterator) -> ParseResult {
-    let (st_line, st_pos) = it.start_pos()?;
+    let (st_line, st_pos) = it.start_pos("operation")?;
     let arithmetic = it.parse(&parse_level_5)?;
     macro_rules! bin_op {
         ($it:expr, $fun:path, $ast:ident, $arithmetic:expr, $msg:expr) => {{
@@ -91,7 +91,7 @@ fn parse_level_6(it: &mut TPIterator) -> ParseResult {
 }
 
 fn parse_level_5(it: &mut TPIterator) -> ParseResult {
-    let (st_line, st_pos) = it.start_pos()?;
+    let (st_line, st_pos) = it.start_pos("operation")?;
     let arithmetic = it.parse(&parse_level_4)?;
     macro_rules! bin_op {
         ($it:expr, $fun:path, $ast:ident, $arithmetic:expr, $msg:expr) => {{
@@ -115,7 +115,7 @@ fn parse_level_5(it: &mut TPIterator) -> ParseResult {
 }
 
 fn parse_level_4(it: &mut TPIterator) -> ParseResult {
-    let (st_line, st_pos) = it.start_pos()?;
+    let (st_line, st_pos) = it.start_pos("operation")?;
     let arithmetic = it.parse(&parse_level_3)?;
     macro_rules! bin_op {
         ($it:expr, $fun:path, $ast:ident, $arithmetic:expr, $msg:expr) => {{
@@ -134,7 +134,7 @@ fn parse_level_4(it: &mut TPIterator) -> ParseResult {
 }
 
 fn parse_level_3(it: &mut TPIterator) -> ParseResult {
-    let (st_line, st_pos) = it.start_pos()?;
+    let (st_line, st_pos) = it.start_pos("operation")?;
     let arithmetic = it.parse(&parse_level_2)?;
     macro_rules! bin_op {
         ($it:expr, $fun:path, $ast:ident, $arithmetic:expr, $msg:expr) => {{
@@ -172,7 +172,7 @@ fn parse_level_3(it: &mut TPIterator) -> ParseResult {
 }
 
 fn parse_level_2(it: &mut TPIterator) -> ParseResult {
-    let (st_line, st_pos) = it.start_pos()?;
+    let (st_line, st_pos) = it.start_pos("operation")?;
     macro_rules! un_op {
         ($it:expr, $fun:path, $tok:ident, $ast:ident, $msg:expr) => {{
             let factor = $it.parse(&$fun)?;
@@ -198,7 +198,7 @@ fn parse_level_2(it: &mut TPIterator) -> ParseResult {
 }
 
 fn parse_level_1(it: &mut TPIterator) -> ParseResult {
-    let (st_line, st_pos) = it.start_pos()?;
+    let (st_line, st_pos) = it.start_pos("operation")?;
     let arithmetic = it.parse(&parse_factor)?;
     macro_rules! bin_op {
         ($it:expr, $fun:path, $ast:ident, $arithmetic:expr, $msg:expr) => {{
@@ -216,7 +216,7 @@ fn parse_level_1(it: &mut TPIterator) -> ParseResult {
 }
 
 fn parse_factor(it: &mut TPIterator) -> ParseResult {
-    let (st_line, st_pos) = it.start_pos()?;
+    let (st_line, st_pos) = it.start_pos("operation")?;
     macro_rules! literal {
         ($it:expr, $factor:expr, $ast:ident) => {{
             let (en_line, en_pos) = $it.eat(&Token::$ast($factor.clone()), "factor")?;
@@ -240,6 +240,17 @@ fn parse_factor(it: &mut TPIterator) -> ParseResult {
             }
             _ => it.parse(&parse_expression)
         },
+        // TODO add system to also allow us to say something should for instance be an expression
+        &[
+            Token::Id(String::new()),
+            Token::_Self,
+            Token::Real(String::new()),
+            Token::Int(String::new()),
+            Token::Bool(true),
+            Token::Bool(false),
+            Token::Str(String::new()),
+            Token::ENum(String::new(), String::new())
+        ],
         "factor"
     )
 }

--- a/src/parser/parse_result.rs
+++ b/src/parser/parse_result.rs
@@ -1,75 +1,51 @@
 use crate::lexer::token::Token;
 use crate::lexer::token::TokenPos;
 use crate::parser::ast::ASTNodePos;
-use std::error;
-use std::fmt;
 
 pub type ParseResult<T = Box<ASTNodePos>> = std::result::Result<T, ParseErr>;
 
 #[derive(Debug)]
-pub enum ParseErr {
-    UtilBodyErr,
-    Cause { parsing: String, cause: Box<ParseErr>, position: Option<TokenPos> },
-    CustomErr { expected: String, actual: TokenPos },
-    InternalErr { message: String },
-    TokenErr { expected: Token, actual: TokenPos, message: String },
-    EOFErr { expected: Token },
-    CustomEOFErr { expected: String },
-    IndErr { expected: i32, actual: i32, position: Option<TokenPos> }
+pub struct ParseErr {
+    pub line:  i32,
+    pub pos:   i32,
+    pub width: i32,
+    pub msg:   String
 }
 
-impl fmt::Display for ParseErr {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match self {
-            ParseErr::Cause { ref parsing, ref cause, ref position } => match cause.fmt(f) {
-                Ok(_) => match position {
-                    Some(pos) =>
-                        write!(f, "\nIn <{}> at ({}:{})", parsing, pos.st_line, pos.st_pos),
-                    None => write!(f, "\nIn <{}>", parsing)
-                },
-                err => err
-            },
-            ParseErr::UtilBodyErr => write!(f, "\nUtil module cannot have a body."),
-            ParseErr::EOFErr { expected } =>
-                write!(f, "\nExpected '{}', but end of file.", expected),
-            ParseErr::CustomErr { expected, actual } => write!(
-                f,
-                "\nExpected {} at ({}:{}) (line:col), but was '{}'.",
-                expected, actual.st_line, actual.st_pos, actual.token
-            ),
-            ParseErr::TokenErr { expected, actual, message } => write!(
-                f,
-                "\nExpected '{}' at ({}:{}) (line:col), but was '{}', in {}.",
-                expected, actual.st_line, actual.st_pos, actual.token, message
-            ),
-            ParseErr::CustomEOFErr { expected } =>
-                write!(f, "\nExpected '{}', but end of file.", expected),
-            ParseErr::IndErr { expected, actual, position } => match position {
-                Some(pos) => write!(
-                    f,
-                    "\nExpected indentation of {}, but was {}, at ({}:{})(next token: {})",
-                    expected, actual, pos.st_line, pos.st_pos, pos.token
-                ),
-                None => write!(f, "\nExpected indentation of {}, but was {}.", expected, actual)
-            },
-            ParseErr::InternalErr { message } => write!(f, "{}.", message)
-        }
+pub fn expected_construct(msg: &str, actual: &TokenPos) -> ParseErr {
+    ParseErr {
+        line:  actual.st_line,
+        pos:   actual.st_pos,
+        width: actual.token.clone().width(),
+        msg:   format!("Expected a {}, but found token '{}'", msg, actual.token)
     }
 }
 
-impl error::Error for ParseErr {
-    fn description(&self) -> &str {
-        match self {
-            ParseErr::Cause { .. } => "A parsing error occurred",
-            ParseErr::UtilBodyErr => "Util module cannot have a body.",
-            ParseErr::EOFErr { .. } => "Expected token but end of file.",
-            ParseErr::TokenErr { .. } => "Unexpected token encountered.",
-            ParseErr::CustomErr { .. } => "Expected condition to be met.",
-            ParseErr::CustomEOFErr { .. } => "Expected condition to be met.",
-            ParseErr::IndErr { .. } => "Unexpected indentation.",
-            ParseErr::InternalErr { .. } => "Internal error."
-        }
+pub fn expected(expected: &Token, actual: &TokenPos, msg: &str) -> ParseErr {
+    ParseErr {
+        line:  actual.st_line,
+        pos:   actual.st_pos,
+        width: actual.token.clone().width(),
+        msg:   format!(
+            "Expected token '{}' in {}, but found token '{}'",
+            expected, msg, actual.token
+        )
     }
+}
 
-    fn source(&self) -> Option<&(error::Error + 'static)> { None }
+pub fn custom(msg: &str, line: i32, pos: i32) -> ParseErr {
+    ParseErr { line, pos, width: -1, msg: msg.to_string() }
+}
+
+pub fn eof(msg: &str) -> ParseErr {
+    ParseErr { line: -1, pos: -1, width: -1, msg: msg.to_string() }
+}
+
+pub fn eof_expected(token: &Token) -> ParseErr {
+    ParseErr {
+        line:  -1,
+        pos:   -1,
+        width: -1,
+        msg:   format!("Expected token '{}', but end of file", token)
+    }
 }

--- a/src/parser/parse_result.rs
+++ b/src/parser/parse_result.rs
@@ -6,10 +6,31 @@ pub type ParseResult<T = Box<ASTNodePos>> = std::result::Result<T, ParseErr>;
 
 #[derive(Debug)]
 pub struct ParseErr {
-    pub line:  i32,
-    pub pos:   i32,
-    pub width: i32,
-    pub msg:   String
+    pub line:   i32,
+    pub pos:    i32,
+    pub width:  i32,
+    pub msg:    String,
+    pub causes: Vec<String>
+}
+
+impl ParseErr {
+    /// Add cause of error to message as long as the maximum depth has not been
+    /// exceeded.
+    ///
+    /// Else, it is ignored.
+    pub fn clone_with_cause(&self, cause: &str) -> ParseErr {
+        ParseErr {
+            line:   self.line,
+            pos:    self.pos,
+            width:  self.width,
+            msg:    self.msg.clone(),
+            causes: {
+                let mut new = self.causes.clone();
+                new.push(format!("in {} \"{}\"", an_or_a(cause), cause));
+                new
+            }
+        }
+    }
 }
 
 fn comma_separated(tokens: &[Token]) -> String {
@@ -26,49 +47,52 @@ fn an_or_a(parsing: &str) -> &str {
 
 pub fn expected_one_of(tokens: &[Token], actual: &TokenPos, parsing: &str) -> ParseErr {
     ParseErr {
-        line:  actual.st_line,
-        pos:   actual.st_pos,
-        width: actual.token.clone().width(),
-        msg:   format!(
+        line:   actual.st_line,
+        pos:    actual.st_pos,
+        width:  actual.token.clone().width(),
+        msg:    format!(
             "Expected one of [{}] while parsing {} \"{}\", but found token '{}'",
             comma_separated(tokens),
             an_or_a(parsing),
             parsing,
             actual.token
-        )
+        ),
+        causes: vec![]
     }
 }
 
 pub fn expected(expected: &Token, actual: &TokenPos, parsing: &str) -> ParseErr {
     ParseErr {
-        line:  actual.st_line,
-        pos:   actual.st_pos,
-        width: actual.token.clone().width(),
-        msg:   format!(
+        line:   actual.st_line,
+        pos:    actual.st_pos,
+        width:  actual.token.clone().width(),
+        msg:    format!(
             "Expected token '{}' while parsing {} \"{}\", but found token '{}'",
             expected,
             an_or_a(parsing),
             parsing,
             actual.token
-        )
+        ),
+        causes: vec![]
     }
 }
 
 pub fn custom(msg: &str, line: i32, pos: i32) -> ParseErr {
-    ParseErr { line, pos, width: -1, msg: title_case(msg) }
+    ParseErr { line, pos, width: -1, msg: title_case(msg), causes: vec![] }
 }
 
 pub fn eof_expected_one_of(tokens: &[Token], parsing: &str) -> ParseErr {
     ParseErr {
-        line:  -1,
-        pos:   -1,
-        width: -1,
-        msg:   format!(
+        line:   -1,
+        pos:    -1,
+        width:  -1,
+        msg:    format!(
             "Expected one of {} while parsing {} \"{}\", but end of file",
             comma_separated(tokens),
             an_or_a(parsing),
             parsing
-        )
+        ),
+        causes: vec![]
     }
 }
 

--- a/src/parser/parse_result.rs
+++ b/src/parser/parse_result.rs
@@ -10,14 +10,23 @@ pub struct ParseErr {
     pub pos:    i32,
     pub width:  i32,
     pub msg:    String,
-    pub causes: Vec<(String, i32, i32)>
+    pub causes: Vec<Cause>
+}
+
+#[derive(Debug, Clone)]
+pub struct Cause {
+    pub line:  i32,
+    pub pos:   i32,
+    pub cause: String
+}
+
+impl Cause {
+    pub fn new(cause: &str, line: i32, pos: i32) -> Cause {
+        Cause { line, pos, cause: String::from(cause) }
+    }
 }
 
 impl ParseErr {
-    /// Add cause of error to message as long as the maximum depth has not been
-    /// exceeded.
-    ///
-    /// Else, it is ignored.
     pub fn clone_with_cause(&self, cause: &str, line: i32, pos: i32) -> ParseErr {
         ParseErr {
             line:   self.line,
@@ -25,23 +34,11 @@ impl ParseErr {
             width:  self.width,
             msg:    self.msg.clone(),
             causes: {
-                let mut new = self.causes.clone();
-                new.push((format!("in \"{}\"", cause), line, pos));
-                new
+                let mut new_causes = self.causes.clone();
+                new_causes.push(Cause::new(cause, line, pos));
+                new_causes
             }
         }
-    }
-}
-
-fn comma_separated(tokens: &[Token]) -> String {
-    let list = tokens.iter().fold(String::new(), |acc, token| acc + &format!("'{}', ", token));
-    String::from(&list[0..if list.len() >= 2 { list.len() - 2 } else { 0 }])
-}
-
-fn an_or_a(parsing: &str) -> &str {
-    match parsing.chars().next() {
-        Some(c) if ['a', 'e', 'i', 'o', 'u'].contains(&c.to_ascii_lowercase()) => "an",
-        _ => "a"
     }
 }
 
@@ -93,6 +90,18 @@ pub fn eof_expected_one_of(tokens: &[Token], parsing: &str) -> ParseErr {
             parsing
         ),
         causes: vec![]
+    }
+}
+
+fn comma_separated(tokens: &[Token]) -> String {
+    let list = tokens.iter().fold(String::new(), |acc, token| acc + &format!("'{}', ", token));
+    String::from(&list[0..if list.len() >= 2 { list.len() - 2 } else { 0 }])
+}
+
+fn an_or_a(parsing: &str) -> &str {
+    match parsing.chars().next() {
+        Some(c) if ['a', 'e', 'i', 'o', 'u'].contains(&c.to_ascii_lowercase()) => "an",
+        _ => "a"
     }
 }
 

--- a/src/parser/parse_result.rs
+++ b/src/parser/parse_result.rs
@@ -17,28 +17,39 @@ fn comma_separated(tokens: &[Token]) -> String {
     String::from(&list[0..if list.len() >= 2 { list.len() - 2 } else { 0 }])
 }
 
-pub fn expected_one_of(tokens: &[Token], actual: &TokenPos, msg: &str) -> ParseErr {
+fn an_or_a(parsing: &str) -> &str {
+    match parsing.chars().next() {
+        Some(c) if ['a', 'e', 'i', 'o', 'u'].contains(&c.to_ascii_lowercase()) => "an",
+        _ => "a"
+    }
+}
+
+pub fn expected_one_of(tokens: &[Token], actual: &TokenPos, parsing: &str) -> ParseErr {
     ParseErr {
         line:  actual.st_line,
         pos:   actual.st_pos,
         width: actual.token.clone().width(),
         msg:   format!(
-            "Expected one of [{}] while parsing {}, but found token '{}'",
+            "Expected one of [{}] while parsing {} \"{}\", but found token '{}'",
             comma_separated(tokens),
-            msg,
+            an_or_a(parsing),
+            parsing,
             actual.token
         )
     }
 }
 
-pub fn expected(expected: &Token, actual: &TokenPos, msg: &str) -> ParseErr {
+pub fn expected(expected: &Token, actual: &TokenPos, parsing: &str) -> ParseErr {
     ParseErr {
         line:  actual.st_line,
         pos:   actual.st_pos,
         width: actual.token.clone().width(),
         msg:   format!(
-            "Expected token '{}' while parsing {}, but found token '{}'",
-            expected, msg, actual.token
+            "Expected token '{}' while parsing {} \"{}\", but found token '{}'",
+            expected,
+            an_or_a(parsing),
+            parsing,
+            actual.token
         )
     }
 }
@@ -47,15 +58,16 @@ pub fn custom(msg: &str, line: i32, pos: i32) -> ParseErr {
     ParseErr { line, pos, width: -1, msg: title_case(msg) }
 }
 
-pub fn eof_expected_one_of(tokens: &[Token], msg: &str) -> ParseErr {
+pub fn eof_expected_one_of(tokens: &[Token], parsing: &str) -> ParseErr {
     ParseErr {
         line:  -1,
         pos:   -1,
         width: -1,
         msg:   format!(
-            "Expected one of {} while parsing {}, but end of file",
+            "Expected one of {} while parsing {} \"{}\", but end of file",
             comma_separated(tokens),
-            msg
+            an_or_a(parsing),
+            parsing
         )
     }
 }

--- a/src/parser/parse_result.rs
+++ b/src/parser/parse_result.rs
@@ -10,7 +10,7 @@ pub struct ParseErr {
     pub pos:    i32,
     pub width:  i32,
     pub msg:    String,
-    pub causes: Vec<String>
+    pub causes: Vec<(String, i32, i32)>
 }
 
 impl ParseErr {
@@ -18,7 +18,7 @@ impl ParseErr {
     /// exceeded.
     ///
     /// Else, it is ignored.
-    pub fn clone_with_cause(&self, cause: &str) -> ParseErr {
+    pub fn clone_with_cause(&self, cause: &str, line: i32, pos: i32) -> ParseErr {
         ParseErr {
             line:   self.line,
             pos:    self.pos,
@@ -26,7 +26,7 @@ impl ParseErr {
             msg:    self.msg.clone(),
             causes: {
                 let mut new = self.causes.clone();
-                new.push(format!("in {} \"{}\"", an_or_a(cause), cause));
+                new.push((format!("in \"{}\"", cause), line, pos));
                 new
             }
         }

--- a/src/parser/parse_result.rs
+++ b/src/parser/parse_result.rs
@@ -17,7 +17,11 @@ pub fn expected_construct(msg: &str, actual: &TokenPos) -> ParseErr {
         line:  actual.st_line,
         pos:   actual.st_pos,
         width: actual.token.clone().width(),
-        msg:   format!("Expected a {}, but found token '{}'", msg, actual.token)
+        msg:   match msg.chars().next() {
+            Some(c) if ['a', 'e', 'i', 'o', 'u'].contains(&c.to_ascii_lowercase()) =>
+                format!("Expected an {}, but found token '{}'", msg, actual.token),
+            _ => format!("Expected a {}, but found token '{}'", msg, actual.token)
+        }
     }
 }
 
@@ -34,11 +38,11 @@ pub fn expected(expected: &Token, actual: &TokenPos, msg: &str) -> ParseErr {
 }
 
 pub fn custom(msg: &str, line: i32, pos: i32) -> ParseErr {
-    ParseErr { line, pos, width: -1, msg: msg.to_string() }
+    ParseErr { line, pos, width: -1, msg: title_case(msg) }
 }
 
 pub fn eof(msg: &str) -> ParseErr {
-    ParseErr { line: -1, pos: -1, width: -1, msg: msg.to_string() }
+    ParseErr { line: -1, pos: -1, width: -1, msg: title_case(msg) }
 }
 
 pub fn eof_expected(token: &Token) -> ParseErr {
@@ -48,4 +52,12 @@ pub fn eof_expected(token: &Token) -> ParseErr {
         width: -1,
         msg:   format!("Expected token '{}', but end of file", token)
     }
+}
+
+fn title_case(s: &str) -> String {
+    let mut tile_case = String::from(s);
+    if let Some(first) = tile_case.get_mut(0..1) {
+        first.make_ascii_uppercase();
+    }
+    tile_case.to_string()
 }

--- a/src/parser/statement.rs
+++ b/src/parser/statement.rs
@@ -7,7 +7,7 @@ use crate::parser::definition::parse_definition;
 use crate::parser::expr_or_stmt::parse_expr_or_stmt;
 use crate::parser::expression::parse_expression;
 use crate::parser::iterator::TPIterator;
-use crate::parser::parse_result::ParseErr::*;
+use crate::parser::parse_result::expected_construct;
 use crate::parser::parse_result::ParseResult;
 
 pub fn parse_statement(it: &mut TPIterator) -> ParseResult {
@@ -15,7 +15,7 @@ pub fn parse_statement(it: &mut TPIterator) -> ParseResult {
         &|it, token_pos| match token_pos.token {
             Token::Print => {
                 it.eat(&Token::Print, "statement")?;
-                let expr = it.parse(&parse_expression, "print statement")?;
+                let expr = it.parse(&parse_expression)?;
                 let (st_line, st_pos) = (token_pos.st_line, token_pos.st_pos);
                 let (en_line, en_pos) = (expr.en_line, expr.en_pos);
                 let node = ASTNode::Print { expr };
@@ -34,7 +34,7 @@ pub fn parse_statement(it: &mut TPIterator) -> ParseResult {
             Token::Raise => {
                 it.eat(&Token::Raise, "statement")?;
                 let (st_line, st_pos) = (token_pos.st_line, token_pos.st_pos);
-                let error = it.parse(&parse_expression, "raise")?;
+                let error = it.parse(&parse_expression)?;
                 let (en_line, en_pos) = (error.en_line, error.en_pos);
                 let node = ASTNode::Raise { error };
                 Ok(Box::from(ASTNodePos { st_line, st_pos, en_line, en_pos, node }))
@@ -42,7 +42,7 @@ pub fn parse_statement(it: &mut TPIterator) -> ParseResult {
             Token::Def => parse_definition(it),
             Token::With => parse_with(it),
             Token::For | Token::While => parse_cntrl_flow_stmt(it),
-            _ => Err(CustomErr { expected: "statement".to_string(), actual: token_pos.clone() })
+            _ => Err(expected_construct("statement", token_pos))
         },
         "statement"
     )
@@ -51,9 +51,9 @@ pub fn parse_statement(it: &mut TPIterator) -> ParseResult {
 pub fn parse_with(it: &mut TPIterator) -> ParseResult {
     let (st_line, st_pos) = it.start_pos()?;
     it.eat(&Token::With, "with")?;
-    let resource = it.parse(&parse_expression, "with resource")?;
+    let resource = it.parse(&parse_expression)?;
     let _as = it.parse_if(&Token::As, &parse_id_maybe_type, "with id")?;
-    let expr = it.parse(&parse_expr_or_stmt, "with body")?;
+    let expr = it.parse(&parse_expr_or_stmt)?;
 
     let (en_line, en_pos) = (expr.en_line, expr.en_pos);
     let node = ASTNode::With { resource, _as, expr };

--- a/src/parser/statement.rs
+++ b/src/parser/statement.rs
@@ -15,7 +15,7 @@ pub fn parse_statement(it: &mut TPIterator) -> ParseResult {
         &|it, token_pos| match token_pos.token {
             Token::Print => {
                 it.eat(&Token::Print, "statement")?;
-                let expr = it.parse(&parse_expression)?;
+                let expr = it.parse(&parse_expression, "statement")?;
                 let (st_line, st_pos) = (token_pos.st_line, token_pos.st_pos);
                 let (en_line, en_pos) = (expr.en_line, expr.en_pos);
                 let node = ASTNode::Print { expr };
@@ -34,7 +34,7 @@ pub fn parse_statement(it: &mut TPIterator) -> ParseResult {
             Token::Raise => {
                 it.eat(&Token::Raise, "statement")?;
                 let (st_line, st_pos) = (token_pos.st_line, token_pos.st_pos);
-                let error = it.parse(&parse_expression)?;
+                let error = it.parse(&parse_expression, "statement")?;
                 let (en_line, en_pos) = (error.en_line, error.en_pos);
                 let node = ASTNode::Raise { error };
                 Ok(Box::from(ASTNodePos { st_line, st_pos, en_line, en_pos, node }))
@@ -72,9 +72,9 @@ pub fn parse_statement(it: &mut TPIterator) -> ParseResult {
 pub fn parse_with(it: &mut TPIterator) -> ParseResult {
     let (st_line, st_pos) = it.start_pos("with")?;
     it.eat(&Token::With, "with")?;
-    let resource = it.parse(&parse_expression)?;
+    let resource = it.parse(&parse_expression, "with")?;
     let _as = it.parse_if(&Token::As, &parse_id_maybe_type, "with id")?;
-    let expr = it.parse(&parse_expr_or_stmt)?;
+    let expr = it.parse(&parse_expr_or_stmt, "with")?;
 
     let (en_line, en_pos) = (expr.en_line, expr.en_pos);
     let node = ASTNode::With { resource, _as, expr };

--- a/src/parser/statement.rs
+++ b/src/parser/statement.rs
@@ -7,7 +7,7 @@ use crate::parser::definition::parse_definition;
 use crate::parser::expr_or_stmt::parse_expr_or_stmt;
 use crate::parser::expression::parse_expression;
 use crate::parser::iterator::TPIterator;
-use crate::parser::parse_result::expected_construct;
+use crate::parser::parse_result::expected_one_of;
 use crate::parser::parse_result::ParseResult;
 
 pub fn parse_statement(it: &mut TPIterator) -> ParseResult {
@@ -42,14 +42,35 @@ pub fn parse_statement(it: &mut TPIterator) -> ParseResult {
             Token::Def => parse_definition(it),
             Token::With => parse_with(it),
             Token::For | Token::While => parse_cntrl_flow_stmt(it),
-            _ => Err(expected_construct("statement", token_pos))
+            _ => Err(expected_one_of(
+                &[
+                    Token::Print,
+                    Token::Pass,
+                    Token::Raise,
+                    Token::Def,
+                    Token::With,
+                    Token::For,
+                    Token::While
+                ],
+                token_pos,
+                "statement"
+            ))
         },
+        &[
+            Token::Print,
+            Token::Pass,
+            Token::Raise,
+            Token::Def,
+            Token::With,
+            Token::For,
+            Token::While
+        ],
         "statement"
     )
 }
 
 pub fn parse_with(it: &mut TPIterator) -> ParseResult {
-    let (st_line, st_pos) = it.start_pos()?;
+    let (st_line, st_pos) = it.start_pos("with")?;
     it.eat(&Token::With, "with")?;
     let resource = it.parse(&parse_expression)?;
     let _as = it.parse_if(&Token::As, &parse_id_maybe_type, "with id")?;

--- a/src/parser/statement.rs
+++ b/src/parser/statement.rs
@@ -15,7 +15,8 @@ pub fn parse_statement(it: &mut TPIterator) -> ParseResult {
         &|it, token_pos| match token_pos.token {
             Token::Print => {
                 it.eat(&Token::Print, "statement")?;
-                let expr = it.parse(&parse_expression, "statement")?;
+                let expr =
+                    it.parse(&parse_expression, "statement", token_pos.st_line, token_pos.st_pos)?;
                 let (st_line, st_pos) = (token_pos.st_line, token_pos.st_pos);
                 let (en_line, en_pos) = (expr.en_line, expr.en_pos);
                 let node = ASTNode::Print { expr };
@@ -34,7 +35,7 @@ pub fn parse_statement(it: &mut TPIterator) -> ParseResult {
             Token::Raise => {
                 it.eat(&Token::Raise, "statement")?;
                 let (st_line, st_pos) = (token_pos.st_line, token_pos.st_pos);
-                let error = it.parse(&parse_expression, "statement")?;
+                let error = it.parse(&parse_expression, "statement", st_line, st_pos)?;
                 let (en_line, en_pos) = (error.en_line, error.en_pos);
                 let node = ASTNode::Raise { error };
                 Ok(Box::from(ASTNodePos { st_line, st_pos, en_line, en_pos, node }))
@@ -72,9 +73,9 @@ pub fn parse_statement(it: &mut TPIterator) -> ParseResult {
 pub fn parse_with(it: &mut TPIterator) -> ParseResult {
     let (st_line, st_pos) = it.start_pos("with")?;
     it.eat(&Token::With, "with")?;
-    let resource = it.parse(&parse_expression, "with")?;
-    let _as = it.parse_if(&Token::As, &parse_id_maybe_type, "with id")?;
-    let expr = it.parse(&parse_expr_or_stmt, "with")?;
+    let resource = it.parse(&parse_expression, "with", st_line, st_pos)?;
+    let _as = it.parse_if(&Token::As, &parse_id_maybe_type, "with id", st_line, st_pos)?;
+    let expr = it.parse(&parse_expr_or_stmt, "with", st_line, st_pos)?;
 
     let (en_line, en_pos) = (expr.en_line, expr.en_pos);
     let node = ASTNode::With { resource, _as, expr };

--- a/src/pipeline/error.rs
+++ b/src/pipeline/error.rs
@@ -5,52 +5,35 @@ use std::path::PathBuf;
 const SYNTAX_ERR_MAX_DEPTH: usize = 2;
 
 pub fn syntax_err(err: &ParseErr, source: &str, in_path: &PathBuf) -> String {
-    let source_line = source.lines().nth(err.line as usize - 1);
-
-    let trimmed_causes = &err.causes[0..min(err.causes.len(), SYNTAX_ERR_MAX_DEPTH)];
-
-    let mut offset = -2;
-    let mut last_line = -1;
-    let cause_formatter = trimmed_causes.iter().fold(String::new(), |acc, (cause, line, pos)| {
-        let source_line = if *line > 0 { source.lines().nth(*line as usize - 1) } else { Some("") };
-
-        if last_line != *line {
-            last_line = *line;
-            offset += 2;
+    let cause_formatter = &err.causes[0..min(err.causes.len(), SYNTAX_ERR_MAX_DEPTH)].iter().fold(
+        String::new(),
+        |acc, cause| {
             acc + &format!(
-                "     | {}|- {}\n     | {}^ {} ({}:{})\n",
-                String::from_utf8(vec![b' '; offset as usize]).unwrap(),
-                source_line.unwrap_or(""),
-                String::from_utf8(vec![b' '; (pos + 2 + offset) as usize]).unwrap(),
-                cause,
-                line,
-                pos,
-            )
-        } else {
-            acc + &format!(
-                "     | {}^ {} ({}:{})\n",
-                String::from_utf8(vec![b' '; (pos + 2 + offset) as usize]).unwrap(),
-                cause,
-                line,
-                pos,
+                "     | {:3} |- {}\n     | {}^ in {} ({}:{})\n",
+                cause.line,
+                source.lines().nth(cause.line as usize - 1).unwrap_or(""),
+                String::from_utf8(vec![b' '; cause.pos as usize + 6]).unwrap(),
+                cause.cause,
+                cause.line,
+                cause.pos,
             )
         }
-    });
+    );
 
     format!(
         "--> {}:{}:{}
-{:3}  | {}
-     | {}{}
      | {}
+     | {:3} |- {}
+     | {}{}
 {}",
         in_path.display(),
         err.line,
         err.pos,
-        err.line,
-        source_line.unwrap_or(""),
-        String::from_utf8(vec![b' '; err.pos as usize - 1]).unwrap(),
-        String::from_utf8(vec![b'^'; err.width as usize]).unwrap(),
         err.msg,
+        err.line,
+        source.lines().nth(err.line as usize - 1).unwrap_or(""),
+        String::from_utf8(vec![b' '; err.pos as usize + 6]).unwrap(),
+        String::from_utf8(vec![b'^'; err.width as usize]).unwrap(),
         cause_formatter
     )
 }

--- a/src/pipeline/error.rs
+++ b/src/pipeline/error.rs
@@ -2,7 +2,7 @@ use crate::parser::parse_result::ParseErr;
 use std::cmp::min;
 use std::path::PathBuf;
 
-const SYNTAX_ERR_MAX_DEPTH: usize = 3;
+const SYNTAX_ERR_MAX_DEPTH: usize = 2;
 
 pub fn syntax_err(err: &ParseErr, source: &str, in_path: &PathBuf) -> String {
     let source_line = source.lines().nth(err.line as usize - 1);
@@ -18,18 +18,18 @@ pub fn syntax_err(err: &ParseErr, source: &str, in_path: &PathBuf) -> String {
             last_line = *line;
             offset += 2;
             acc + &format!(
-                "     |{} |- {}\n     |{}^ {} ({}:{})\n",
-                String::from_utf8(vec![b' '; 2 + (err.pos + offset) as usize]).unwrap(),
+                "     | {}|- {}\n     | {}^ {} ({}:{})\n",
+                String::from_utf8(vec![b' '; offset as usize]).unwrap(),
                 source_line.unwrap_or(""),
-                String::from_utf8(vec![b' '; (err.pos + pos + 5 + offset) as usize]).unwrap(),
+                String::from_utf8(vec![b' '; (pos + 2 + offset) as usize]).unwrap(),
                 cause,
                 line,
                 pos,
             )
         } else {
             acc + &format!(
-                "     |{}^ {} ({}:{})\n",
-                String::from_utf8(vec![b' '; (err.pos + pos + 5 + offset) as usize]).unwrap(),
+                "     | {}^ {} ({}:{})\n",
+                String::from_utf8(vec![b' '; (pos + 2 + offset) as usize]).unwrap(),
                 cause,
                 line,
                 pos,
@@ -39,9 +39,10 @@ pub fn syntax_err(err: &ParseErr, source: &str, in_path: &PathBuf) -> String {
 
     format!(
         "--> {}:{}:{}
-     |
 {:3}  | {}
-     | {}{} {}\n{}",
+     | {}{}
+     | {}
+{}",
         in_path.display(),
         err.line,
         err.pos,

--- a/src/pipeline/error.rs
+++ b/src/pipeline/error.rs
@@ -5,35 +5,35 @@ use std::path::PathBuf;
 const SYNTAX_ERR_MAX_DEPTH: usize = 2;
 
 pub fn syntax_err(err: &ParseErr, source: &str, in_path: &PathBuf) -> String {
-    let cause_formatter = &err.causes[0..min(err.causes.len(), SYNTAX_ERR_MAX_DEPTH)].iter().fold(
-        String::new(),
-        |acc, cause| {
+    let cause_formatter = &err.causes[0..min(err.causes.len(), SYNTAX_ERR_MAX_DEPTH)]
+        .iter()
+        .rev()
+        .fold(String::new(), |acc, cause| {
             acc + &format!(
-                "     | {:3} |- {}\n     | {}^ in {} ({}:{})\n",
+                "{:3}  |- {}\n     | {}^ in {} ({}:{})\n",
                 cause.line,
                 source.lines().nth(cause.line as usize - 1).unwrap_or(""),
-                String::from_utf8(vec![b' '; cause.pos as usize + 6]).unwrap(),
+                String::from_utf8(vec![b' '; cause.pos as usize]).unwrap(),
                 cause.cause,
                 cause.line,
                 cause.pos,
             )
-        }
-    );
+        });
 
     format!(
         "--> {}:{}:{}
      | {}
-     | {:3} |- {}
-     | {}{}
-{}",
+{}
+{:3}  |- {}
+     | {}{}",
         in_path.display(),
         err.line,
         err.pos,
         err.msg,
+        cause_formatter,
         err.line,
         source.lines().nth(err.line as usize - 1).unwrap_or(""),
-        String::from_utf8(vec![b' '; err.pos as usize + 6]).unwrap(),
-        String::from_utf8(vec![b'^'; err.width as usize]).unwrap(),
-        cause_formatter
+        String::from_utf8(vec![b' '; err.pos as usize]).unwrap(),
+        String::from_utf8(vec![b'^'; err.width as usize]).unwrap()
     )
 }

--- a/src/pipeline/error.rs
+++ b/src/pipeline/error.rs
@@ -2,18 +2,26 @@ use crate::parser::parse_result::ParseErr;
 use std::cmp::min;
 use std::path::PathBuf;
 
-const SYNTAX_ERR_MAX_DEPTH: usize = 2;
+const SYNTAX_ERR_MAX_DEPTH: usize = 3;
 
 pub fn syntax_err(err: &ParseErr, source: &str, in_path: &PathBuf) -> String {
     let source_line = source.lines().nth(err.line as usize - 1);
 
     let trimmed_causes = &err.causes[0..min(err.causes.len(), SYNTAX_ERR_MAX_DEPTH)];
-    let cause_formatter = trimmed_causes.iter().fold(String::new(), |acc, cause| {
+
+    let mut offset = -2;
+    let cause_formatter = trimmed_causes.iter().fold(String::new(), |acc, (cause, line, pos)| {
+        let source_line = if *line > 0 { source.lines().nth(*line as usize - 1) } else { Some("") };
+
+        offset += 2;
         acc + &format!(
-            "{}{}{}\n",
-            String::from_utf8(vec![b' '; 5]).unwrap(),
-            String::from_utf8(vec![b' '; err.pos as usize - 1]).unwrap(),
-            cause
+            "     |{} |- {}\n     |{}^ {} ({}:{})\n",
+            String::from_utf8(vec![b' '; 2 + (err.pos + offset) as usize]).unwrap(),
+            source_line.unwrap_or(""),
+            String::from_utf8(vec![b' '; (err.pos + pos + 5 + offset) as usize]).unwrap(),
+            cause,
+            line,
+            pos,
         )
     });
 

--- a/src/pipeline/error.rs
+++ b/src/pipeline/error.rs
@@ -10,19 +10,31 @@ pub fn syntax_err(err: &ParseErr, source: &str, in_path: &PathBuf) -> String {
     let trimmed_causes = &err.causes[0..min(err.causes.len(), SYNTAX_ERR_MAX_DEPTH)];
 
     let mut offset = -2;
+    let mut last_line = -1;
     let cause_formatter = trimmed_causes.iter().fold(String::new(), |acc, (cause, line, pos)| {
         let source_line = if *line > 0 { source.lines().nth(*line as usize - 1) } else { Some("") };
 
-        offset += 2;
-        acc + &format!(
-            "     |{} |- {}\n     |{}^ {} ({}:{})\n",
-            String::from_utf8(vec![b' '; 2 + (err.pos + offset) as usize]).unwrap(),
-            source_line.unwrap_or(""),
-            String::from_utf8(vec![b' '; (err.pos + pos + 5 + offset) as usize]).unwrap(),
-            cause,
-            line,
-            pos,
-        )
+        if last_line != *line {
+            last_line = *line;
+            offset += 2;
+            acc + &format!(
+                "     |{} |- {}\n     |{}^ {} ({}:{})\n",
+                String::from_utf8(vec![b' '; 2 + (err.pos + offset) as usize]).unwrap(),
+                source_line.unwrap_or(""),
+                String::from_utf8(vec![b' '; (err.pos + pos + 5 + offset) as usize]).unwrap(),
+                cause,
+                line,
+                pos,
+            )
+        } else {
+            acc + &format!(
+                "     |{}^ {} ({}:{})\n",
+                String::from_utf8(vec![b' '; (err.pos + pos + 5 + offset) as usize]).unwrap(),
+                cause,
+                line,
+                pos,
+            )
+        }
     });
 
     format!(

--- a/src/pipeline/error.rs
+++ b/src/pipeline/error.rs
@@ -1,0 +1,20 @@
+use crate::parser::parse_result::ParseErr;
+use std::path::PathBuf;
+
+pub fn syntax_err(err: &ParseErr, source: &str, in_path: &PathBuf) -> String {
+    let source_line = source.lines().nth(err.line as usize - 1);
+    format!(
+        "--> {}:{}:{}
+     |
+{:3}  | {}
+     | {}{} {}\n",
+        in_path.display(),
+        err.line,
+        err.pos,
+        err.line,
+        source_line.unwrap_or(""),
+        String::from_utf8(vec![b' '; err.pos as usize - 1]).unwrap(),
+        String::from_utf8(vec![b'^'; err.width as usize]).unwrap(),
+        err.msg
+    )
+}

--- a/src/pipeline/mod.rs
+++ b/src/pipeline/mod.rs
@@ -138,7 +138,7 @@ fn input(in_path: &PathBuf) -> Result<ASTNodePos, (String, String)> {
                 in_path.display(),
                 err.line,
                 err.pos,
-                err.pos,
+                err.line,
                 source_line,
                 String::from_utf8(vec![b' '; err.pos as usize - 1]).unwrap(),
                 String::from_utf8(vec![b'^'; err.width as usize]).unwrap(),
@@ -152,7 +152,7 @@ fn input(in_path: &PathBuf) -> Result<ASTNodePos, (String, String)> {
                 in_path.display(),
                 err.line,
                 err.pos,
-                err.pos,
+                err.line,
                 String::from_utf8(vec![b' '; err.pos as usize]).unwrap(),
                 err.msg
             )

--- a/src/pipeline/mod.rs
+++ b/src/pipeline/mod.rs
@@ -132,8 +132,8 @@ fn input(in_path: &PathBuf) -> Result<ASTNodePos, (String, String)> {
             Some(source_line) => format!(
                 "--> {}:{}:{}
     |
-{}  |  {}
-    |  {}{} {}
+{}  | {}
+    | {}{} {}
             ",
                 in_path.display(),
                 err.line,
@@ -147,7 +147,7 @@ fn input(in_path: &PathBuf) -> Result<ASTNodePos, (String, String)> {
             None => format!(
                 "--> {}:{}:{}\n|
 {}  |
-    |  {}^ {}
+    | {}^ {}
             ",
                 in_path.display(),
                 err.line,

--- a/tests/resources/valid/class/generics.mamba
+++ b/tests/resources/valid/class/generics.mamba
@@ -1,7 +1,7 @@
 # This class has no state
 class MyClass2[C, A isa MyGeneric] isa MyType[A, C]
     def private z_modified
-    def private mut <- 10
+    def private mut other_field <- 10
 
     def init(mut self, other_field: Int, z: Int) raises [Err] =>
         if z > 10 then raise Err("Something is wrong!")

--- a/tests/resources/valid/class/generics.mamba
+++ b/tests/resources/valid/class/generics.mamba
@@ -1,7 +1,7 @@
 # This class has no state
 class MyClass2[C, A isa MyGeneric] isa MyType[A, C]
     def private z_modified
-    def private mut other_field <- 10
+    def private mut <- 10
 
     def init(mut self, other_field: Int, z: Int) raises [Err] =>
         if z > 10 then raise Err("Something is wrong!")


### PR DESCRIPTION
### Relevant issues
Resolves #95 

### Summary
Display parse errors as syntax error messages, together with the accompanyin source code. I.e.:

```
[syntax] ✖ --> path/to/file/generics.mamba:19:28
    |
28  |     def private fun_b(self => print "this function is private!"
    |                            ^^ Expected an identifier, but found token '=>'
``` 
