### PR TITLE
Add unimplemented error message

### DIFF
--- a/src/desugar/call.rs
+++ b/src/desugar/call.rs
@@ -2,19 +2,20 @@ use crate::core::construct::Core;
 use crate::desugar::common::desugar_vec;
 use crate::desugar::context::Context;
 use crate::desugar::context::State;
+use crate::desugar::desugar_result::DesugarResult;
 use crate::desugar::node::desugar_node;
 use crate::parser::ast::ASTNode;
 
-pub fn desugar_call(node: &ASTNode, ctx: &mut Context, state: &State) -> Core {
-    match node {
+pub fn desugar_call(node: &ASTNode, ctx: &mut Context, state: &State) -> DesugarResult {
+    Ok(match node {
         ASTNode::PropertyCall { instance, property } => Core::PropertyCall {
-            object:   Box::from(desugar_node(instance, ctx, state)),
-            property: Box::from(desugar_node(property, ctx, state))
+            object:   Box::from(desugar_node(instance, ctx, state)?),
+            property: Box::from(desugar_node(property, ctx, state)?)
         },
         ASTNode::FunctionCall { name, args } => Core::FunctionCall {
-            function: Box::from(desugar_node(name, ctx, state)),
-            args:     desugar_vec(args, ctx, state)
+            function: Box::from(desugar_node(name, ctx, state)?),
+            args:     desugar_vec(args, ctx, state)?
         },
         other => panic!("Expected call flow but was: {:?}.", other)
-    }
+    })
 }

--- a/src/desugar/call.rs
+++ b/src/desugar/call.rs
@@ -1,20 +1,21 @@
 use crate::core::construct::Core;
 use crate::desugar::common::desugar_vec;
-use crate::desugar::context::Context;
+use crate::desugar::context::Imports;
 use crate::desugar::context::State;
 use crate::desugar::desugar_result::DesugarResult;
 use crate::desugar::node::desugar_node;
 use crate::parser::ast::ASTNode;
+use crate::parser::ast::ASTNodePos;
 
-pub fn desugar_call(node: &ASTNode, ctx: &mut Context, state: &State) -> DesugarResult {
-    Ok(match node {
+pub fn desugar_call(node_pos: &ASTNodePos, imp: &mut Imports, state: &State) -> DesugarResult {
+    Ok(match &node_pos.node {
         ASTNode::PropertyCall { instance, property } => Core::PropertyCall {
-            object:   Box::from(desugar_node(instance, ctx, state)?),
-            property: Box::from(desugar_node(property, ctx, state)?)
+            object:   Box::from(desugar_node(instance, imp, state)?),
+            property: Box::from(desugar_node(property, imp, state)?)
         },
         ASTNode::FunctionCall { name, args } => Core::FunctionCall {
-            function: Box::from(desugar_node(name, ctx, state)?),
-            args:     desugar_vec(args, ctx, state)?
+            function: Box::from(desugar_node(name, imp, state)?),
+            args:     desugar_vec(args, imp, state)?
         },
         other => panic!("Expected call flow but was: {:?}.", other)
     })

--- a/src/desugar/class.rs
+++ b/src/desugar/class.rs
@@ -2,6 +2,7 @@ use crate::core::construct::Core;
 use crate::desugar::common::desugar_vec;
 use crate::desugar::context::Context;
 use crate::desugar::context::State;
+use crate::desugar::desugar_result::DesugarResult;
 use crate::desugar::node::desugar_node;
 use crate::parser::ast::ASTNode;
 use crate::parser::ast::ASTNodePos;
@@ -14,40 +15,41 @@ use std::ops::Deref;
 /// This property should be ensured by the type checker.
 ///
 /// We add arguments and calls to super for parents.
-pub fn desugar_class(node: &ASTNode, ctx: &mut Context, state: &State) -> Core {
-    match node {
+pub fn desugar_class(node: &ASTNode, ctx: &mut Context, state: &State) -> DesugarResult {
+    Ok(match node {
         ASTNode::TypeDef { _type, body: Some(body) } => match (&_type.node, &body.node) {
             (ASTNode::Type { id, .. }, ASTNode::Block { statements }) => Core::ClassDef {
-                name:        Box::from(desugar_node(id, ctx, state)),
+                name:        Box::from(desugar_node(id, ctx, state)?),
                 parents:     Vec::new(),
                 definitions: desugar_vec(statements, ctx, &State {
                     tup:         state.tup,
                     expect_expr: state.expect_expr,
                     interface:   true
-                })
+                })?
             },
             other => panic!("desugar didn't recognize while making type definition: {:?}.", other)
         },
         ASTNode::TypeDef { _type, body: None } => match &_type.node {
             ASTNode::Type { id, .. } => Core::ClassDef {
-                name:        Box::from(desugar_node(id, ctx, state)),
-                parents:     Vec::new(),
-                definitions: Vec::new()
+                name:        Box::from(desugar_node(id, ctx, state)?),
+                parents:     vec![],
+                definitions: vec![]
             },
             other => panic!("desugar didn't recognize while making type definition: {:?}.", other)
         },
 
         ASTNode::Class { _type, body, args, parents } => match (&_type.node, &body.node) {
             (ASTNode::Type { id, .. }, ASTNode::Block { statements }) => {
-                let (parent_names, parent_args, super_calls) = extract_parents(parents, ctx, state);
-                let core_definitions: Vec<Core> = desugar_vec(statements, ctx, state);
-                let inline_args = desugar_vec(args, ctx, state);
+                let (parent_names, parent_args, super_calls) =
+                    extract_parents(parents, ctx, state)?;
+                let core_definitions: Vec<Core> = desugar_vec(statements, ctx, state)?;
+                let inline_args = desugar_vec(args, ctx, state)?;
 
                 let final_definitions = if parent_names.is_empty() && inline_args.is_empty() {
-                    desugar_vec(statements, ctx, state)
+                    desugar_vec(statements, ctx, state)?
                 } else {
                     let (found_constructor, augmented_definitions) =
-                        add_parent_to_constructor(&core_definitions, &parent_args, &super_calls);
+                        add_parent_to_constructor(&core_definitions, &parent_args, &super_calls)?;
 
                     if found_constructor && !args.is_empty() {
                         panic!("Cannot have explicit constructor and inline arguments.")
@@ -59,20 +61,20 @@ pub fn desugar_class(node: &ASTNode, ctx: &mut Context, state: &State) -> Core {
                             &parent_args,
                             &super_calls,
                             &augmented_definitions
-                        )
+                        )?
                     }
                 };
 
                 Core::ClassDef {
-                    name:        Box::from(desugar_node(id, ctx, state)),
+                    name:        Box::from(desugar_node(id, ctx, state)?),
                     parents:     parent_names,
                     definitions: final_definitions
                 }
             }
-            other => panic!("desugarer didn't recognize while making class: {:?}.", other)
+            other => panic!("Didn't recognize while making class: {:?}.", other)
         },
         other => panic!("Expected class or type definition but was {:?}", other)
-    }
+    })
 }
 
 fn constructor_from_inline(
@@ -80,7 +82,7 @@ fn constructor_from_inline(
     parent_args: &[Core],
     super_calls: &[Core],
     definitions: &[Core]
-) -> Vec<Core> {
+) -> DesugarResult<Vec<Core>> {
     let mut final_definitions = vec![];
     let mut args = vec![Core::Id { lit: String::from("self") }];
 
@@ -99,17 +101,17 @@ fn constructor_from_inline(
     let id = Box::from(Core::Id { lit: String::from("init") });
     let body = Box::from(Core::Block { statements: Vec::from(super_calls) });
     let core_init = Core::FunDef { private: false, id, args, body };
+
     final_definitions.push(core_init);
     final_definitions.append(&mut Vec::from(definitions));
-
-    final_definitions
+    Ok(final_definitions)
 }
 
 fn add_parent_to_constructor(
     core_definitions: &[Core],
     parent_args: &[Core],
     super_calls: &[Core]
-) -> (bool, Vec<Core>) {
+) -> DesugarResult<(bool, Vec<Core>)> {
     let mut final_definitions = vec![];
     let mut found_constructor = false;
 
@@ -153,14 +155,14 @@ fn add_parent_to_constructor(
         );
     }
 
-    (found_constructor, final_definitions)
+    Ok((found_constructor, final_definitions))
 }
 
 fn extract_parents(
     parents: &[ASTNodePos],
     ctx: &mut Context,
     state: &State
-) -> (Vec<Core>, Vec<Core>, Vec<Core>) {
+) -> DesugarResult<(Vec<Core>, Vec<Core>, Vec<Core>)> {
     let mut parent_names: Vec<Core> = vec![];
     let mut parent_args: Vec<Core> = vec![];
     let mut super_calls: Vec<Core> = vec![];
@@ -168,11 +170,11 @@ fn extract_parents(
     for parent in parents {
         match &parent.node {
             ASTNode::Parent { ref id, args: old_args, .. } => {
-                parent_names.push(desugar_node(id, ctx, state));
+                parent_names.push(desugar_node(id, ctx, state)?);
 
                 let mut args = vec![Core::Id { lit: String::from("self") }];
-                args.append(&mut desugar_vec(old_args, ctx, state));
-                parent_args.append(&mut desugar_vec(old_args, ctx, state));
+                args.append(&mut desugar_vec(old_args, ctx, state)?);
+                parent_args.append(&mut desugar_vec(old_args, ctx, state)?);
 
                 super_calls.push(Core::PropertyCall {
                     object:   Box::from(Core::FunctionCall {
@@ -189,5 +191,5 @@ fn extract_parents(
         }
     }
 
-    (parent_names, parent_args, super_calls)
+    Ok((parent_names, parent_args, super_calls))
 }

--- a/src/desugar/common.rs
+++ b/src/desugar/common.rs
@@ -1,5 +1,5 @@
 use crate::core::construct::Core;
-use crate::desugar::context::Context;
+use crate::desugar::context::Imports;
 use crate::desugar::context::State;
 use crate::desugar::desugar_result::DesugarResult;
 use crate::desugar::node::desugar_node;
@@ -7,12 +7,12 @@ use crate::parser::ast::ASTNodePos;
 
 pub fn desugar_vec(
     node_vec: &[ASTNodePos],
-    ctx: &mut Context,
+    imp: &mut Imports,
     state: &State
 ) -> DesugarResult<Vec<Core>> {
     let mut result = vec![];
     for node_pos in node_vec {
-        result.push(desugar_node(node_pos, ctx, state)?)
+        result.push(desugar_node(node_pos, imp, state)?)
     }
 
     Ok(result)

--- a/src/desugar/common.rs
+++ b/src/desugar/common.rs
@@ -1,9 +1,19 @@
 use crate::core::construct::Core;
 use crate::desugar::context::Context;
 use crate::desugar::context::State;
+use crate::desugar::desugar_result::DesugarResult;
 use crate::desugar::node::desugar_node;
 use crate::parser::ast::ASTNodePos;
 
-pub fn desugar_vec(node_pos: &[ASTNodePos], ctx: &mut Context, state: &State) -> Vec<Core> {
-    node_pos.iter().map(|node_pos| desugar_node(node_pos, ctx, state)).collect()
+pub fn desugar_vec(
+    node_vec: &[ASTNodePos],
+    ctx: &mut Context,
+    state: &State
+) -> DesugarResult<Vec<Core>> {
+    let mut result = vec![];
+    for node_pos in node_vec {
+        result.push(desugar_node(node_pos, ctx, state)?)
+    }
+
+    Ok(result)
 }

--- a/src/desugar/context.rs
+++ b/src/desugar/context.rs
@@ -10,12 +10,12 @@ impl State {
     pub fn new() -> State { State { tup: 1, expect_expr: false, interface: false } }
 }
 
-pub struct Context {
+pub struct Imports {
     pub imports: Vec<Core>
 }
 
-impl Context {
-    pub fn new() -> Context { Context { imports: vec![] } }
+impl Imports {
+    pub fn new() -> Imports { Imports { imports: vec![] } }
 
     pub fn add_import(&mut self, import: &str) {
         self.imports.push(Core::Import { imports: vec![Core::Id { lit: String::from(import) }] });

--- a/src/desugar/control_flow.rs
+++ b/src/desugar/control_flow.rs
@@ -1,25 +1,30 @@
 use crate::core::construct::Core;
-use crate::desugar::context::Context;
+use crate::desugar::context::Imports;
 use crate::desugar::context::State;
 use crate::desugar::desugar_result::DesugarResult;
 use crate::desugar::node::desugar_node;
 use crate::parser::ast::ASTNode;
+use crate::parser::ast::ASTNodePos;
 
-pub fn desugar_control_flow(node: &ASTNode, ctx: &mut Context, state: &State) -> DesugarResult {
-    Ok(match node {
+pub fn desugar_control_flow(
+    node_pos: &ASTNodePos,
+    imp: &mut Imports,
+    state: &State
+) -> DesugarResult {
+    Ok(match &node_pos.node {
         ASTNode::IfElse { cond, then, _else } => match _else {
             Some(_else) => Core::IfElse {
-                cond:  Box::from(desugar_node(cond, ctx, state)?),
-                then:  Box::from(desugar_node(then, ctx, state)?),
-                _else: Box::from(desugar_node(_else, ctx, state)?)
+                cond:  Box::from(desugar_node(cond, imp, state)?),
+                then:  Box::from(desugar_node(then, imp, state)?),
+                _else: Box::from(desugar_node(_else, imp, state)?)
             },
             None => Core::If {
-                cond: Box::from(desugar_node(cond, ctx, state)?),
-                then: Box::from(desugar_node(then, ctx, state)?)
+                cond: Box::from(desugar_node(cond, imp, state)?),
+                then: Box::from(desugar_node(then, imp, state)?)
             }
         },
         ASTNode::Match { cond, cases } => {
-            let expr = Box::from(desugar_node(cond, ctx, state)?);
+            let expr = Box::from(desugar_node(cond, imp, state)?);
             let mut core_cases = vec![];
             let mut core_defaults = vec![];
 
@@ -28,10 +33,10 @@ pub fn desugar_control_flow(node: &ASTNode, ctx: &mut Context, state: &State) ->
                     ASTNode::Case { cond, body } => match &cond.node {
                         ASTNode::IdType { id, .. } => match id.node {
                             ASTNode::Underscore =>
-                                core_defaults.push(desugar_node(body.as_ref(), ctx, state)?),
+                                core_defaults.push(desugar_node(body.as_ref(), imp, state)?),
                             _ => core_cases.push(Core::KeyValue {
-                                key:   Box::from(desugar_node(cond.as_ref(), ctx, state)?),
-                                value: Box::from(desugar_node(body.as_ref(), ctx, state)?)
+                                key:   Box::from(desugar_node(cond.as_ref(), imp, state)?),
+                                value: Box::from(desugar_node(body.as_ref(), imp, state)?)
                             })
                         },
                         other => panic!("Expected id type as cond but was {:?}", other)
@@ -48,19 +53,19 @@ pub fn desugar_control_flow(node: &ASTNode, ctx: &mut Context, state: &State) ->
                     body: Box::from(core_defaults[0].clone())
                 });
 
-                ctx.add_from_import("collections", "defaultdict");
+                imp.add_from_import("collections", "defaultdict");
                 Core::DefaultDictionary { expr, cases: core_cases, default }
             } else {
                 Core::Dictionary { expr, cases: core_cases }
             }
         }
         ASTNode::While { cond, body } => Core::While {
-            cond: Box::from(desugar_node(cond, ctx, state)?),
-            body: Box::from(desugar_node(body, ctx, state)?)
+            cond: Box::from(desugar_node(cond, imp, state)?),
+            body: Box::from(desugar_node(body, imp, state)?)
         },
         ASTNode::For { expr, body } => Core::For {
-            expr: Box::from(desugar_node(expr, ctx, state)?),
-            body: Box::from(desugar_node(body, ctx, state)?)
+            expr: Box::from(desugar_node(expr, imp, state)?),
+            body: Box::from(desugar_node(body, imp, state)?)
         },
 
         ASTNode::Break => Core::Break,

--- a/src/desugar/definition.rs
+++ b/src/desugar/definition.rs
@@ -1,16 +1,21 @@
 use crate::core::construct::Core;
 use crate::desugar::common::desugar_vec;
-use crate::desugar::context::Context;
+use crate::desugar::context::Imports;
 use crate::desugar::context::State;
 use crate::desugar::desugar_result::DesugarResult;
 use crate::desugar::node::desugar_node;
 use crate::parser::ast::ASTNode;
+use crate::parser::ast::ASTNodePos;
 
-pub fn desugar_definition(node: &ASTNode, ctx: &mut Context, state: &State) -> DesugarResult {
-    Ok(match node {
+pub fn desugar_definition(
+    node_pos: &ASTNodePos,
+    imp: &mut Imports,
+    state: &State
+) -> DesugarResult {
+    Ok(match &node_pos.node {
         ASTNode::Def { private, definition, .. } => match &definition.node {
             ASTNode::VariableDef { id_maybe_type, expression, .. } => {
-                let id = desugar_node(id_maybe_type, ctx, state)?;
+                let id = desugar_node(id_maybe_type, imp, state)?;
                 let new_state = &State {
                     tup:         match id.clone() {
                         Core::Tuple { elements } => elements.len(),
@@ -24,7 +29,7 @@ pub fn desugar_definition(node: &ASTNode, ctx: &mut Context, state: &State) -> D
                     private: *private,
                     id:      Box::from(id.clone()),
                     right:   match (id.clone(), expression) {
-                        (_, Some(expr)) => Box::from(desugar_node(&expr, ctx, &new_state)?),
+                        (_, Some(expr)) => Box::from(desugar_node(&expr, imp, &new_state)?),
                         (Core::Tuple { elements }, None) =>
                             Box::from(Core::Tuple { elements: vec![Core::None; elements.len()] }),
                         (_, None) => Box::from(Core::None)
@@ -33,13 +38,13 @@ pub fn desugar_definition(node: &ASTNode, ctx: &mut Context, state: &State) -> D
             }
             ASTNode::FunDef { id, fun_args, body: expression, .. } => Core::FunDef {
                 private: *private,
-                id:      Box::from(desugar_node(&id, ctx, state)?),
-                args:    desugar_vec(&fun_args, ctx, state)?,
+                id:      Box::from(desugar_node(&id, imp, state)?),
+                args:    desugar_vec(&fun_args, imp, state)?,
                 body:    if state.interface {
                     Box::from(Core::Pass)
                 } else {
                     Box::from(match expression {
-                        Some(expr) => desugar_node(&expr, ctx, &State {
+                        Some(expr) => desugar_node(&expr, imp, &State {
                             tup:         state.tup,
                             expect_expr: true,
                             interface:   state.interface

--- a/src/desugar/definition.rs
+++ b/src/desugar/definition.rs
@@ -2,14 +2,15 @@ use crate::core::construct::Core;
 use crate::desugar::common::desugar_vec;
 use crate::desugar::context::Context;
 use crate::desugar::context::State;
+use crate::desugar::desugar_result::DesugarResult;
 use crate::desugar::node::desugar_node;
 use crate::parser::ast::ASTNode;
 
-pub fn desugar_definition(node: &ASTNode, ctx: &mut Context, state: &State) -> Core {
-    match node {
+pub fn desugar_definition(node: &ASTNode, ctx: &mut Context, state: &State) -> DesugarResult {
+    Ok(match node {
         ASTNode::Def { private, definition, .. } => match &definition.node {
             ASTNode::VariableDef { id_maybe_type, expression, .. } => {
-                let id = desugar_node(id_maybe_type, ctx, state);
+                let id = desugar_node(id_maybe_type, ctx, state)?;
                 let new_state = &State {
                     tup:         match id.clone() {
                         Core::Tuple { elements } => elements.len(),
@@ -23,7 +24,7 @@ pub fn desugar_definition(node: &ASTNode, ctx: &mut Context, state: &State) -> C
                     private: *private,
                     id:      Box::from(id.clone()),
                     right:   match (id.clone(), expression) {
-                        (_, Some(expr)) => Box::from(desugar_node(&expr, ctx, &new_state)),
+                        (_, Some(expr)) => Box::from(desugar_node(&expr, ctx, &new_state)?),
                         (Core::Tuple { elements }, None) =>
                             Box::from(Core::Tuple { elements: vec![Core::None; elements.len()] }),
                         (_, None) => Box::from(Core::None)
@@ -32,8 +33,8 @@ pub fn desugar_definition(node: &ASTNode, ctx: &mut Context, state: &State) -> C
             }
             ASTNode::FunDef { id, fun_args, body: expression, .. } => Core::FunDef {
                 private: *private,
-                id:      Box::from(desugar_node(&id, ctx, state)),
-                args:    desugar_vec(&fun_args, ctx, state),
+                id:      Box::from(desugar_node(&id, ctx, state)?),
+                args:    desugar_vec(&fun_args, ctx, state)?,
                 body:    if state.interface {
                     Box::from(Core::Pass)
                 } else {
@@ -42,7 +43,7 @@ pub fn desugar_definition(node: &ASTNode, ctx: &mut Context, state: &State) -> C
                             tup:         state.tup,
                             expect_expr: true,
                             interface:   state.interface
-                        }),
+                        })?,
                         None => Core::Empty
                     })
                 }
@@ -50,5 +51,5 @@ pub fn desugar_definition(node: &ASTNode, ctx: &mut Context, state: &State) -> C
             definition => panic!("invalid definition format: {:?}.", definition)
         },
         other => panic!("Expected definition but was: {:?}.", other)
-    }
+    })
 }

--- a/src/desugar/desugar_result.rs
+++ b/src/desugar/desugar_result.rs
@@ -1,4 +1,5 @@
 use crate::core::construct::Core;
+use crate::parser::ast::ASTNodePos;
 
 pub type DesugarResult<T = Core> = std::result::Result<T, UnimplementedErr>;
 
@@ -12,11 +13,11 @@ pub struct UnimplementedErr {
 }
 
 impl UnimplementedErr {
-    pub fn new(msg: &str) -> UnimplementedErr {
+    pub fn new(node_pos: &ASTNodePos, msg: &str) -> UnimplementedErr {
         UnimplementedErr {
-            line: 0,
-            pos:  0,
-            msg:  format!("The {} construct has not yet been implemented as of v{}", msg, VERSION)
+            line: node_pos.st_line,
+            pos:  node_pos.st_pos,
+            msg:  format!("The {} construct has not yet been implemented as of v{}.", msg, VERSION)
         }
     }
 }

--- a/src/desugar/desugar_result.rs
+++ b/src/desugar/desugar_result.rs
@@ -7,17 +7,22 @@ const VERSION: &str = env!("CARGO_PKG_VERSION");
 
 #[derive(Debug)]
 pub struct UnimplementedErr {
-    pub line: i32,
-    pub pos:  i32,
-    pub msg:  String
+    pub line:  i32,
+    pub pos:   i32,
+    pub width: i32,
+    pub msg:   String
 }
 
 impl UnimplementedErr {
     pub fn new(node_pos: &ASTNodePos, msg: &str) -> UnimplementedErr {
         UnimplementedErr {
-            line: node_pos.st_line,
-            pos:  node_pos.st_pos,
-            msg:  format!("The {} construct has not yet been implemented as of v{}.", msg, VERSION)
+            line:  node_pos.st_line,
+            pos:   node_pos.st_pos,
+            width: node_pos.en_pos - node_pos.st_pos,
+            msg:   format!(
+                "The {} construct has not yet been implemented as of v{}.",
+                msg, VERSION
+            )
         }
     }
 }

--- a/src/desugar/desugar_result.rs
+++ b/src/desugar/desugar_result.rs
@@ -1,0 +1,22 @@
+use crate::core::construct::Core;
+
+pub type DesugarResult<T = Core> = std::result::Result<T, UnimplementedErr>;
+
+const VERSION: &str = env!("CARGO_PKG_VERSION");
+
+#[derive(Debug)]
+pub struct UnimplementedErr {
+    pub line: i32,
+    pub pos:  i32,
+    pub msg:  String
+}
+
+impl UnimplementedErr {
+    pub fn new(msg: &str) -> UnimplementedErr {
+        UnimplementedErr {
+            line: 0,
+            pos:  0,
+            msg:  format!("The {} construct has not yet been implemented as of v{}", msg, VERSION)
+        }
+    }
+}

--- a/src/desugar/mod.rs
+++ b/src/desugar/mod.rs
@@ -1,4 +1,4 @@
-use crate::desugar::context::Context;
+use crate::desugar::context::Imports;
 use crate::desugar::context::State;
 use crate::desugar::desugar_result::DesugarResult;
 use crate::desugar::node::desugar_node;
@@ -77,5 +77,5 @@ pub mod desugar_result;
 /// let core_node = desugar(&ast_definition_node_pos);
 /// ```
 pub fn desugar(input: &ASTNodePos) -> DesugarResult {
-    desugar_node(&input, &mut Context::new(), &State::new())
+    desugar_node(&input, &mut Imports::new(), &State::new())
 }

--- a/src/desugar/node.rs
+++ b/src/desugar/node.rs
@@ -44,7 +44,7 @@ pub fn desugar_node(node_pos: &ASTNodePos, imp: &mut Imports, state: &State) -> 
 
         ASTNode::AddOp => Core::AddOp,
         ASTNode::SubOp => Core::SubOp,
-        ASTNode::SqrtOp => unimplemented!("sqrt"),
+        ASTNode::SqrtOp => return Err(UnimplementedErr::new(node_pos, "square root")),
         ASTNode::MulOp => Core::MulOp,
         ASTNode::FDivOp => Core::FDivOp,
         ASTNode::DivOp => Core::DivOp,
@@ -64,8 +64,8 @@ pub fn desugar_node(node_pos: &ASTNodePos, imp: &mut Imports, state: &State) -> 
         ASTNode::List { elements } => Core::List { elements: desugar_vec(elements, imp, state)? },
         ASTNode::Set { elements } => Core::Set { elements: desugar_vec(elements, imp, state)? },
 
-        ASTNode::ListBuilder { .. } => unimplemented!("list builder"),
-        ASTNode::SetBuilder { .. } => unimplemented!("set builder"),
+        ASTNode::ListBuilder { .. } => return Err(UnimplementedErr::new(node_pos, "list builder")),
+        ASTNode::SetBuilder { .. } => return Err(UnimplementedErr::new(node_pos, "set builder")),
 
         ASTNode::ReturnEmpty => Core::Return { expr: Box::from(Core::None) },
         ASTNode::Return { expr } =>
@@ -279,7 +279,7 @@ pub fn desugar_node(node_pos: &ASTNodePos, imp: &mut Imports, state: &State) -> 
         ASTNode::Raises { expr_or_stmt, .. } => desugar_node(expr_or_stmt, imp, state)?,
         ASTNode::Raise { error } =>
             Core::Raise { error: Box::from(desugar_node(error, imp, state)?) },
-        ASTNode::Retry { .. } => unimplemented!("Retry has not yet been implemented."),
+        ASTNode::Retry { .. } => return Err(UnimplementedErr::new(node_pos, "retry")),
 
         ASTNode::Handle { expr_or_stmt, cases } => {
             let mut statements = vec![];

--- a/src/desugar/node.rs
+++ b/src/desugar/node.rs
@@ -6,31 +6,33 @@ use crate::desugar::context::Context;
 use crate::desugar::context::State;
 use crate::desugar::control_flow::desugar_control_flow;
 use crate::desugar::definition::desugar_definition;
+use crate::desugar::desugar_result::DesugarResult;
+use crate::desugar::desugar_result::UnimplementedErr;
 use crate::parser::ast::ASTNode;
 use crate::parser::ast::ASTNodePos;
 
-pub fn desugar_node(node_pos: &ASTNodePos, ctx: &mut Context, state: &State) -> Core {
-    match &node_pos.node {
+pub fn desugar_node(node_pos: &ASTNodePos, ctx: &mut Context, state: &State) -> DesugarResult {
+    Ok(match &node_pos.node {
         ASTNode::Import { import, _as } => match _as.len() {
-            0 => Core::Import { imports: desugar_vec(import, ctx, state) },
+            0 => Core::Import { imports: desugar_vec(import, ctx, state)? },
             _ => Core::ImportAs {
-                imports: desugar_vec(import, ctx, state),
-                _as:     desugar_vec(_as, ctx, state)
+                imports: desugar_vec(import, ctx, state)?,
+                _as:     desugar_vec(_as, ctx, state)?
             }
         },
         ASTNode::FromImport { id, import } => Core::FromImport {
-            from:   Box::from(desugar_node(id, ctx, state)),
-            import: Box::from(desugar_node(import, ctx, state))
+            from:   Box::from(desugar_node(id, ctx, state)?),
+            import: Box::from(desugar_node(import, ctx, state)?)
         },
 
-        definition @ ASTNode::Def { .. } => desugar_definition(definition, ctx, state),
+        definition @ ASTNode::Def { .. } => desugar_definition(definition, ctx, state)?,
         ASTNode::Reassign { left, right } => Core::Assign {
-            left:  Box::from(desugar_node(left, ctx, state)),
-            right: Box::from(desugar_node(right, ctx, state))
+            left:  Box::from(desugar_node(left, ctx, state)?),
+            right: Box::from(desugar_node(right, ctx, state)?)
         },
 
         ASTNode::Block { statements } =>
-            Core::Block { statements: desugar_vec(statements, ctx, state) },
+            Core::Block { statements: desugar_vec(statements, ctx, state)? },
 
         ASTNode::Int { lit } => Core::Int { int: lit.clone() },
         ASTNode::Real { lit } => Core::Float { float: lit.clone() },
@@ -52,192 +54,192 @@ pub fn desugar_node(node_pos: &ASTNodePos, ctx: &mut Context, state: &State) -> 
         ASTNode::LeOp => Core::LeOp,
         ASTNode::GeOp => Core::GeOp,
 
-        ASTNode::IdType { id, .. } => desugar_node(id, ctx, state),
+        ASTNode::IdType { id, .. } => desugar_node(id, ctx, state)?,
         ASTNode::Id { lit } => Core::Id { lit: lit.clone() },
         ASTNode::_Self => Core::Id { lit: String::from("self") },
         ASTNode::Init => Core::Id { lit: String::from("init") },
         ASTNode::Bool { lit } => Core::Bool { _bool: *lit },
 
-        ASTNode::Tuple { elements } => Core::Tuple { elements: desugar_vec(elements, ctx, state) },
-        ASTNode::List { elements } => Core::List { elements: desugar_vec(elements, ctx, state) },
-        ASTNode::Set { elements } => Core::Set { elements: desugar_vec(elements, ctx, state) },
+        ASTNode::Tuple { elements } => Core::Tuple { elements: desugar_vec(elements, ctx, state)? },
+        ASTNode::List { elements } => Core::List { elements: desugar_vec(elements, ctx, state)? },
+        ASTNode::Set { elements } => Core::Set { elements: desugar_vec(elements, ctx, state)? },
 
         ASTNode::ListBuilder { .. } => unimplemented!("list builder"),
         ASTNode::SetBuilder { .. } => unimplemented!("set builder"),
 
         ASTNode::ReturnEmpty => Core::Return { expr: Box::from(Core::None) },
         ASTNode::Return { expr } =>
-            Core::Return { expr: Box::from(desugar_node(expr, ctx, state)) },
-        ASTNode::Print { expr } => Core::Print { expr: Box::from(desugar_node(expr, ctx, state)) },
+            Core::Return { expr: Box::from(desugar_node(expr, ctx, state)?) },
+        ASTNode::Print { expr } => Core::Print { expr: Box::from(desugar_node(expr, ctx, state)?) },
 
         control_flow @ ASTNode::IfElse { .. }
         | control_flow @ ASTNode::Match { .. }
         | control_flow @ ASTNode::While { .. }
         | control_flow @ ASTNode::For { .. }
         | control_flow @ ASTNode::Break
-        | control_flow @ ASTNode::Continue => desugar_control_flow(control_flow, ctx, state),
+        | control_flow @ ASTNode::Continue => desugar_control_flow(control_flow, ctx, state)?,
         ASTNode::Case { .. } => panic!("Case cannot be top-level"),
 
-        ASTNode::Not { expr } => Core::Not { expr: Box::from(desugar_node(expr, ctx, state)) },
+        ASTNode::Not { expr } => Core::Not { expr: Box::from(desugar_node(expr, ctx, state)?) },
         ASTNode::And { left, right } => Core::And {
-            left:  Box::from(desugar_node(left, ctx, state)),
-            right: Box::from(desugar_node(right, ctx, state))
+            left:  Box::from(desugar_node(left, ctx, state)?),
+            right: Box::from(desugar_node(right, ctx, state)?)
         },
         ASTNode::Or { left, right } => Core::Or {
-            left:  Box::from(desugar_node(left, ctx, state)),
-            right: Box::from(desugar_node(right, ctx, state))
+            left:  Box::from(desugar_node(left, ctx, state)?),
+            right: Box::from(desugar_node(right, ctx, state)?)
         },
         ASTNode::Is { left, right } => Core::Is {
-            left:  Box::from(desugar_node(left, ctx, state)),
-            right: Box::from(desugar_node(right, ctx, state))
+            left:  Box::from(desugar_node(left, ctx, state)?),
+            right: Box::from(desugar_node(right, ctx, state)?)
         },
         ASTNode::IsN { left, right } => Core::IsN {
-            left:  Box::from(desugar_node(left, ctx, state)),
-            right: Box::from(desugar_node(right, ctx, state))
+            left:  Box::from(desugar_node(left, ctx, state)?),
+            right: Box::from(desugar_node(right, ctx, state)?)
         },
         ASTNode::Eq { left, right } => Core::Eq {
-            left:  Box::from(desugar_node(left, ctx, state)),
-            right: Box::from(desugar_node(right, ctx, state))
+            left:  Box::from(desugar_node(left, ctx, state)?),
+            right: Box::from(desugar_node(right, ctx, state)?)
         },
         ASTNode::Neq { left, right } => Core::Neq {
-            left:  Box::from(desugar_node(left, ctx, state)),
-            right: Box::from(desugar_node(right, ctx, state))
+            left:  Box::from(desugar_node(left, ctx, state)?),
+            right: Box::from(desugar_node(right, ctx, state)?)
         },
         ASTNode::IsA { left, right } => Core::IsA {
-            left:  Box::from(desugar_node(left, ctx, state)),
-            right: Box::from(desugar_node(right, ctx, state))
+            left:  Box::from(desugar_node(left, ctx, state)?),
+            right: Box::from(desugar_node(right, ctx, state)?)
         },
         ASTNode::IsNA { left, right } => Core::Not {
             expr: Box::from(Core::IsA {
-                left:  Box::from(desugar_node(left, ctx, state)),
-                right: Box::from(desugar_node(right, ctx, state))
+                left:  Box::from(desugar_node(left, ctx, state)?),
+                right: Box::from(desugar_node(right, ctx, state)?)
             })
         },
 
         ASTNode::Add { left, right } => Core::Add {
-            left:  Box::from(desugar_node(left, ctx, state)),
-            right: Box::from(desugar_node(right, ctx, state))
+            left:  Box::from(desugar_node(left, ctx, state)?),
+            right: Box::from(desugar_node(right, ctx, state)?)
         },
         ASTNode::Sub { left, right } => Core::Sub {
-            left:  Box::from(desugar_node(left, ctx, state)),
-            right: Box::from(desugar_node(right, ctx, state))
+            left:  Box::from(desugar_node(left, ctx, state)?),
+            right: Box::from(desugar_node(right, ctx, state)?)
         },
         ASTNode::Mul { left, right } => Core::Mul {
-            left:  Box::from(desugar_node(left, ctx, state)),
-            right: Box::from(desugar_node(right, ctx, state))
+            left:  Box::from(desugar_node(left, ctx, state)?),
+            right: Box::from(desugar_node(right, ctx, state)?)
         },
         ASTNode::Div { left, right } => Core::Div {
-            left:  Box::from(desugar_node(left, ctx, state)),
-            right: Box::from(desugar_node(right, ctx, state))
+            left:  Box::from(desugar_node(left, ctx, state)?),
+            right: Box::from(desugar_node(right, ctx, state)?)
         },
         ASTNode::FDiv { left, right } => Core::FDiv {
-            left:  Box::from(desugar_node(left, ctx, state)),
-            right: Box::from(desugar_node(right, ctx, state))
+            left:  Box::from(desugar_node(left, ctx, state)?),
+            right: Box::from(desugar_node(right, ctx, state)?)
         },
         ASTNode::Mod { left, right } => Core::Mod {
-            left:  Box::from(desugar_node(left, ctx, state)),
-            right: Box::from(desugar_node(right, ctx, state))
+            left:  Box::from(desugar_node(left, ctx, state)?),
+            right: Box::from(desugar_node(right, ctx, state)?)
         },
         ASTNode::Pow { left, right } => Core::Pow {
-            left:  Box::from(desugar_node(left, ctx, state)),
-            right: Box::from(desugar_node(right, ctx, state))
+            left:  Box::from(desugar_node(left, ctx, state)?),
+            right: Box::from(desugar_node(right, ctx, state)?)
         },
 
         ASTNode::BAnd { left, right } => Core::BAnd {
-            left:  Box::from(desugar_node(left, ctx, state)),
-            right: Box::from(desugar_node(right, ctx, state))
+            left:  Box::from(desugar_node(left, ctx, state)?),
+            right: Box::from(desugar_node(right, ctx, state)?)
         },
         ASTNode::BOr { left, right } => Core::BOr {
-            left:  Box::from(desugar_node(left, ctx, state)),
-            right: Box::from(desugar_node(right, ctx, state))
+            left:  Box::from(desugar_node(left, ctx, state)?),
+            right: Box::from(desugar_node(right, ctx, state)?)
         },
         ASTNode::BXOr { left, right } => Core::BXOr {
-            left:  Box::from(desugar_node(left, ctx, state)),
-            right: Box::from(desugar_node(right, ctx, state))
+            left:  Box::from(desugar_node(left, ctx, state)?),
+            right: Box::from(desugar_node(right, ctx, state)?)
         },
         ASTNode::BOneCmpl { expr } =>
-            Core::BOneCmpl { expr: Box::from(desugar_node(expr, ctx, state)) },
+            Core::BOneCmpl { expr: Box::from(desugar_node(expr, ctx, state)?) },
         ASTNode::BLShift { left, right } => Core::BLShift {
-            left:  Box::from(desugar_node(left, ctx, state)),
-            right: Box::from(desugar_node(right, ctx, state))
+            left:  Box::from(desugar_node(left, ctx, state)?),
+            right: Box::from(desugar_node(right, ctx, state)?)
         },
         ASTNode::BRShift { left, right } => Core::BRShift {
-            left:  Box::from(desugar_node(left, ctx, state)),
-            right: Box::from(desugar_node(right, ctx, state))
+            left:  Box::from(desugar_node(left, ctx, state)?),
+            right: Box::from(desugar_node(right, ctx, state)?)
         },
 
-        ASTNode::AddU { expr } => Core::AddU { expr: Box::from(desugar_node(expr, ctx, state)) },
-        ASTNode::SubU { expr } => Core::SubU { expr: Box::from(desugar_node(expr, ctx, state)) },
+        ASTNode::AddU { expr } => Core::AddU { expr: Box::from(desugar_node(expr, ctx, state)?) },
+        ASTNode::SubU { expr } => Core::SubU { expr: Box::from(desugar_node(expr, ctx, state)?) },
         ASTNode::Sqrt { expr } => {
             ctx.add_import("math");
-            Core::Sqrt { expr: Box::from(desugar_node(expr, ctx, state)) }
+            Core::Sqrt { expr: Box::from(desugar_node(expr, ctx, state)?) }
         }
 
         ASTNode::Le { left, right } => Core::Le {
-            left:  Box::from(desugar_node(left, ctx, state)),
-            right: Box::from(desugar_node(right, ctx, state))
+            left:  Box::from(desugar_node(left, ctx, state)?),
+            right: Box::from(desugar_node(right, ctx, state)?)
         },
         ASTNode::Leq { left, right } => Core::Leq {
-            left:  Box::from(desugar_node(left, ctx, state)),
-            right: Box::from(desugar_node(right, ctx, state))
+            left:  Box::from(desugar_node(left, ctx, state)?),
+            right: Box::from(desugar_node(right, ctx, state)?)
         },
         ASTNode::Ge { left, right } => Core::Ge {
-            left:  Box::from(desugar_node(left, ctx, state)),
-            right: Box::from(desugar_node(right, ctx, state))
+            left:  Box::from(desugar_node(left, ctx, state)?),
+            right: Box::from(desugar_node(right, ctx, state)?)
         },
         ASTNode::Geq { left, right } => Core::Geq {
-            left:  Box::from(desugar_node(left, ctx, state)),
-            right: Box::from(desugar_node(right, ctx, state))
+            left:  Box::from(desugar_node(left, ctx, state)?),
+            right: Box::from(desugar_node(right, ctx, state)?)
         },
 
         ASTNode::FunArg { vararg, id_maybe_type, default } => Core::FunArg {
             vararg:  *vararg,
-            id:      Box::from(desugar_node(id_maybe_type, ctx, state)),
+            id:      Box::from(desugar_node(id_maybe_type, ctx, state)?),
             default: match default {
-                Some(default) => Box::from(desugar_node(default, ctx, state)),
+                Some(default) => Box::from(desugar_node(default, ctx, state)?),
                 None => Box::from(Core::Empty)
             }
         },
 
         call @ ASTNode::FunctionCall { .. } | call @ ASTNode::PropertyCall { .. } =>
-            desugar_call(call, ctx, state),
+            desugar_call(call, ctx, state)?,
 
         ASTNode::AnonFun { args, body } => Core::AnonFun {
-            args: desugar_vec(args, ctx, state),
-            body: Box::from(desugar_node(body, ctx, state))
+            args: desugar_vec(args, ctx, state)?,
+            body: Box::from(desugar_node(body, ctx, state)?)
         },
 
         ASTNode::In { left, right } => Core::In {
-            left:  Box::from(desugar_node(left, ctx, state)),
-            right: Box::from(desugar_node(right, ctx, state))
+            left:  Box::from(desugar_node(left, ctx, state)?),
+            right: Box::from(desugar_node(right, ctx, state)?)
         },
         ASTNode::Range { from, to, inclusive, step } => Core::Range {
-            from: Box::from(desugar_node(from, ctx, state)),
+            from: Box::from(desugar_node(from, ctx, state)?),
             to:   Box::from(if *inclusive {
                 Core::Add {
-                    left:  Box::from(desugar_node(to, ctx, state)),
+                    left:  Box::from(desugar_node(to, ctx, state)?),
                     right: Box::from(Core::Int { int: String::from("1") })
                 }
             } else {
-                desugar_node(to, ctx, state)
+                desugar_node(to, ctx, state)?
             }),
             step: Box::from(if let Some(step) = step {
-                desugar_node(step, ctx, state)
+                desugar_node(step, ctx, state)?
             } else {
                 Core::Int { int: String::from("1") }
             })
         },
         ASTNode::Underscore => Core::UnderScore,
         ASTNode::QuestOr { left, right } => Core::Or {
-            left:  Box::from(desugar_node(left, ctx, state)),
-            right: Box::from(desugar_node(right, ctx, state))
+            left:  Box::from(desugar_node(left, ctx, state)?),
+            right: Box::from(desugar_node(right, ctx, state)?)
         },
         ASTNode::Script { statements } =>
-            Core::Block { statements: desugar_vec(statements, ctx, state) },
+            Core::Block { statements: desugar_vec(statements, ctx, state)? },
         ASTNode::File { modules, type_defs, imports, .. } => {
-            let mut imports = desugar_vec(imports, ctx, state);
-            let mut type_definitions = desugar_vec(type_defs, ctx, state);
-            let mut modules = desugar_vec(modules, ctx, state);
+            let mut imports = desugar_vec(imports, ctx, state)?;
+            let mut type_definitions = desugar_vec(type_defs, ctx, state)?;
+            let mut modules = desugar_vec(modules, ctx, state)?;
             imports.append(&mut ctx.imports);
 
             let mut statements = imports;
@@ -251,32 +253,32 @@ pub fn desugar_node(node_pos: &ASTNodePos, ctx: &mut Context, state: &State) -> 
         | ASTNode::Type { .. }
         | ASTNode::TypeFun { .. } => Core::Empty,
 
-        type_def @ ASTNode::TypeDef { .. } => desugar_class(type_def, ctx, state),
-        class @ ASTNode::Class { .. } => desugar_class(class, ctx, state),
+        type_def @ ASTNode::TypeDef { .. } => desugar_class(type_def, ctx, state)?,
+        class @ ASTNode::Class { .. } => desugar_class(class, ctx, state)?,
         ASTNode::Generic { .. } => Core::Empty,
         ASTNode::Parent { .. } => panic!("Parent cannot be top-level"),
 
-        ASTNode::Condition { .. } => unimplemented!("Condition has not yet been implemented."),
+        ASTNode::Condition { .. } => return Err(UnimplementedErr::new("condition")),
 
         ASTNode::Comment { comment } => Core::Comment { comment: comment.clone() },
         ASTNode::Pass => Core::Pass,
 
         ASTNode::With { resource, _as, expr } => match _as {
             Some(_as) => Core::WithAs {
-                resource: Box::from(desugar_node(resource, ctx, state)),
-                _as:      Box::from(desugar_node(_as, ctx, state)),
-                expr:     Box::from(desugar_node(expr, ctx, state))
+                resource: Box::from(desugar_node(resource, ctx, state)?),
+                _as:      Box::from(desugar_node(_as, ctx, state)?),
+                expr:     Box::from(desugar_node(expr, ctx, state)?)
             },
             None => Core::With {
-                resource: Box::from(desugar_node(resource, ctx, state)),
-                expr:     Box::from(desugar_node(expr, ctx, state))
+                resource: Box::from(desugar_node(resource, ctx, state)?),
+                expr:     Box::from(desugar_node(expr, ctx, state)?)
             }
         },
 
         ASTNode::Step { .. } => panic!("Step cannot be top level."),
-        ASTNode::Raises { expr_or_stmt, .. } => desugar_node(expr_or_stmt, ctx, state),
+        ASTNode::Raises { expr_or_stmt, .. } => desugar_node(expr_or_stmt, ctx, state)?,
         ASTNode::Raise { error } =>
-            Core::Raise { error: Box::from(desugar_node(error, ctx, state)) },
+            Core::Raise { error: Box::from(desugar_node(error, ctx, state)?) },
         ASTNode::Retry { .. } => unimplemented!("Retry has not yet been implemented."),
 
         ASTNode::Handle { expr_or_stmt, cases } => {
@@ -284,14 +286,14 @@ pub fn desugar_node(node_pos: &ASTNodePos, ctx: &mut Context, state: &State) -> 
             if let ASTNode::Def { definition, .. } = &expr_or_stmt.node {
                 if let ASTNode::VariableDef { id_maybe_type, .. } = &definition.node {
                     statements.push(Core::Assign {
-                        left:  Box::from(desugar_node(id_maybe_type.as_ref(), ctx, state)),
+                        left:  Box::from(desugar_node(id_maybe_type.as_ref(), ctx, state)?),
                         right: Box::from(Core::None)
                     });
                 }
             };
 
             statements.push(Core::TryExcept {
-                _try:   Box::from(desugar_node(&expr_or_stmt.clone(), ctx, state)),
+                _try:   Box::from(desugar_node(&expr_or_stmt.clone(), ctx, state)?),
                 except: {
                     let mut except = Vec::new();
                     for case in cases {
@@ -309,9 +311,9 @@ pub fn desugar_node(node_pos: &ASTNodePos, ctx: &mut Context, state: &State) -> 
                         };
 
                         except.push(Core::Except {
-                            id:    Box::from(desugar_node(id, ctx, state)),
-                            class: Box::from(desugar_node(class, ctx, state)),
-                            body:  Box::from(desugar_node(body, ctx, state))
+                            id:    Box::from(desugar_node(id, ctx, state)?),
+                            class: Box::from(desugar_node(class, ctx, state)?),
+                            body:  Box::from(desugar_node(body, ctx, state)?)
                         });
                     }
                     except
@@ -323,5 +325,5 @@ pub fn desugar_node(node_pos: &ASTNodePos, ctx: &mut Context, state: &State) -> 
 
         ASTNode::VariableDef { .. } => panic!("Variable definition cannot be top level."),
         ASTNode::FunDef { .. } => panic!("Function definition cannot be top level.")
-    }
+    })
 }

--- a/src/pipeline/error.rs
+++ b/src/pipeline/error.rs
@@ -1,5 +1,7 @@
+use crate::desugar::desugar_result::UnimplementedErr;
 use crate::parser::parse_result::ParseErr;
 use std::cmp::min;
+use std::path::Path;
 use std::path::PathBuf;
 
 const SYNTAX_ERR_MAX_DEPTH: usize = 2;
@@ -31,6 +33,23 @@ pub fn syntax_err(err: &ParseErr, source: &str, in_path: &PathBuf) -> String {
         err.pos,
         err.msg,
         cause_formatter,
+        err.line,
+        source.lines().nth(err.line as usize - 1).unwrap_or(""),
+        String::from_utf8(vec![b' '; err.pos as usize]).unwrap(),
+        String::from_utf8(vec![b'^'; err.width as usize]).unwrap()
+    )
+}
+
+pub fn unimplemented_err(err: &UnimplementedErr, source: &str, in_path: &Path) -> String {
+    format!(
+        "--> {}:{}:{}
+     | {}
+{:3}  |- {}
+     | {}{}",
+        in_path.display(),
+        err.line,
+        err.pos,
+        err.msg,
         err.line,
         source.lines().nth(err.line as usize - 1).unwrap_or(""),
         String::from_utf8(vec![b' '; err.pos as usize]).unwrap(),

--- a/src/pipeline/mod.rs
+++ b/src/pipeline/mod.rs
@@ -136,7 +136,7 @@ fn input(in_path: &PathBuf) -> Result<ASTNodePos, (String, String)> {
 }
 
 fn output(typed_ast_tree: &ASTNodePos, out_path: &Path) -> Result<(), (String, String)> {
-    let core_tree = desugar(&typed_ast_tree);
+    let core_tree = desugar(&typed_ast_tree).unwrap();
     let source = to_source(&core_tree);
 
     match out_path.parent() {

--- a/src/pipeline/mod.rs
+++ b/src/pipeline/mod.rs
@@ -4,6 +4,7 @@ use crate::lexer::tokenize;
 use crate::parser::ast::ASTNodePos;
 use crate::parser::parse;
 use crate::pipeline::error::syntax_err;
+use crate::pipeline::error::unimplemented_err;
 use crate::type_checker::check;
 use glob::glob;
 use leg::*;
@@ -86,12 +87,12 @@ pub fn pipeline(
     out_dir: &Path,
     relative_file_paths: &[OsString]
 ) -> Result<(), Vec<(String, String)>> {
-    let mut ast_trees = vec![];
+    let mut trees = vec![];
     let mut syntax_errors = vec![];
 
     for in_path in relative_file_paths.iter().map(|p| in_dir.join(p)) {
         match input(&in_path) {
-            Ok(ast_tree) => ast_trees.push(ast_tree),
+            Ok(ast_tree) => trees.push(ast_tree),
             Err(err) => syntax_errors.push(err)
         }
     }
@@ -102,13 +103,19 @@ pub fn pipeline(
 
     let type_err: fn(Vec<String>) -> Vec<(String, String)> =
         |e: Vec<String>| e.iter().map(|e| (String::from("typing"), e.clone())).collect();
-    let typed_ast_trees = check(ast_trees.as_slice()).map_err(type_err)?;
-    debug_assert_eq!(typed_ast_trees.len(), relative_file_paths.len());
+
+    {
+        let ast_trees: Vec<ASTNodePos> = trees.iter().map(|(tree, ..)| tree.clone()).collect();
+        let typed_ast_trees = check(ast_trees.as_slice()).map_err(type_err)?;
+        debug_assert_eq!(typed_ast_trees.len(), relative_file_paths.len());
+    }
 
     let mut i = 0;
-    for typed_ast_tree in typed_ast_trees.iter() {
+    for (typed_ast_tree, source, in_path) in trees {
         match output(
             &typed_ast_tree,
+            &source,
+            &in_path,
             out_dir.join(relative_file_paths[i].clone()).with_extension("py").as_path()
         ) {
             Ok(..) => i += 1,
@@ -118,7 +125,7 @@ pub fn pipeline(
     Ok(())
 }
 
-fn input(in_path: &PathBuf) -> Result<ASTNodePos, (String, String)> {
+fn input(in_path: &PathBuf) -> Result<(ASTNodePos, String, PathBuf), (String, String)> {
     let mut input_file = OpenOptions::new()
         .read(true)
         .open(in_path.clone())
@@ -132,11 +139,18 @@ fn input(in_path: &PathBuf) -> Result<ASTNodePos, (String, String)> {
     let tokens = tokenize(source.as_ref()).map_err(|e| (String::from("token"), e.to_string()))?;
     parse(&tokens)
         .map_err(|err| (String::from("syntax"), syntax_err(&err, &source, in_path)))
-        .map(|ok| *ok)
+        .map(|ok| (*ok, source, in_path.clone()))
 }
 
-fn output(typed_ast_tree: &ASTNodePos, out_path: &Path) -> Result<(), (String, String)> {
-    let core_tree = desugar(&typed_ast_tree).unwrap();
+fn output(
+    typed_ast_tree: &ASTNodePos,
+    source: &str,
+    in_path: &Path,
+    out_path: &Path
+) -> Result<(), (String, String)> {
+    let core_tree = desugar(&typed_ast_tree).map_err(|err| {
+        (String::from("unimplemented"), unimplemented_err(&err, &source, in_path))
+    })?;
     let source = to_source(&core_tree);
 
     match out_path.parent() {

--- a/tests/core/mod.rs
+++ b/tests/core/mod.rs
@@ -2,7 +2,7 @@ macro_rules! to_py {
     ($source:expr) => {{
         let tokens = tokenize(&$source).unwrap();
         let ast_nodes = parse(&tokens).unwrap();
-        let desugared = desugar(&ast_nodes);
+        let desugared = desugar(&ast_nodes).unwrap();
         to_source(&desugared)
     }};
 }

--- a/tests/desugar/class.rs
+++ b/tests/desugar/class.rs
@@ -69,3 +69,12 @@ fn from_import_verify() {
     assert_eq!(import[0], Core::ENum { num: String::from("a"), exp: String::from("100") });
     assert_eq!(import[1], Core::Float { float: String::from("3000.5") });
 }
+
+#[test]
+fn condition_verify() {
+    let cond = to_pos!(ASTNode::Bool { lit: true });
+    let condition = to_pos!(ASTNode::Condition { cond, _else: None });
+
+    let result = desugar(&condition);
+    assert!(result.is_err());
+}

--- a/tests/desugar/class.rs
+++ b/tests/desugar/class.rs
@@ -14,7 +14,7 @@ fn import_verify() {
     let import = to_pos!(ASTNode::Import { import, _as });
 
     let core_import = match desugar(&import) {
-        Core::Import { imports } => imports,
+        Ok(Core::Import { imports }) => imports,
         other => panic!("Expected tuple but got {:?}", other)
     };
 
@@ -33,7 +33,7 @@ fn import_as_verify() {
     let import = to_pos!(ASTNode::Import { import, _as });
 
     let (core_import, core_as) = match desugar(&import) {
-        Core::ImportAs { imports, _as } => (imports, _as),
+        Ok(Core::ImportAs { imports, _as }) => (imports, _as),
         other => panic!("Expected import but got {:?}", other)
     };
 
@@ -57,7 +57,7 @@ fn from_import_verify() {
     });
 
     let (from, import) = match desugar(&import) {
-        Core::FromImport { from, import } => match &import.deref() {
+        Ok(Core::FromImport { from, import }) => match &import.deref() {
             Core::Import { imports } => (from.clone(), imports.clone()),
             other => panic!("Expected import but got {:?}", other)
         },

--- a/tests/desugar/collection.rs
+++ b/tests/desugar/collection.rs
@@ -65,13 +65,21 @@ fn list_verify() {
 }
 
 #[test]
-#[ignore]
 fn set_builder_verify() {
-    unimplemented!();
+    let item = to_pos!(ASTNode::Id { lit: String::from("a") });
+    let conditions = vec![];
+    let list_builder = to_pos!(ASTNode::SetBuilder { item, conditions });
+
+    let desugar_result = desugar(&list_builder);
+    assert!(desugar_result.is_err());
 }
 
 #[test]
-#[ignore]
 fn list_builder_verify() {
-    unimplemented!();
+    let item = to_pos!(ASTNode::Id { lit: String::from("a") });
+    let conditions = vec![];
+    let list_builder = to_pos!(ASTNode::ListBuilder { item, conditions });
+
+    let desugar_result = desugar(&list_builder);
+    assert!(desugar_result.is_err());
 }

--- a/tests/desugar/collection.rs
+++ b/tests/desugar/collection.rs
@@ -13,7 +13,7 @@ fn tuple_verify() {
     let core = desugar(&tuple);
 
     let core_elements = match core {
-        Core::Tuple { elements } => elements,
+        Ok(Core::Tuple { elements }) => elements,
         other => panic!("Expected tuple but got {:?}", other)
     };
 
@@ -38,7 +38,7 @@ fn set_verify() {
     let core = desugar(&tuple);
 
     let core_elements = match core {
-        Core::Set { elements } => elements,
+        Ok(Core::Set { elements }) => elements,
         other => panic!("Expected tuple but got {:?}", other)
     };
 
@@ -56,7 +56,7 @@ fn list_verify() {
     let core = desugar(&tuple);
 
     let core_elements = match core {
-        Core::List { elements } => elements,
+        Ok(Core::List { elements }) => elements,
         other => panic!("Expected tuple but got {:?}", other)
     };
 

--- a/tests/desugar/control_flow.rs
+++ b/tests/desugar/control_flow.rs
@@ -10,7 +10,7 @@ fn if_verify() {
     let if_stmt = to_pos!(ASTNode::IfElse { cond, then, _else: None });
 
     let (core_cond, core_then) = match desugar(&if_stmt) {
-        Core::If { cond, then } => (cond, then),
+        Ok(Core::If { cond, then }) => (cond, then),
         other => panic!("Expected reassign but was {:?}", other)
     };
 
@@ -26,7 +26,7 @@ fn if_else_verify() {
     let if_stmt = to_pos!(ASTNode::IfElse { cond, then, _else: Some(_else) });
 
     let (core_cond, core_then, core_else) = match desugar(&if_stmt) {
-        Core::IfElse { cond, then, _else } => (cond, then, _else),
+        Ok(Core::IfElse { cond, then, _else }) => (cond, then, _else),
         other => panic!("Expected reassign but was {:?}", other)
     };
 
@@ -42,7 +42,7 @@ fn while_verify() {
     let while_stmt = to_pos!(ASTNode::While { cond, body });
 
     let (core_cond, core_body) = match desugar(&while_stmt) {
-        Core::While { cond, body } => (cond, body),
+        Ok(Core::While { cond, body }) => (cond, body),
         other => panic!("Expected reassign but was {:?}", other)
     };
 
@@ -57,7 +57,7 @@ fn for_verify() {
     let for_stmt = to_pos!(ASTNode::For { expr, body });
 
     let (core_expr, core_body) = match desugar(&for_stmt) {
-        Core::For { expr, body } => (expr, body),
+        Ok(Core::For { expr, body }) => (expr, body),
         other => panic!("Expected for but was {:?}", other)
     };
 
@@ -72,7 +72,7 @@ fn range_verify() {
     let range = to_pos!(ASTNode::Range { from, to, inclusive: false, step: None });
 
     let (from, to, step) = match desugar(&range) {
-        Core::Range { from, to, step } => (from, to, step),
+        Ok(Core::Range { from, to, step }) => (from, to, step),
         other => panic!("Expected range but was {:?}", other)
     };
 
@@ -88,7 +88,7 @@ fn range_incl_verify() {
     let range = to_pos!(ASTNode::Range { from, to, inclusive: true, step: None });
 
     let (from, to, step) = match desugar(&range) {
-        Core::Range { from, to, step } => (from, to, step),
+        Ok(Core::Range { from, to, step }) => (from, to, step),
         other => panic!("Expected range but was {:?}", other)
     };
 
@@ -108,7 +108,7 @@ fn range_step_verify() {
     let range = to_pos!(ASTNode::Range { from, to, inclusive: false, step });
 
     let (from, to, step) = match desugar(&range) {
-        Core::Range { from, to, step } => (from, to, step),
+        Ok(Core::Range { from, to, step }) => (from, to, step),
         other => panic!("Expected range but was {:?}", other)
     };
 

--- a/tests/desugar/definition.rs
+++ b/tests/desugar/definition.rs
@@ -11,7 +11,7 @@ fn reassign_verify() {
     let reassign = to_pos!(ASTNode::Reassign { left, right });
 
     let (left, right) = match desugar(&reassign) {
-        Core::Assign { left, right } => (left, right),
+        Ok(Core::Assign { left, right }) => (left, right),
         other => panic!("Expected reassign but was {:?}", other)
     };
 
@@ -30,7 +30,7 @@ fn variable_private_def_verify() {
     let def = to_pos!(ASTNode::Def { private: false, definition });
 
     let (private, id, right) = match desugar(&def) {
-        Core::VarDef { private, id, right } => (private, id, right),
+        Ok(Core::VarDef { private, id, right }) => (private, id, right),
         other => panic!("Expected var def but got: {:?}.", other)
     };
 
@@ -50,7 +50,7 @@ fn variable_def_verify() {
     let def = to_pos!(ASTNode::Def { private: true, definition });
 
     let (private, id, right) = match desugar(&def) {
-        Core::VarDef { private, id, right } => (private, id, right),
+        Ok(Core::VarDef { private, id, right }) => (private, id, right),
         other => panic!("Expected var def but got: {:?}.", other)
     };
 
@@ -78,7 +78,7 @@ fn tuple_def_verify() {
     let def = to_pos!(ASTNode::Def { private: true, definition });
 
     let (private, id, right) = match desugar(&def) {
-        Core::VarDef { private, id, right } => (private, id, right),
+        Ok(Core::VarDef { private, id, right }) => (private, id, right),
         other => panic!("Expected var def but got: {:?}.", other)
     };
 
@@ -101,7 +101,7 @@ fn variable_def_none_verify() {
     let def = to_pos!(ASTNode::Def { private: true, definition });
 
     let (private, id, right) = match desugar(&def) {
-        Core::VarDef { private, id, right } => (private, id, right),
+        Ok(Core::VarDef { private, id, right }) => (private, id, right),
         other => panic!("Expected var def but got: {:?}.", other)
     };
 
@@ -125,7 +125,7 @@ fn tuple_def_none_verify() {
 
     let def = to_pos!(ASTNode::Def { private: true, definition });
     let (private, id, right) = match desugar(&def) {
-        Core::VarDef { private, id, right } => (private, id, right),
+        Ok(Core::VarDef { private, id, right }) => (private, id, right),
         other => panic!("Expected var def but got: {:?}.", other)
     };
 
@@ -159,7 +159,7 @@ fn fun_def_verify() {
     let def = to_pos!(ASTNode::Def { private: false, definition });
 
     let (private, id, args, body) = match desugar(&def) {
-        Core::FunDef { private, id, args, body } => (private, id, args, body),
+        Ok(Core::FunDef { private, id, args, body }) => (private, id, args, body),
         other => panic!("Expected fun def but got: {:?}.", other)
     };
 
@@ -197,7 +197,7 @@ fn fun_def_default_arg_verify() {
     let def = to_pos!(ASTNode::Def { private: false, definition });
 
     let (private, id, args, body) = match desugar(&def) {
-        Core::FunDef { private, id, args, body } => (private, id, args, body),
+        Ok(Core::FunDef { private, id, args, body }) => (private, id, args, body),
         other => panic!("Expected fun def but got: {:?}.", other)
     };
 
@@ -229,7 +229,7 @@ fn fun_def_with_body_verify() {
     let def = to_pos!(ASTNode::Def { private: false, definition });
 
     let (private, id, args, body) = match desugar(&def) {
-        Core::FunDef { private, id, args, body } => (private, id, args, body),
+        Ok(Core::FunDef { private, id, args, body }) => (private, id, args, body),
         other => panic!("Expected fun def but got: {:?}.", other)
     };
 
@@ -253,7 +253,7 @@ fn anon_fun_verify() {
     });
 
     let (args, body) = match desugar(&anon_fun) {
-        Core::AnonFun { args, body } => (args, body),
+        Ok(Core::AnonFun { args, body }) => (args, body),
         other => panic!("Expected anon fun but got: {:?}.", other)
     };
 

--- a/tests/desugar/error.rs
+++ b/tests/desugar/error.rs
@@ -12,7 +12,7 @@ fn with_verify() {
     let with = to_pos!(ASTNode::With { resource, _as, expr });
 
     let (resource, _as, expr) = match desugar(&with) {
-        Core::WithAs { resource, _as, expr } => (resource, _as, expr),
+        Ok(Core::WithAs { resource, _as, expr }) => (resource, _as, expr),
         other => panic!("Expected with as but was {:?}", other)
     };
 
@@ -28,7 +28,7 @@ fn with_no_as_verify() {
     let with = to_pos!(ASTNode::With { resource, _as: None, expr });
 
     let (resource, expr) = match desugar(&with) {
-        Core::With { resource, expr } => (resource, expr),
+        Ok(Core::With { resource, expr }) => (resource, expr),
         other => panic!("Expected with but was {:?}", other)
     };
 
@@ -42,7 +42,7 @@ fn handle_empty_verify() {
     let handle = to_pos!(ASTNode::Handle { expr_or_stmt, cases: vec![] });
 
     let (_try, except) = match desugar(&handle) {
-        Core::Block { statements } => {
+        Ok(Core::Block { statements }) => {
             assert_eq!(statements.len(), 1);
             match &statements[0] {
                 Core::TryExcept { _try, except } => (_try.clone(), except.clone()),
@@ -72,7 +72,7 @@ fn handle_verify() {
     let handle = to_pos!(ASTNode::Handle { expr_or_stmt, cases: vec![case] });
 
     let (_try, except) = match desugar(&handle) {
-        Core::Block { statements } => {
+        Ok(Core::Block { statements }) => {
             assert_eq!(statements.len(), 1);
             match &statements[0] {
                 Core::TryExcept { _try, except } => (_try.clone(), except.clone()),

--- a/tests/desugar/expression_and_statements.rs
+++ b/tests/desugar/expression_and_statements.rs
@@ -7,26 +7,26 @@ use std::panic;
 #[test]
 fn break_verify() {
     let _break = to_pos!(ASTNode::Break);
-    assert_eq!(desugar(&_break), Core::Break);
+    assert_eq!(desugar(&_break).unwrap(), Core::Break);
 }
 
 #[test]
 fn continue_verify() {
     let _continue = to_pos!(ASTNode::Continue);
-    assert_eq!(desugar(&_continue), Core::Continue);
+    assert_eq!(desugar(&_continue).unwrap(), Core::Continue);
 }
 
 #[test]
 fn pass_verify() {
     let pass = to_pos!(ASTNode::Pass);
-    assert_eq!(desugar(&pass), Core::Pass);
+    assert_eq!(desugar(&pass).unwrap(), Core::Pass);
 }
 
 #[test]
 fn print_verify() {
     let expr = to_pos!(ASTNode::Str { lit: String::from("a") });
     let print_stmt = to_pos!(ASTNode::Print { expr });
-    assert_eq!(desugar(&print_stmt), Core::Print {
+    assert_eq!(desugar(&print_stmt).unwrap(), Core::Print {
         expr: Box::from(Core::Str { _str: String::from("a") })
     });
 }
@@ -36,7 +36,7 @@ fn return_verify() {
     let expr = to_pos!(ASTNode::Str { lit: String::from("a") });
     let print_stmt = to_pos!(ASTNode::Return { expr });
 
-    assert_eq!(desugar(&print_stmt), Core::Return {
+    assert_eq!(desugar(&print_stmt).unwrap(), Core::Return {
         expr: Box::from(Core::Str { _str: String::from("a") })
     });
 }
@@ -44,19 +44,19 @@ fn return_verify() {
 #[test]
 fn return_empty_verify() {
     let print_stmt = to_pos!(ASTNode::ReturnEmpty);
-    assert_eq!(desugar(&print_stmt), Core::Return { expr: Box::from(Core::None) });
+    assert_eq!(desugar(&print_stmt).unwrap(), Core::Return { expr: Box::from(Core::None) });
 }
 
 #[test]
 fn init_verify() {
     let _break = to_pos!(ASTNode::Init);
-    assert_eq!(desugar(&_break), Core::Id { lit: String::from("init") });
+    assert_eq!(desugar(&_break).unwrap(), Core::Id { lit: String::from("init") });
 }
 
 #[test]
 fn self_verify() {
     let _break = to_pos!(ASTNode::_Self);
-    assert_eq!(desugar(&_break), Core::Id { lit: String::from("self") });
+    assert_eq!(desugar(&_break).unwrap(), Core::Id { lit: String::from("self") });
 }
 
 #[test]
@@ -66,7 +66,7 @@ fn import_verify() {
         _as:    vec![to_pos_unboxed!(ASTNode::Id { lit: String::from("b") })]
     });
 
-    assert_eq!(desugar(&_break), Core::ImportAs {
+    assert_eq!(desugar(&_break).unwrap(), Core::ImportAs {
         imports: vec![Core::Id { lit: String::from("a") }],
         _as:     vec![Core::Id { lit: String::from("b") }]
     });
@@ -82,7 +82,7 @@ fn from_import_as_verify() {
         })
     });
 
-    assert_eq!(desugar(&_break), Core::FromImport {
+    assert_eq!(desugar(&_break).unwrap(), Core::FromImport {
         from:   Box::from(Core::Id { lit: String::from("f") }),
         import: Box::from(Core::ImportAs {
             imports: vec![Core::Id { lit: String::from("a") }],
@@ -97,5 +97,5 @@ fn raises_empty_verify() {
         expr_or_stmt: Box::from(to_pos!(ASTNode::Id { lit: String::from("a") })),
         errors:       vec![]
     });
-    assert_eq!(desugar(&type_def), Core::Id { lit: String::from("a") });
+    assert_eq!(desugar(&type_def).unwrap(), Core::Id { lit: String::from("a") });
 }

--- a/tests/desugar/expression_and_statements.rs
+++ b/tests/desugar/expression_and_statements.rs
@@ -99,3 +99,10 @@ fn raises_empty_verify() {
     });
     assert_eq!(desugar(&type_def).unwrap(), Core::Id { lit: String::from("a") });
 }
+
+#[test]
+fn retry_verify() {
+    let retry = to_pos!(ASTNode::Retry);
+    let result = desugar(&retry);
+    assert!(result.is_err());
+}

--- a/tests/desugar/operation.rs
+++ b/tests/desugar/operation.rs
@@ -6,7 +6,7 @@ use mamba::parser::ast::ASTNodePos;
 macro_rules! verify_op {
     ($op:ident) => {{
         let add_op = to_pos!(ASTNode::$op);
-        let core = desugar(&add_op);
+        let core = desugar(&add_op).unwrap();
         assert_eq!(core, Core::$op);
     }};
 }
@@ -18,8 +18,8 @@ macro_rules! verify {
         let add_node = to_pos!(ASTNode::$ast { left: to_pos!(left), right: to_pos!(right) });
 
         let (left, right) = match desugar(&add_node) {
-            Core::$ast { left, right } => (left, right),
-            other => panic!("Expected mul but was {:?}", other)
+            Ok(Core::$ast { left, right }) => (left, right),
+            other => panic!("Expected binary operation but was {:?}", other)
         };
 
         assert_eq!(*left, Core::Id { lit: String::from("left") });
@@ -33,8 +33,8 @@ macro_rules! verify_unary {
         let add_node = to_pos!(ASTNode::$ast { expr });
 
         let expr_des = match desugar(&add_node) {
-            Core::$ast { expr } => expr,
-            other => panic!("Expected mul but was {:?}", other)
+            Ok(Core::$ast { expr }) => expr,
+            other => panic!("Expected unary operation but was {:?}", other)
         };
 
         assert_eq!(*expr_des, Core::Id { lit: String::from("expression") });

--- a/tests/desugar/operation.rs
+++ b/tests/desugar/operation.rs
@@ -142,9 +142,10 @@ fn sub_op_verify() {
 }
 
 #[test]
-#[ignore]
 fn sqrt_op_verify() {
-    unimplemented!();
+    let sqrt_node = to_pos!(ASTNode::SqrtOp);
+    let result = desugar(&sqrt_node);
+    assert!(result.is_err());
 }
 
 #[test]

--- a/tests/desugar/types.rs
+++ b/tests/desugar/types.rs
@@ -9,13 +9,13 @@ fn type_alias_empty_verify() {
         _type:      Box::from(to_pos!(ASTNode::Pass)),
         conditions: vec![]
     });
-    assert_eq!(desugar(&type_def), Core::Empty);
+    assert_eq!(desugar(&type_def).unwrap(), Core::Empty);
 }
 
 #[test]
 fn type_tup_empty_verify() {
     let type_def = to_pos!(ASTNode::TypeTup { types: vec![] });
-    assert_eq!(desugar(&type_def), Core::Empty);
+    assert_eq!(desugar(&type_def).unwrap(), Core::Empty);
 }
 
 #[test]
@@ -24,5 +24,5 @@ fn type_fun_empty_verify() {
         _type: Box::from(to_pos!(ASTNode::Pass)),
         body:  Box::from(to_pos!(ASTNode::Pass))
     });
-    assert_eq!(desugar(&type_def), Core::Empty);
+    assert_eq!(desugar(&type_def).unwrap(), Core::Empty);
 }


### PR DESCRIPTION
### Relevant issues
#94 
In some cases, it is better to create an error message which explains to the user that a certain construct has not been implemented yet instead of panicking.

### Summary
Show error message that a certain construct has not bee implemented as opposed to simply panicking.
Panicking should only occur in the case that an ASTNode is malformed, which should be caught in by the type checker. Perhaps it is best however to create a different error message for this instead of panicking.

### Added Tests
Tests to check that an unimplemented error is thrown for the following constructs:
- square roots
- list and set builders
- retry
- condition
