### PR TITLE
Allow exceptions without class name

### DIFF
--- a/src/core/construct.rs
+++ b/src/core/construct.rs
@@ -96,6 +96,7 @@ pub enum Core {
 
     TryExcept { _try: Box<Core>, except: Vec<Core> },
     Except { id: Box<Core>, class: Box<Core>, body: Box<Core> },
+    ExceptNoClass { id: Box<Core>, body: Box<Core> },
     Raise { error: Box<Core> },
 
     With { resource: Box<Core>, expr: Box<Core> },

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -135,8 +135,13 @@ fn to_py(core: &Core, ind: usize) -> String {
         Core::Set { elements } => format!("set([{}])", comma_delimited(elements, ind)),
         Core::List { elements } => format!("[{}]", comma_delimited(elements, ind)),
         Core::KeyValue { key, value } => format!("{} : {}", to_py(key, ind), to_py(value, ind)),
-        Core::Dictionary { expr, cases } =>
-            format!("{{\n{}\n}}[{}]", comma_delimited(cases, ind + 1), to_py(expr, ind)),
+        Core::Dictionary { expr, cases } => format!(
+            "{{\n{}{}\n{}}}[{}]",
+            indent(ind + 1),
+            comma_delimited(cases, ind + 1),
+            indent(ind),
+            to_py(expr, ind)
+        ),
         Core::DefaultDictionary { expr, cases, default } => format!(
             "defaultdict({}, {{\n{}\n{}}})[{}]",
             to_py(default, ind),
@@ -286,6 +291,12 @@ fn to_py(core: &Core, ind: usize) -> String {
         Core::Except { id, class, body } => format!(
             "except {} as {}:\n{}{}\n",
             to_py(class, ind),
+            to_py(id, ind),
+            indent(ind + 1),
+            to_py(body, ind + 1)
+        ),
+        Core::ExceptNoClass { id, body } => format!(
+            "except Exception as {}:\n{}{}\n",
             to_py(id, ind),
             indent(ind + 1),
             to_py(body, ind + 1)

--- a/src/desugar/control_flow.rs
+++ b/src/desugar/control_flow.rs
@@ -2,6 +2,7 @@ use crate::core::construct::Core;
 use crate::desugar::context::Imports;
 use crate::desugar::context::State;
 use crate::desugar::desugar_result::DesugarResult;
+use crate::desugar::desugar_result::UnimplementedErr;
 use crate::desugar::node::desugar_node;
 use crate::parser::ast::ASTNode;
 use crate::parser::ast::ASTNodePos;
@@ -39,7 +40,11 @@ pub fn desugar_control_flow(
                                 value: Box::from(desugar_node(body.as_ref(), imp, state)?)
                             })
                         },
-                        other => panic!("Expected id type as cond but was {:?}", other)
+                        _ =>
+                            return Err(UnimplementedErr::new(
+                                node_pos,
+                                "match case expression as condition (pattern matching)"
+                            )),
                     },
                     other => panic!("Expected case but was {:?}", other)
                 }

--- a/src/desugar/node.rs
+++ b/src/desugar/node.rs
@@ -302,19 +302,22 @@ pub fn desugar_node(node_pos: &ASTNodePos, imp: &mut Imports, state: &State) -> 
                             other => panic!("Expected case but was {:?}", other)
                         };
 
-                        let (id, class) = match &cond.node {
+                        match &cond.node {
                             ASTNode::IdType { id, _type: Some(ty), .. } => match &ty.node {
-                                ASTNode::Type { id: ty, .. } => (id, ty),
+                                ASTNode::Type { id: ty, .. } => except.push(Core::Except {
+                                    id:    Box::from(desugar_node(id, imp, state)?),
+                                    class: Box::from(desugar_node(ty, imp, state)?),
+                                    body:  Box::from(desugar_node(body, imp, state)?)
+                                }),
                                 other => panic!("Expected type but was {:?}", other)
                             },
+                            ASTNode::IdType { id, _type: None, .. } =>
+                                except.push(Core::ExceptNoClass {
+                                    id:   Box::from(desugar_node(id, imp, state)?),
+                                    body: Box::from(desugar_node(body, imp, state)?)
+                                }),
                             other => panic!("Expected id type but was {:?}", other)
                         };
-
-                        except.push(Core::Except {
-                            id:    Box::from(desugar_node(id, imp, state)?),
-                            class: Box::from(desugar_node(class, imp, state)?),
-                            body:  Box::from(desugar_node(body, imp, state)?)
-                        });
                     }
                     except
                 }

--- a/src/parser/control_flow_expr.rs
+++ b/src/parser/control_flow_expr.rs
@@ -73,7 +73,7 @@ pub fn parse_match_cases(it: &mut TPIterator) -> ParseResult<Vec<ASTNodePos>> {
 fn parse_match_case(it: &mut TPIterator) -> ParseResult {
     let (st_line, st_pos) = it.start_pos("match case")?;
 
-    let cond = it.parse(&parse_expression_maybe_type, "match case", st_line, st_pos)?;
+    let cond = it.parse(&parse_id_maybe_type, "match case", st_line, st_pos)?;
     it.eat(&Token::BTo, "match case")?;
     let body = it.parse(&parse_expr_or_stmt, "match case", st_line, st_pos)?;
 
@@ -82,7 +82,7 @@ fn parse_match_case(it: &mut TPIterator) -> ParseResult {
     Ok(Box::from(ASTNodePos { st_line, st_pos, en_line, en_pos, node }))
 }
 
-pub fn parse_expression_maybe_type(it: &mut TPIterator) -> ParseResult {
+pub fn parse_id_maybe_type(it: &mut TPIterator) -> ParseResult {
     let (st_line, st_pos) = it.start_pos("expression maybe type")?;
     let mutable = it.eat_if(&Token::Mut).is_some();
 

--- a/tests/resources/valid/class/generics.mamba
+++ b/tests/resources/valid/class/generics.mamba
@@ -6,8 +6,13 @@ class MyClass2[C, A isa MyGeneric] isa MyType[A, C]
     def init(mut self, other_field: Int, z: Int) raises [Err] =>
         if z > 10 then raise Err("Something is wrong!")
         self.z_modified <- z * SOME_CONSTANT
+
+        def something <- match c
+            b => d
+            other: Thing => a
+
         def a <- self.z_modified handle
-            err1: MyErr =>
+            err1 =>
                 print "hey"
                 print "there"
             err2: MyErr => print "hoi"

--- a/tests/resources/valid/class/generics_check.py
+++ b/tests/resources/valid/class/generics_check.py
@@ -7,11 +7,15 @@ class MyClass2(MyType):
         super().__init__(self)
         if z > 10: raise Err("Something is wrong!")
         self.z_modified = z * SOME_CONSTANT
-        a = None
 
+        something = {
+            b : d, other : a
+        }[c]
+
+        a = None
         try:
             a = self.z_modified
-        except MyErr as err1:
+        except Exception as err1:
             print("hey")
             print("there")
         except MyErr as err2:


### PR DESCRIPTION
### Relevant issues
Fixes #138 
However, the issue does not describe the problem accurately, see the summary.

### Summary
Match arms can have a condition without an explicit type as a condition.
However, this was not the case for exceptions.
I opted to allow this, and these arms become generic catchall arms which handle all exceptions.

Also fix indentation error when outputting dictionaries.

### Added Tests
- Test to verify that we can have a match arm condition without a type
- Test to verify that we can have a handle arm condition without a type, which should become a catchall arm which handles all exceptions types (`except Exception as <id>`).
