### PR TITLE
Add command line elaboration to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,6 +284,26 @@ print "a has value {a}."
 If we don't want to use a `handle`, we can simply use `raises` after a statement or exception to show that its execution might result in an exception, but we don't want to handle that here.
 See the sections above for examples where we don't handle errors and simply pass them on using `raises`.
 
+## 💻 Using the Command Line Interface
+
+### Usage
+```
+mamba [OPTIONS]
+```
+
+### Options
+```
+-i, --input <INPUT>      Input file or directory.
+                         If file, file taken as input.
+                         If directory, recursively search all sub-directories for *.mamba files.
+                         If no input given, current directory used as input directory.
+-o, --output <OUTPUT>    Output directory to store mamba files.
+                         Output directory structure reflects input directory structure.
+                         If no output given, 'target' directory created in current directory and is used as ouput.
+```
+
+You can type `mamba -help` for a message containing roughly the above information.
+
 ## 👥 Contributing
 
 Before submitting your first issue or pull request, please take the time to read both our [contribution guidelines](CONTRIBUTING.md) and our [code of conduct](CODE_OF_CONDUCT.md).

--- a/src/cli.yml
+++ b/src/cli.yml
@@ -1,6 +1,8 @@
 name: Mamba
 author: Joël Abrahams
-about: Transpile Mamba to Python code
+about: |
+  Transpile Mamba to Python code.
+  Documentation available at http://joelabrahams.nl/mamba_doc/.
 args:
     - input:
         short: i
@@ -9,15 +11,15 @@ args:
         help: |
           Input file or directory.
           If file, file taken as input.
-          If directory, recursively search all sub-directories for mamba files.
-          If no input given, current directory taken is directory.
+          If directory, recursively search all sub-directories for *.mamba files.
+          If no input given, current directory used as input directory.
         takes_value: true
     - output:
         short: o
         long: output
         value_name: OUTPUT
         help: |
-          Output directory to story mamba files.
+          Output directory to store mamba files.
           Output directory structure reflects input directory structure.
-          If no output given, target directory created in current directory and output stored here.
+          If no output given, 'target' directory created in current directory and is used as ouput.
         takes_value: true

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,6 +13,7 @@ pub fn main() -> Result<(), String> {
 
     let yaml = load_yaml!("cli.yml");
     let matches = App::from_yaml(yaml).version(VERSION).get_matches();
+
     match std::env::current_dir() {
         Ok(current_dir) => {
             let in_path = matches.value_of("input");


### PR DESCRIPTION
### Summary
Fix some grammar errors in cli help message.
Add link to documentation in about message.

This should make it slightly easier for people to get up and started, though in future there should be more elaborate documentation on the usage of the CLI of Mamba.