### PR TITLE
Improve (Public) Interface

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -3,27 +3,27 @@ extern crate clap;
 
 use clap::App;
 use leg::*;
-use mamba::pipeline::mamba_to_python;
-use std::result::Result::Err;
+use mamba::pipeline::transpile_directory;
 
 const VERSION: &str = env!("CARGO_PKG_VERSION");
 
 pub fn main() -> Result<(), String> {
     head("Mamba", Some("🐍"), Some(VERSION));
+    let current_dir = std::env::current_dir().map_err(|err| {
+        error(format!("Error while finding current directory: {:#?}", err).as_str(), None, None);
+        format!("Error while finding current directory: {:#?}", err)
+    })?;
 
     let yaml = load_yaml!("cli.yml");
     let matches = App::from_yaml(yaml).version(VERSION).get_matches();
+    let in_path = matches.value_of("input");
+    let out_path = matches.value_of("output");
 
-    match std::env::current_dir() {
-        Ok(current_dir) => {
-            let in_path = matches.value_of("input");
-            let out_path = matches.value_of("output");
-
-            mamba_to_python(&current_dir, in_path, out_path).map(|_| ())
-        }
-        e => {
-            error(format!("Error while finding current directory: {:#?}", e).as_str(), None, None);
-            Err(format!("Error while finding current directory: {:#?}", e))
-        }
-    }
+    transpile_directory(&current_dir, in_path, out_path)
+        .map_err(|errors| {
+            errors.iter().for_each(|(ty, msg)| error(msg, Some(ty), None));
+            let error = errors.last();
+            format!("An error occurred: {:#?}", error)
+        })
+        .map(|_| ())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,9 +22,9 @@ pub fn main() -> Result<(), String> {
     transpile_directory(&current_dir, in_path, out_path)
         .map_err(|errors| {
             errors.iter().for_each(|(ty, msg)| error(msg, Some(ty), None));
-            match errors.last() {
+            match errors.first() {
                 Some((ty, msg)) => format!(
-                    "{} {} type  error occurred: {}",
+                    "{} {} type error occurred: {}",
                     match ty.chars().next() {
                         Some(c) if ['a', 'e', 'i', 'o', 'u'].contains(&c.to_ascii_lowercase()) =>
                             "An",

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,8 +22,19 @@ pub fn main() -> Result<(), String> {
     transpile_directory(&current_dir, in_path, out_path)
         .map_err(|errors| {
             errors.iter().for_each(|(ty, msg)| error(msg, Some(ty), None));
-            let error = errors.last();
-            format!("An error occurred: {:#?}", error)
+            match errors.last() {
+                Some((ty, msg)) => format!(
+                    "{} {} type  error occurred: {}",
+                    match ty.chars().next() {
+                        Some(c) if ['a', 'e', 'i', 'o', 'u'].contains(&c.to_ascii_lowercase()) =>
+                            "An",
+                        _ => "A"
+                    },
+                    ty,
+                    msg
+                ),
+                None => String::new()
+            }
         })
         .map(|_| ())
 }

--- a/src/pipeline/error.rs
+++ b/src/pipeline/error.rs
@@ -1,12 +1,11 @@
 use crate::desugar::desugar_result::UnimplementedErr;
 use crate::parser::parse_result::ParseErr;
 use std::cmp::min;
-use std::path::Path;
 use std::path::PathBuf;
 
 const SYNTAX_ERR_MAX_DEPTH: usize = 2;
 
-pub fn syntax_err(err: &ParseErr, source: &str, in_path: &PathBuf) -> String {
+pub fn syntax_err(err: &ParseErr, source: &str, in_path: &Option<PathBuf>) -> String {
     let cause_formatter = &err.causes[0..min(err.causes.len(), SYNTAX_ERR_MAX_DEPTH)]
         .iter()
         .rev()
@@ -23,12 +22,12 @@ pub fn syntax_err(err: &ParseErr, source: &str, in_path: &PathBuf) -> String {
         });
 
     format!(
-        "--> {}:{}:{}
+        "--> {:#?}:{}:{}
      | {}
 {}
 {:3}  |- {}
      | {}{}",
-        in_path.display(),
+        in_path,
         err.line,
         err.pos,
         err.msg,
@@ -40,13 +39,17 @@ pub fn syntax_err(err: &ParseErr, source: &str, in_path: &PathBuf) -> String {
     )
 }
 
-pub fn unimplemented_err(err: &UnimplementedErr, source: &str, in_path: &Path) -> String {
+pub fn unimplemented_err(
+    err: &UnimplementedErr,
+    source: &str,
+    in_path: &Option<PathBuf>
+) -> String {
     format!(
-        "--> {}:{}:{}
+        "--> {:#?}:{}:{}
      | {}
 {:3}  |- {}
      | {}{}",
-        in_path.display(),
+        in_path,
         err.line,
         err.pos,
         err.msg,

--- a/src/pipeline/error.rs
+++ b/src/pipeline/error.rs
@@ -27,7 +27,7 @@ pub fn syntax_err(err: &ParseErr, source: &str, in_path: &Option<PathBuf>) -> St
 {}
 {:3}  |- {}
      | {}{}",
-        in_path,
+        in_path.clone().unwrap_or_default(),
         err.line,
         err.pos,
         err.msg,
@@ -49,7 +49,7 @@ pub fn unimplemented_err(
      | {}
 {:3}  |- {}
      | {}{}",
-        in_path,
+        in_path.clone().unwrap_or_default(),
         err.line,
         err.pos,
         err.msg,

--- a/src/pipeline/io.rs
+++ b/src/pipeline/io.rs
@@ -1,0 +1,26 @@
+use std::fs::OpenOptions;
+use std::io::Read;
+use std::io::Write;
+use std::path::PathBuf;
+
+pub fn read_source(source_path: &PathBuf) -> Result<String, (String, String)> {
+    let mut source = String::new();
+    OpenOptions::new()
+        .read(true)
+        .open(source_path.clone())
+        .map_err(|e| (String::from("input"), format!("{}: '{}'", e, source_path.display())))?
+        .read_to_string(&mut source)
+        .map_err(|e| (String::from("input"), format!("{}: '{}'", e, source_path.display())))?;
+
+    Ok(source)
+}
+
+pub fn write_source(source: &str, out_path: &PathBuf) -> Result<usize, (String, String)> {
+    OpenOptions::new()
+        .create(true)
+        .write(true)
+        .open(out_path.clone())
+        .map_err(|e| (String::from("output"), format!("{}: '{}'", e, out_path.display())))?
+        .write(source.as_ref())
+        .map_err(|e| (String::from("output"), format!("{}: '{}'", e, out_path.display())))
+}

--- a/src/pipeline/io.rs
+++ b/src/pipeline/io.rs
@@ -1,26 +1,67 @@
+use std::ffi::OsString;
 use std::fs::OpenOptions;
 use std::io::Read;
 use std::io::Write;
+use std::path::Path;
 use std::path::PathBuf;
+
+use glob::glob;
+use pathdiff::diff_paths;
+use std::fs;
 
 pub fn read_source(source_path: &PathBuf) -> Result<String, (String, String)> {
     let mut source = String::new();
     OpenOptions::new()
         .read(true)
-        .open(source_path.clone())
-        .map_err(|e| (String::from("input"), format!("{}: '{}'", e, source_path.display())))?
+        .open(source_path)
+        .map_err(|e| (String::from("input"), format!("{}: {}", e, source_path.display())))?
         .read_to_string(&mut source)
-        .map_err(|e| (String::from("input"), format!("{}: '{}'", e, source_path.display())))?;
-
+        .map_err(|e| (String::from("input"), format!("{}: {}", e, source_path.display())))?;
     Ok(source)
 }
 
 pub fn write_source(source: &str, out_path: &PathBuf) -> Result<usize, (String, String)> {
+    match out_path.parent() {
+        Some(parent) => fs::create_dir_all(parent)
+            .map_err(|e| (String::from("output"), format!("{}: {}", e, parent.display())))?,
+        None =>
+            return Err((
+                String::from("output"),
+                format!("No parent directory: {}", out_path.display())
+            )),
+    };
+
     OpenOptions::new()
-        .create(true)
         .write(true)
-        .open(out_path.clone())
-        .map_err(|e| (String::from("output"), format!("{}: '{}'", e, out_path.display())))?
+        .create(true)
+        .open(out_path)
+        .map_err(|e| (String::from("output"), format!("{}: {}", e, out_path.display())))?
         .write(source.as_ref())
-        .map_err(|e| (String::from("output"), format!("{}: '{}'", e, out_path.display())))
+        .map_err(|e| (String::from("output"), format!("{}: {}", e, out_path.display())))
+}
+
+/// Get all `*.mamba` files paths relative to given path.
+///
+/// If path is file, return file name.
+/// If directory, return all `*.mamba` files as relative paths to given path.
+pub fn relative_files(in_path: &Path) -> Result<Vec<OsString>, (String, String)> {
+    if in_path.is_file() {
+        let in_file_name = in_path.file_name().unwrap_or_else(|| unreachable!());
+        return Ok(vec![in_file_name.to_os_string()]);
+    }
+
+    let pattern_path = in_path.to_owned().join("**").join("*.mamba");
+    let pattern = pattern_path.as_os_str().to_string_lossy();
+    let glob = glob(pattern.as_ref())
+        .map_err(|e| (String::from("file"), format!("Unable to recursively find files: {}", e)))?;
+
+    let mut relative_paths = vec![];
+    for absolute_result in glob {
+        let absolute_path = absolute_result.map_err(|e| (String::from("file"), e.to_string()))?;
+        let relative_path = diff_paths(absolute_path.as_path(), in_path)
+            .ok_or((String::from("file"), String::from("Unable to create relative path")))?;
+        relative_paths.push(relative_path.into_os_string());
+    }
+
+    Ok(relative_paths)
 }

--- a/src/pipeline/mod.rs
+++ b/src/pipeline/mod.rs
@@ -98,7 +98,7 @@ pub fn mamba_to_python(
     })?;
 
     // In future, desugaring stage should take in a vector and return a vector for
-    // more complex desugaring.
+    // more complex desugaring rules.
     let mut python_sources = vec![];
     let mut type_errors = vec![];
     for (ast_node_pos, source, source_path) in ast_node_pairs {

--- a/src/pipeline/mod.rs
+++ b/src/pipeline/mod.rs
@@ -37,7 +37,7 @@ pub fn transpile_directory(
 ) -> Result<PathBuf, Vec<(String, String)>> {
     let src_path = maybe_in.map_or(current_dir.join(IN_FILE), |p| current_dir.join(p));
     let out_dir = current_dir.join(maybe_out.unwrap_or(OUT_FILE));
-    info(format!("Output will be stored in '{}'", out_dir.display()).as_str(), None, None);
+    info(format!("Input is '{}'", src_path.display()).as_str(), None, None);
 
     let relative_paths = io::relative_files(src_path.as_path()).map_err(|error| vec![error])?;
     let in_absolute_paths = if src_path.is_dir() {
@@ -47,6 +47,17 @@ pub fn transpile_directory(
     };
     let out_absolute_paths: Vec<PathBuf> =
         relative_paths.iter().map(|os_string| out_dir.join(os_string)).collect();
+
+    info(
+        format!(
+            "Transpiling {} file{}",
+            out_absolute_paths.len(),
+            if out_absolute_paths.len() > 1 { "s" } else { "" }
+        )
+        .as_str(),
+        None,
+        None
+    );
 
     let mut sources = vec![];
     for source_path in in_absolute_paths.clone() {
@@ -64,6 +75,7 @@ pub fn transpile_directory(
         io::write_source(source, &out_path).map_err(|error| vec![error])?;
     }
 
+    success(format!("Output stored in '{}'", out_dir.display()).as_str(), None, None);
     Ok(out_dir)
 }
 

--- a/tests/output/class.rs
+++ b/tests/output/class.rs
@@ -5,13 +5,13 @@ use crate::common::python_src_to_stmts;
 use crate::common::resource_content;
 use crate::common::resource_path;
 use crate::output::common::PYTHON;
-use mamba::pipeline::mamba_to_python;
+use mamba::pipeline::transpile_directory;
 use std::path::Path;
 use std::process::Command;
 
 #[test]
-fn generics_ast_verify() -> Result<(), String> {
-    mamba_to_python(
+fn generics_ast_verify() -> Result<(), Vec<(String, String)>> {
+    transpile_directory(
         &Path::new(&resource_path(true, &["class"], "")),
         Some("generics.mamba"),
         None
@@ -37,8 +37,8 @@ fn generics_ast_verify() -> Result<(), String> {
 }
 
 #[test]
-fn import_ast_verify() -> Result<(), String> {
-    mamba_to_python(
+fn import_ast_verify() -> Result<(), Vec<(String, String)>> {
+    transpile_directory(
         &Path::new(resource_path(true, &["class"], "").as_str()),
         Some("import.mamba"),
         None
@@ -65,8 +65,8 @@ fn import_ast_verify() -> Result<(), String> {
 }
 
 #[test]
-fn parent_ast_verify() -> Result<(), String> {
-    mamba_to_python(
+fn parent_ast_verify() -> Result<(), Vec<(String, String)>> {
+    transpile_directory(
         &Path::new(resource_path(true, &["class"], "").as_str()),
         Some("parent.mamba"),
         None
@@ -93,8 +93,8 @@ fn parent_ast_verify() -> Result<(), String> {
 }
 
 #[test]
-fn types_ast_verify() -> Result<(), String> {
-    mamba_to_python(
+fn types_ast_verify() -> Result<(), Vec<(String, String)>> {
+    transpile_directory(
         &Path::new(resource_path(true, &["class"], "").as_str()),
         Some("types.mamba"),
         None

--- a/tests/output/control_flow.rs
+++ b/tests/output/control_flow.rs
@@ -5,13 +5,13 @@ use crate::common::python_src_to_stmts;
 use crate::common::resource_content;
 use crate::common::resource_path;
 use crate::output::common::PYTHON;
-use mamba::pipeline::mamba_to_python;
+use mamba::pipeline::transpile_directory;
 use std::path::Path;
 use std::process::Command;
 
 #[test]
-fn for_ast_verify() -> Result<(), String> {
-    mamba_to_python(
+fn for_ast_verify() -> Result<(), Vec<(String, String)>> {
+    transpile_directory(
         &Path::new(&resource_path(true, &["control_flow"], "")),
         Some("for_statements.mamba"),
         None
@@ -38,8 +38,8 @@ fn for_ast_verify() -> Result<(), String> {
 }
 
 #[test]
-fn if_ast_verify() -> Result<(), String> {
-    mamba_to_python(
+fn if_ast_verify() -> Result<(), Vec<(String, String)>> {
+    transpile_directory(
         &Path::new(&resource_path(true, &["control_flow"], "")),
         Some("if.mamba"),
         None
@@ -66,8 +66,8 @@ fn if_ast_verify() -> Result<(), String> {
 }
 
 #[test]
-fn while_ast_verify() -> Result<(), String> {
-    mamba_to_python(
+fn while_ast_verify() -> Result<(), Vec<(String, String)>> {
+    transpile_directory(
         &Path::new(&resource_path(true, &["control_flow"], "")),
         Some("while.mamba"),
         None
@@ -94,8 +94,8 @@ fn while_ast_verify() -> Result<(), String> {
 }
 
 #[test]
-fn match_ast_verify() -> Result<(), String> {
-    mamba_to_python(
+fn match_ast_verify() -> Result<(), Vec<(String, String)>> {
+    transpile_directory(
         &Path::new(&resource_path(true, &["control_flow"], "")),
         Some("match.mamba"),
         None

--- a/tests/output/error.rs
+++ b/tests/output/error.rs
@@ -5,13 +5,17 @@ use crate::common::python_src_to_stmts;
 use crate::common::resource_content;
 use crate::common::resource_path;
 use crate::output::common::PYTHON;
-use mamba::pipeline::mamba_to_python;
+use mamba::pipeline::transpile_directory;
 use std::path::Path;
 use std::process::Command;
 
 #[test]
-fn handle_ast_verify() -> Result<(), String> {
-    mamba_to_python(&Path::new(&resource_path(true, &["error"], "")), Some("handle.mamba"), None)?;
+fn handle_ast_verify() -> Result<(), Vec<(String, String)>> {
+    transpile_directory(
+        &Path::new(&resource_path(true, &["error"], "")),
+        Some("handle.mamba"),
+        None
+    )?;
 
     let cmd = Command::new(PYTHON)
         .arg("-m")
@@ -34,8 +38,12 @@ fn handle_ast_verify() -> Result<(), String> {
 }
 
 #[test]
-fn raise_ast_verify() -> Result<(), String> {
-    mamba_to_python(&Path::new(&resource_path(true, &["error"], "")), Some("raise.mamba"), None)?;
+fn raise_ast_verify() -> Result<(), Vec<(String, String)>> {
+    transpile_directory(
+        &Path::new(&resource_path(true, &["error"], "")),
+        Some("raise.mamba"),
+        None
+    )?;
 
     let cmd = Command::new(PYTHON)
         .arg("-m")

--- a/tests/output/function.rs
+++ b/tests/output/function.rs
@@ -5,13 +5,13 @@ use crate::common::python_src_to_stmts;
 use crate::common::resource_content;
 use crate::common::resource_path;
 use crate::output::common::PYTHON;
-use mamba::pipeline::mamba_to_python;
+use mamba::pipeline::transpile_directory;
 use std::path::Path;
 use std::process::Command;
 
 #[test]
-fn call_ast_verify() -> Result<(), String> {
-    mamba_to_python(
+fn call_ast_verify() -> Result<(), Vec<(String, String)>> {
+    transpile_directory(
         &Path::new(&resource_path(true, &["function"], "")),
         Some("calls.mamba"),
         None
@@ -38,8 +38,8 @@ fn call_ast_verify() -> Result<(), String> {
 }
 
 #[test]
-fn definition_ast_verify() -> Result<(), String> {
-    mamba_to_python(
+fn definition_ast_verify() -> Result<(), Vec<(String, String)>> {
+    transpile_directory(
         &Path::new(&resource_path(true, &["function"], "")),
         Some("definition.mamba"),
         None
@@ -66,8 +66,8 @@ fn definition_ast_verify() -> Result<(), String> {
 }
 
 #[test]
-fn infix_calls_ast_verify() -> Result<(), String> {
-    mamba_to_python(
+fn infix_calls_ast_verify() -> Result<(), Vec<(String, String)>> {
+    transpile_directory(
         &Path::new(resource_path(true, &["function"], "").as_str()),
         Some("infix_calls.mamba"),
         None

--- a/tests/output/operation.rs
+++ b/tests/output/operation.rs
@@ -5,13 +5,13 @@ use crate::common::python_src_to_stmts;
 use crate::common::resource_content;
 use crate::common::resource_path;
 use crate::output::common::PYTHON;
-use mamba::pipeline::mamba_to_python;
+use mamba::pipeline::transpile_directory;
 use std::path::Path;
 use std::process::Command;
 
 #[test]
-fn arithmetic_ast_verify() -> Result<(), String> {
-    mamba_to_python(
+fn arithmetic_ast_verify() -> Result<(), Vec<(String, String)>> {
+    transpile_directory(
         &Path::new(&resource_path(true, &["operation"], "")),
         Some("arithmetic.mamba"),
         None
@@ -38,8 +38,8 @@ fn arithmetic_ast_verify() -> Result<(), String> {
 }
 
 #[test]
-fn bitwise_ast_verify() -> Result<(), String> {
-    mamba_to_python(
+fn bitwise_ast_verify() -> Result<(), Vec<(String, String)>> {
+    transpile_directory(
         &Path::new(&resource_path(true, &["operation"], "")),
         Some("bitwise.mamba"),
         None
@@ -66,8 +66,8 @@ fn bitwise_ast_verify() -> Result<(), String> {
 }
 
 #[test]
-fn boolean_ast_verify() -> Result<(), String> {
-    mamba_to_python(
+fn boolean_ast_verify() -> Result<(), Vec<(String, String)>> {
+    transpile_directory(
         &Path::new(&resource_path(true, &["operation"], "")),
         Some("boolean.mamba"),
         None


### PR DESCRIPTION
### Relevant issues
The interface was rather messy.

### Summary
The following are now public:
- main function, which is the command-line interface
- A `transpile_directory` function, which is used by the command line interface. This allows us to transpile entire directories
- A `mamba_to_python` function, which takes a vector of Strings representing mamba source code and returns a vector of Strings representing Python source code. This function *optionally* takes directories as an argument to improve error messages.

Internals may still be accessed through the library (`lib.rs`), but the above form part of the public interface.