### PR TITLE
Type check contents of f-Strings

### DIFF
--- a/src/common/position.rs
+++ b/src/common/position.rs
@@ -30,6 +30,13 @@ impl Position {
         max(1, max(self.end.pos - self.start.pos, self.start.pos - self.end.pos))
     }
 
+    pub fn offset(&self, offset: &CaretPos) -> Position {
+        Position {
+            start: self.start.clone().offset(offset),
+            end:   self.end.clone().offset(offset)
+        }
+    }
+
     pub fn union(&self, other: &Position) -> Position {
         Position {
             start: CaretPos {
@@ -47,6 +54,10 @@ impl Position {
 impl CaretPos {
     /// Create new endpoint with given line and position.
     pub fn new(line: i32, pos: i32) -> CaretPos { CaretPos { line, pos } }
+
+    pub fn offset(self, offset: &CaretPos) -> CaretPos {
+        CaretPos { line: self.line + offset.line - 1, pos: self.pos + offset.pos - 1 }
+    }
 
     /// Create new [EndPoint] which is offset in the vertical direction by the
     /// given amount.

--- a/src/core/construct.rs
+++ b/src/core/construct.rs
@@ -80,6 +80,9 @@ pub enum Core {
     Str {
         _str: String
     },
+    FStr {
+        _str: String
+    },
     Bool {
         _bool: bool
     },

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -33,7 +33,7 @@ pub mod construct;
 ///     _else: Box::from(Core::Str { _str: String::from("c") })
 /// };
 ///
-/// assert_eq!(to_source(&core_node), "if a: f\"b\"\nelse: f\"c\"\n");
+/// assert_eq!(to_source(&core_node), "if a: \"b\"\nelse: \"c\"\n");
 /// ```
 pub fn to_source(core: &Core) -> String { format!("{}\n", to_py(&core, 0)) }
 
@@ -53,7 +53,8 @@ fn to_py(core: &Core, ind: usize) -> String {
                 format!("{}[{}]", lit, comma_delimited(generics, ind))
             },
         Core::IdType { lit, ty } => format!("{}: {}", lit, to_py(ty, ind)),
-        Core::Str { _str } => format!("f\"{}\"", _str),
+        Core::Str { _str } => format!("\"{}\"", _str),
+        Core::FStr { _str } => format!("f\"{}\"", _str),
         Core::Int { int } => int.clone(),
         Core::ENum { num, exp } => format!("({} * 10 ** {})", num, exp),
         Core::Float { float } => float.clone(),

--- a/src/desugar/node.rs
+++ b/src/desugar/node.rs
@@ -48,7 +48,7 @@ pub fn desugar_node(ast: &AST, imp: &mut Imports, state: &State) -> DesugarResul
             num: num.clone(),
             exp: if exp.is_empty() { String::from("0") } else { exp.clone() }
         },
-        Node::Str { lit } => Core::Str { _str: lit.clone() },
+        Node::Str { lit, .. } => Core::Str { _str: lit.clone() },
 
         Node::AddOp => Core::AddOp,
         Node::SubOp => Core::SubOp,

--- a/src/desugar/node.rs
+++ b/src/desugar/node.rs
@@ -48,7 +48,12 @@ pub fn desugar_node(ast: &AST, imp: &mut Imports, state: &State) -> DesugarResul
             num: num.clone(),
             exp: if exp.is_empty() { String::from("0") } else { exp.clone() }
         },
-        Node::Str { lit, .. } => Core::Str { _str: lit.clone() },
+        Node::Str { lit, expressions } =>
+            if expressions.is_empty() {
+                Core::Str { _str: lit.clone() }
+            } else {
+                Core::FStr { _str: lit.clone() }
+            },
 
         Node::AddOp => Core::AddOp,
         Node::SubOp => Core::SubOp,

--- a/src/lexer/token.rs
+++ b/src/lexer/token.rs
@@ -46,7 +46,7 @@ pub enum Token {
     Real(String),
     Int(String),
     ENum(String, String),
-    Str(String),
+    Str(String, Vec<Vec<Lex>>),
     Bool(bool),
     Range,
     RangeIncl,
@@ -132,7 +132,7 @@ impl Token {
             Token::Int(int) => int.len(),
             Token::Bool(true) => 4,
             Token::Bool(false) => 5,
-            Token::Str(_str) => _str.len(),
+            Token::Str(_str, _) => _str.len(),
             Token::ENum(num, exp) => num.len() + 1 + exp.len(),
             other => format!("{}", other).len()
         } as i32)
@@ -144,7 +144,7 @@ impl Token {
             (Token::Real(_), Token::Real(_)) => true,
             (Token::Int(_), Token::Int(_)) => true,
             (Token::Bool(_), Token::Bool(_)) => true,
-            (Token::Str(_), Token::Str(_)) => true,
+            (Token::Str(..), Token::Str(..)) => true,
             (Token::ENum(..), Token::ENum(..)) => true,
             _ => left == right
         }
@@ -187,7 +187,7 @@ impl fmt::Display for Token {
                 } else {
                     format!("{}E{}", int, exp)
                 },
-            Token::Str(string) => format!("\"{}\"", string),
+            Token::Str(string, _) => format!("\"{}\"", string),
             Token::Bool(boolean) => String::from(if boolean { "True" } else { "False" }),
 
             Token::Range => String::from(".."),

--- a/src/parser/ast.rs
+++ b/src/parser/ast.rs
@@ -196,7 +196,8 @@ pub enum Node {
         exp: String
     },
     Str {
-        lit: String
+        lit:         String,
+        expressions: Vec<AST>
     },
     Bool {
         lit: bool

--- a/src/parser/class.rs
+++ b/src/parser/class.rs
@@ -81,7 +81,7 @@ pub fn parse_parent(it: &mut LexIterator) -> ParseResult {
             _ => Err(expected_one_of(
                 &[
                     Token::Id(String::new()),
-                    Token::Str(String::new()),
+                    Token::Str(String::new(), vec![]),
                     Token::Int(String::new()),
                     Token::Real(String::new()),
                     Token::ENum(String::new(), String::new()),

--- a/src/type_checker/infer/literal.rs
+++ b/src/type_checker/infer/literal.rs
@@ -17,9 +17,9 @@ pub fn infer_literal(ast: &AST, env: &Environment, ctx: &Context) -> InferResult
             Node::ENum { .. } => ctx.lookup(&TypeName::from(concrete::ENUM_PRIMITIVE), &ast.pos),
             Node::Str { expressions, .. } => {
                 for expression in expressions {
-                    println!("{:?}", expression);
                     let (expr_ty, _) = infer(expression, env, ctx)?;
-                    expr_ty.expr_ty(&expression.pos)?;
+                    let expr_ty = expr_ty.expr_ty(&expression.pos)?;
+                    expr_ty.fun("__str__", &[], &expression.pos)?;
                 }
                 ctx.lookup(&TypeName::from(concrete::STRING_PRIMITIVE), &ast.pos)
             }

--- a/src/type_checker/infer/literal.rs
+++ b/src/type_checker/infer/literal.rs
@@ -4,7 +4,7 @@ use crate::type_checker::context::type_name::TypeName;
 use crate::type_checker::context::Context;
 use crate::type_checker::environment::infer_type::InferType;
 use crate::type_checker::environment::Environment;
-use crate::type_checker::infer::InferResult;
+use crate::type_checker::infer::{infer, InferResult};
 use crate::type_checker::type_result::TypeErr;
 
 // TODO type check expressions within fstrings
@@ -15,7 +15,14 @@ pub fn infer_literal(ast: &AST, env: &Environment, ctx: &Context) -> InferResult
             Node::Real { .. } => ctx.lookup(&TypeName::from(concrete::FLOAT_PRIMITIVE), &ast.pos),
             Node::Int { .. } => ctx.lookup(&TypeName::from(concrete::INT_PRIMITIVE), &ast.pos),
             Node::ENum { .. } => ctx.lookup(&TypeName::from(concrete::ENUM_PRIMITIVE), &ast.pos),
-            Node::Str { .. } => ctx.lookup(&TypeName::from(concrete::STRING_PRIMITIVE), &ast.pos),
+            Node::Str { expressions, .. } => {
+                for expression in expressions {
+                    println!("{:?}", expression);
+                    let (expr_ty, _) = infer(expression, env, ctx)?;
+                    expr_ty.expr_ty(&expression.pos)?;
+                }
+                ctx.lookup(&TypeName::from(concrete::STRING_PRIMITIVE), &ast.pos)
+            }
             Node::Bool { .. } => ctx.lookup(&TypeName::from(concrete::BOOL_PRIMITIVE), &ast.pos),
             _ => Err(vec![TypeErr::new(&ast.pos, "Expected control flow")])
         }?),

--- a/src/type_checker/resources/primitives/bool.py
+++ b/src/type_checker/resources/primitives/bool.py
@@ -2,3 +2,4 @@ class bool:
     def __init__(self): pass
 
     def __bool__(self) -> bool: pass
+    def __str__(self) -> str: pass

--- a/src/type_checker/resources/primitives/complex.py
+++ b/src/type_checker/resources/primitives/complex.py
@@ -1,4 +1,6 @@
 class complex:
+    def __init__(self, real: float, imaginary: float) -> complex: pass
+
     def __add__(self, other: int) -> complex: pass
     def __add__(self, other: float) -> complex: pass
     def __add__(self, other: complex) -> complex: pass
@@ -24,3 +26,4 @@ class complex:
     def __pow__(self, power: complex, modulo=None) -> complex: pass
 
     def __bool__(self) -> bool: pass
+    def __str__(self) -> str: pass

--- a/src/type_checker/resources/primitives/float.py
+++ b/src/type_checker/resources/primitives/float.py
@@ -44,3 +44,4 @@ class float:
     def __lt__(self, other: float) -> bool: pass
 
     def __bool__(self) -> bool: pass
+    def __str__(self) -> str: pass

--- a/src/type_checker/resources/primitives/int.py
+++ b/src/type_checker/resources/primitives/int.py
@@ -45,3 +45,4 @@ class int:
     def __lt__(self, other: float) -> bool: pass
 
     def __bool__(self) -> bool: pass
+    def __str__(self) -> str: pass

--- a/src/type_checker/resources/primitives/string.py
+++ b/src/type_checker/resources/primitives/string.py
@@ -4,6 +4,7 @@ class str:
     def __add__(self, other: complex) -> string: pass
     def __add__(self, other: bool) -> string: pass
     def __add__(self, other: string) -> string: pass
+    def __str__(self) -> str: pass
 
     def __iter__(self) -> str_iterator: pass
 

--- a/src/type_checker/resources/std_lib/collection.py
+++ b/src/type_checker/resources/std_lib/collection.py
@@ -5,6 +5,7 @@ class set(Generic[T]):
     def __iter__(self) -> set_iterator[T]: pass
 
     def __bool__(self) -> bool: pass
+    def __str__(self) -> str: pass
 
 class set_iterator(Generic[T]):
     def __init__(self): pass
@@ -15,6 +16,7 @@ class list(Generic[T]):
     def __iter__(self) -> list_iterator[T]: pass
 
     def __bool__(self) -> bool: pass
+    def __str__(self) -> str: pass
 
 class list_iterator(Generic[T]):
     def __init__(self): pass

--- a/src/type_checker/resources/std_lib/exception.py
+++ b/src/type_checker/resources/std_lib/exception.py
@@ -1,2 +1,3 @@
 class Exception:
     def __init__(self): pass
+    def __str__(self) -> str: pass

--- a/src/type_checker/resources/std_lib/optional.py
+++ b/src/type_checker/resources/std_lib/optional.py
@@ -2,3 +2,4 @@ class None:
     def __init__(self): pass
 
     def __bool__(self) -> bool: pass
+    def __str__(self) -> str: pass

--- a/src/type_checker/resources/std_lib/range.py
+++ b/src/type_checker/resources/std_lib/range.py
@@ -4,6 +4,7 @@ class range:
     step: int = 0
 
     def __iter__(self) -> range_iterator: pass
+    def __str__(self) -> str: pass
 
 class range_iterator:
     def __init__(self): pass

--- a/src/type_checker/resources/std_lib/typing.py
+++ b/src/type_checker/resources/std_lib/typing.py
@@ -1,2 +1,3 @@
 class Generic:
     def __init__(self): pass
+    def __str__(self) -> str: pass

--- a/tests/desugar/definition.rs
+++ b/tests/desugar/definition.rs
@@ -185,7 +185,10 @@ fn fun_def_default_arg_verify() {
         fun_args: vec![to_pos_unboxed!(Node::FunArg {
             vararg:        false,
             id_maybe_type: to_pos!(Node::Id { lit: String::from("arg1") }),
-            default:       Some(to_pos!(Node::Str { lit: String::from("asdf") }))
+            default:       Some(to_pos!(Node::Str {
+                lit:         String::from("asdf"),
+                expressions: vec![]
+            }))
         })],
         ret_ty:   None,
         raises:   vec![],
@@ -245,7 +248,7 @@ fn anon_fun_verify() {
             to_pos_unboxed!(Node::Id { lit: String::from("first") }),
             to_pos_unboxed!(Node::Id { lit: String::from("second") })
         ],
-        body: to_pos!(Node::Str { lit: String::from("this_string") })
+        body: to_pos!(Node::Str { lit: String::from("this_string"), expressions: vec![] })
     });
 
     let (args, body) = match desugar(&anon_fun) {

--- a/tests/desugar/expression_and_statements.rs
+++ b/tests/desugar/expression_and_statements.rs
@@ -25,7 +25,7 @@ fn pass_verify() {
 
 #[test]
 fn print_verify() {
-    let expr = to_pos!(Node::Str { lit: String::from("a") });
+    let expr = to_pos!(Node::Str { lit: String::from("a"), expressions: vec![] });
     let print_stmt = to_pos!(Node::Print { expr });
     assert_eq!(desugar(&print_stmt).unwrap(), Core::Print {
         expr: Box::from(Core::Str { _str: String::from("a") })
@@ -34,7 +34,7 @@ fn print_verify() {
 
 #[test]
 fn return_verify() {
-    let expr = to_pos!(Node::Str { lit: String::from("a") });
+    let expr = to_pos!(Node::Str { lit: String::from("a"), expressions: vec![] });
     let print_stmt = to_pos!(Node::Return { expr });
 
     assert_eq!(desugar(&print_stmt).unwrap(), Core::Return {

--- a/tests/lexer/lexer.rs
+++ b/tests/lexer/lexer.rs
@@ -89,3 +89,16 @@ fn comparison() {
         }
     ]);
 }
+
+#[test]
+fn fstring() {
+    let source = String::from("\"my string {my_var}\"");
+    let tokens = tokenize(&source).unwrap();
+    assert_eq!(tokens, vec![Lex {
+        pos:   Position::new(&CaretPos::new(1, 1), &CaretPos::new(1, 19)),
+        token: Token::Str(String::from("my string {my_var}"), vec![vec![Lex {
+            pos:   Position::new(&CaretPos::new(1, 12), &CaretPos::new(1, 18)),
+            token: Token::Id(String::from("my_var"))
+        }]],)
+    },]);
+}

--- a/tests/lexer/lexer.rs
+++ b/tests/lexer/lexer.rs
@@ -102,3 +102,57 @@ fn fstring() {
         }]],)
     },]);
 }
+
+#[test]
+fn fstring_set() {
+    let source = String::from("\"{{a, b}}\"");
+    let tokens = tokenize(&source).unwrap();
+    assert_eq!(tokens, vec![Lex {
+        pos:   Position::new(&CaretPos::new(1, 1), &CaretPos::new(1, 9)),
+        token: Token::Str(String::from("{{a, b}}"), vec![vec![
+            Lex {
+                pos:   Position::new(&CaretPos::new(1, 2), &CaretPos::new(1, 3)),
+                token: Token::LCBrack
+            },
+            Lex {
+                pos:   Position::new(&CaretPos::new(1, 3), &CaretPos::new(1, 4)),
+                token: Token::Id(String::from("a"))
+            },
+            Lex {
+                pos:   Position::new(&CaretPos::new(1, 4), &CaretPos::new(1, 5)),
+                token: Token::Comma
+            },
+            Lex {
+                pos:   Position::new(&CaretPos::new(1, 6), &CaretPos::new(1, 7)),
+                token: Token::Id(String::from("b"))
+            },
+            Lex {
+                pos:   Position::new(&CaretPos::new(1, 7), &CaretPos::new(1, 8)),
+                token: Token::RCBrack
+            }
+        ]])
+    },]);
+}
+
+#[test]
+fn fstring_operation() {
+    let source = String::from("\"{a + b}\"");
+    let tokens = tokenize(&source).unwrap();
+    assert_eq!(tokens, vec![Lex {
+        pos:   Position::new(&CaretPos::new(1, 1), &CaretPos::new(1, 8)),
+        token: Token::Str(String::from("{a + b}"), vec![vec![
+            Lex {
+                pos:   Position::new(&CaretPos::new(1, 2), &CaretPos::new(1, 3)),
+                token: Token::Id(String::from("a"))
+            },
+            Lex {
+                pos:   Position::new(&CaretPos::new(1, 4), &CaretPos::new(1, 5)),
+                token: Token::Add
+            },
+            Lex {
+                pos:   Position::new(&CaretPos::new(1, 6), &CaretPos::new(1, 7)),
+                token: Token::Id(String::from("b"))
+            }
+        ]])
+    },]);
+}

--- a/tests/output/valid/definition.rs
+++ b/tests/output/valid/definition.rs
@@ -1,0 +1,33 @@
+use crate::common::{exists_and_delete, python_src_to_stmts, resource_content, resource_path};
+use crate::output::common::PYTHON;
+use mamba::pipeline::transpile_directory;
+use std::path::Path;
+use std::process::Command;
+
+#[test]
+fn long_f_string() -> Result<(), Vec<(String, String)>> {
+    transpile_directory(
+        &Path::new(resource_path(true, &["definition"], "").as_str()),
+        Some("long_f_string.mamba"),
+        None
+    )?;
+
+    let cmd = Command::new(PYTHON)
+        .arg("-m")
+        .arg("py_compile")
+        .arg(resource_path(true, &["definition", "target"], "long_f_string.py"))
+        .output()
+        .unwrap();
+    if cmd.status.code().unwrap() != 0 {
+        panic!("{}", String::from_utf8(cmd.stderr).unwrap());
+    }
+
+    let python_src = resource_content(true, &["definition"], "long_f_string_check.py");
+    let out_src = resource_content(true, &["definition", "target"], "long_f_string.py");
+
+    let python_ast = python_src_to_stmts(&python_src);
+    let out_ast = python_src_to_stmts(&out_src);
+
+    assert_eq!(python_ast, out_ast);
+    Ok(assert!(exists_and_delete(true, &["definition", "target"], "long_f_string.py")))
+}

--- a/tests/output/valid/mod.rs
+++ b/tests/output/valid/mod.rs
@@ -1,5 +1,6 @@
 pub mod class;
 pub mod control_flow;
+pub mod definition;
 pub mod error;
 pub mod function;
 pub mod operation;

--- a/tests/parser/valid/operation.rs
+++ b/tests/parser/valid/operation.rs
@@ -237,7 +237,7 @@ fn or_verify() {
 
     let (left, right) = verify_is_operation!(Or, ast_tree);
     assert_eq!(left.node, Node::Id { lit: String::from("one") });
-    assert_eq!(right.node, Node::Str { lit: String::from("asdf") });
+    assert_eq!(right.node, Node::Str { lit: String::from("asdf"), expressions: vec![] });
 }
 
 #[test]
@@ -275,7 +275,7 @@ fn b_or_verify() {
 
     let (left, right) = verify_is_operation!(BOr, ast_tree);
     assert_eq!(left.node, Node::Id { lit: String::from("one") });
-    assert_eq!(right.node, Node::Str { lit: String::from("asdf") });
+    assert_eq!(right.node, Node::Str { lit: String::from("asdf"), expressions: vec![] });
 }
 
 #[test]
@@ -285,7 +285,7 @@ fn b_xor_verify() {
 
     let (left, right) = verify_is_operation!(BXOr, ast_tree);
     assert_eq!(left.node, Node::Id { lit: String::from("one") });
-    assert_eq!(right.node, Node::Str { lit: String::from("asdf") });
+    assert_eq!(right.node, Node::Str { lit: String::from("asdf"), expressions: vec![] });
 }
 
 #[test]
@@ -294,7 +294,7 @@ fn b_ones_complement_verify() {
     let ast_tree = parse_direct(&tokenize(&source).unwrap()).unwrap();
 
     let expr = verify_is_un_operation!(BOneCmpl, ast_tree);
-    assert_eq!(expr.node, Node::Str { lit: String::from("asdf") });
+    assert_eq!(expr.node, Node::Str { lit: String::from("asdf"), expressions: vec![] });
 }
 
 #[test]
@@ -304,7 +304,7 @@ fn b_lshift_verify() {
 
     let (left, right) = verify_is_operation!(BLShift, ast_tree);
     assert_eq!(left.node, Node::Id { lit: String::from("one") });
-    assert_eq!(right.node, Node::Str { lit: String::from("asdf") });
+    assert_eq!(right.node, Node::Str { lit: String::from("asdf"), expressions: vec![] });
 }
 
 #[test]
@@ -314,5 +314,5 @@ fn brshift_verify() {
 
     let (left, right) = verify_is_operation!(BRShift, ast_tree);
     assert_eq!(left.node, Node::Id { lit: String::from("one") });
-    assert_eq!(right.node, Node::Str { lit: String::from("asdf") });
+    assert_eq!(right.node, Node::Str { lit: String::from("asdf"), expressions: vec![] });
 }

--- a/tests/resources/invalid/type/operation/undefined_field_fstring.mamba
+++ b/tests/resources/invalid/type/operation/undefined_field_fstring.mamba
@@ -1,0 +1,1 @@
+"your name is {your_name}"

--- a/tests/resources/valid/class/generics_check.py
+++ b/tests/resources/valid/class/generics_check.py
@@ -21,14 +21,14 @@ class MyType:
 
 
 class MyClass2(MyType):
-    _z_modified: str = f"asdf"
+    _z_modified: str = "asdf"
     _other_field: int = 10
 
     def __init__(self, other_field: int, z: int):
-        super().__init__(f"the quick brown fox jumped over the slow donkey")
+        super().__init__("the quick brown fox jumped over the slow donkey")
         if z > 10:
-            raise Err1(f"Something is wrong!")
-        self.z_modified = f"fdsa"
+            raise Err1("Something is wrong!")
+        self.z_modified = "fdsa"
 
         (a, b) = (10, 20)
         (a, b) = (30, 40)
@@ -62,7 +62,7 @@ class MyClass2(MyType):
 
     def fun_a(self): print(self)
 
-    def _fun_b(self): print(f"this function is private!")
+    def _fun_b(self): print("this function is private!")
 
     def factorial(self, x: int = 0) -> int: return x * self.factorial(x - 1)
 

--- a/tests/resources/valid/class/parent_check.py
+++ b/tests/resources/valid/class/parent_check.py
@@ -7,4 +7,4 @@ class MyClass1(MyType):
     other: int = None
 
     def __init__(self):
-        super(MyType, self).__init__(f"asdf")
+        super(MyType, self).__init__("asdf")

--- a/tests/resources/valid/class/types_check.py
+++ b/tests/resources/valid/class/types_check.py
@@ -32,7 +32,7 @@ class MyClass(MyType, MyInterface):
     private_field: int = 20
     my_field: int = None
 
-    def __init__(self, my_field: int, other_field: str = f"Hello"):
+    def __init__(self, my_field: int, other_field: str = "Hello"):
         super(MyType, self).__init__(other_field)
         super(MyInterface, self).__init__()
         self.my_field = my_field

--- a/tests/resources/valid/control_flow/for_statements_check.py
+++ b/tests/resources/valid/control_flow/for_statements_check.py
@@ -22,11 +22,11 @@ for i in range(0, 345 + 1, 1):
 a = 1
 b = 112
 for i in range(a, b, 1):
-    print(f"hello")
+    print("hello")
 
 c = 2451
 for i in range(a, c + 1, 20):
-    print(f"world")
+    print("world")
 
 for i in ([1,2], {3,4}):
     print(i)

--- a/tests/resources/valid/control_flow/if_check.py
+++ b/tests/resources/valid/control_flow/if_check.py
@@ -1,40 +1,40 @@
 b = 40
 
 if True:
-    print(f"hello world")
+    print("hello world")
 
 if False:
-    f"hello"
+    "hello"
 else:
-    f"world"
+    "world"
 
 cond = True and False
 cond = True or False
 
 if cond:
-    f"asdf"
-    print(f'hello \"world\"')
+    "asdf"
+    print('hello \"world\"')
 
     if cond or True:
-        f"bbb"
+        "bbb"
     else:
-        f"ccc"
+        "ccc"
 
-    iii = f"iii"
+    iii = "iii"
     if cond or False:
-        f"hhh"
+        "hhh"
     else:
         iii
 else:
-    f"other"
-    print(f'hello \"world\"')
+    "other"
+    print('hello \"world\"')
 
     if cond or True:
-        f"bbb"
+        "bbb"
     else:
-        f"ccc"
+        "ccc"
 
-if f"as" == f"as":
-    print(f"hi")
+if "as" == "as":
+    print("hi")
 else:
-    print(f"asdf")
+    print("asdf")

--- a/tests/resources/valid/control_flow/match_check.py
+++ b/tests/resources/valid/control_flow/match_check.py
@@ -1,10 +1,10 @@
 from collections import defaultdict
 
-a = f"d"
+a = "d"
 
 print({
-    f"b": f"c",
-    f"d": f"e",
+    "b": "c",
+    "d": "e",
 }[a])
 
 # TODO handle tuples
@@ -13,12 +13,12 @@ print({
 # match (b, bb, bbb)
 #    (0, 1, 2) => print "hello world"
 
-nested = f"other"
+nested = "other"
 
 {
-    f"a": f"b",
-    f"c": defaultdict(lambda: f"default", {
-        f"other": f"even_other",
-        f"other_one": f"better_one",
+    "a": "b",
+    "c": defaultdict(lambda: "default", {
+        "other": "even_other",
+        "other_one": "better_one",
     })[nested],
 }[nested]

--- a/tests/resources/valid/control_flow/while_check.py
+++ b/tests/resources/valid/control_flow/while_check.py
@@ -8,4 +8,4 @@ while d:
 
     print(d and True)
 
-print(f"hello")
+print("hello")

--- a/tests/resources/valid/definition/f_strings.mamba
+++ b/tests/resources/valid/definition/f_strings.mamba
@@ -1,0 +1,8 @@
+print "primitive {10}"
+print "primitive {10.2}"
+print "primitive {True}"
+print "primitive {"a string"}"
+
+print "set {{2, 3, 4}}"
+print "list {[2, 3, 4]}"
+print "Optional {undefined}"

--- a/tests/resources/valid/definition/long_f_string.mamba
+++ b/tests/resources/valid/definition/long_f_string.mamba
@@ -1,5 +1,6 @@
 def name <- "My name"
 def some_brackets <- "\{\}"
+def some_more_brackets <- "empty expressions are ignored: {}"
 def age <- 30
 
 def a <- "My name is {name} and my age is {age - 10}."

--- a/tests/resources/valid/definition/long_f_string.mamba
+++ b/tests/resources/valid/definition/long_f_string.mamba
@@ -1,0 +1,6 @@
+def name <- "My name"
+def some_brackets <- "\{\}"
+def age <- 30
+
+def a <- "My name is {name} and my age is {age - 10}."
+print a

--- a/tests/resources/valid/definition/long_f_string_check.py
+++ b/tests/resources/valid/definition/long_f_string_check.py
@@ -1,5 +1,6 @@
 name = "My name"
 some_brackets = "\{\}"
+some_more_brackets = "empty expressions are ignored: {}"
 age = 30
 
 a = f"My name is {name} and my age is {age - 10}."

--- a/tests/resources/valid/definition/long_f_string_check.py
+++ b/tests/resources/valid/definition/long_f_string_check.py
@@ -1,0 +1,6 @@
+name = "My name"
+some_brackets = "\{\}"
+age = 30
+
+a = f"My name is {name} and my age is {age - 10}."
+print(a)

--- a/tests/resources/valid/error/handle_check.py
+++ b/tests/resources/valid/error/handle_check.py
@@ -22,8 +22,8 @@ a = None
 try:
     a = f(10)
 except MyErr1 as err:
-    print(f"Something went wrong")
+    print("Something went wrong")
     a = -1
 except MyErr2 as err:
-    print(f"Something else went wrong")
+    print("Something else went wrong")
     a = -2

--- a/tests/resources/valid/error/raise_check.py
+++ b/tests/resources/valid/error/raise_check.py
@@ -7,11 +7,11 @@ def f(x: int) -> int:
     if x > 0:
         return 10
     else:
-        raise Err(f"Expected positive number.")
+        raise Err("Expected positive number.")
 
 
 def g() -> int:
-    raise Err(f"Error always raised")
+    raise Err("Error always raised")
 
 
 def h(x: int) -> int:

--- a/tests/resources/valid/function/calls_check.py
+++ b/tests/resources/valid/function/calls_check.py
@@ -1,4 +1,4 @@
-def fun_a(): print(f"hello world")
+def fun_a(): print("hello world")
 def fun_b(x: int): print(f"hello {x}")
 
 fun_a()

--- a/tests/resources/valid/function/definition_check.py
+++ b/tests/resources/valid/function/definition_check.py
@@ -5,9 +5,9 @@ from typing import Callable
 def fun_a() -> Optional[int]:
     print(11)
     if True and True:
-        print(f"hello")
+        print("hello")
     if False or True:
-        print(f"world")
+        print("world")
     a = None or 11
     if True:
         return 10
@@ -18,7 +18,7 @@ def fun_b(b: int): print(b)
 
 def fun_c(d: Tuple[str, int]): print(d)
 
-def fun_d(h: Callable[[str, str], int])-> Optional[int]: return h(f"hello", f"world")
+def fun_d(h: Callable[[str, str], int])-> Optional[int]: return h("hello", "world")
 
 def fun_e(m: int, o: Tuple[str, str], r: Callable[[int, Tuple[str, str]], int]) -> int: return r(m, o)
 

--- a/tests/resources/valid/operation/arithmetic_check.py
+++ b/tests/resources/valid/operation/arithmetic_check.py
@@ -1,4 +1,3 @@
-
 import math
 
 a = 10

--- a/tests/type_checker/context/invalid/operation.rs
+++ b/tests/type_checker/context/invalid/operation.rs
@@ -8,3 +8,9 @@ fn string_minus() {
     let source = resource_content(false, &["type", "operation"], "string_minus.mamba");
     check_all(&[(*parse(&tokenize(&source).unwrap()).unwrap(), None, None)]).unwrap_err();
 }
+
+#[test]
+fn undefined_field_fstring() {
+    let source = resource_content(false, &["type", "operation"], "undefined_field_fstring.mamba");
+    check_all(&[(*parse(&tokenize(&source).unwrap()).unwrap(), None, None)]).unwrap_err();
+}

--- a/tests/type_checker/context/valid/definition.rs
+++ b/tests/type_checker/context/valid/definition.rs
@@ -8,3 +8,9 @@ fn nested_mut_field() {
     let source = resource_content(true, &["definition"], "nested_mut_field.mamba");
     check_all(&[(*parse(&tokenize(&source).unwrap()).unwrap(), None, None)]).unwrap();
 }
+
+#[test]
+fn f_strings() {
+    let source = resource_content(true, &["definition"], "f_strings.mamba");
+    check_all(&[(*parse(&tokenize(&source).unwrap()).unwrap(), None, None)]).unwrap();
+}


### PR DESCRIPTION
### Relevant issues
Fixes #178 

### Summary
Add f-strings, which can have expressions contained within `{` and `}`.
I.e.:
```mamba
def my_name <- "Joël"
print "My name is {my_name}."
```
The expressions contained within the curly brackets are type-checked just as any other expression.
In addition to this, we verify that they are indeed expressions (and not statements) and that the resulting value has the `__str__` method.
This means that we are slightly more strict than Python, which would in the case of getting the string value of a value that does not have the `__str__` instead print its memory address:
```python
class A:
     my_field = 20


a = A()
/* prints <__main__.A object at 0x012OHD70> */
print(a)
```

In addition to this, strings which do not contain any expressions are treated and desugared as regular strings.
So:
`"my_string {my_value}"` becomes `f"my_string {my_value}"`
`"Hello World"` becomes/stays `"Hello World"`

### Added Tests
- **Happy** Expressions within f-Strings have the correct position(/offset) (which is useful for error printing
- **Happy** All primitives and collections can be contained within expressions within f-Strings
- **Happy** f-Strings containing expressions which have a type that implements `__str__` work as expected
- **Happy** `{` and `}` preceded by `\` are treated as regular characters
- **Happy** Empty expressions within strings encased in `{` and `}` are ignored
- **Sad** f-Strings containing expressions that contain an expression that doesn't implements `__str__` fails