### PR TITLE
Remove webpage config

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,4 +1,0 @@
-theme: jekyll-theme-minimal
-
-title: Mamba
-description: This is the page of the Mamba repo itself


### PR DESCRIPTION
### Summary
This was a leftover from when we tried out GitHub pages.
However, all documentation will be hoste on a seperate wepag inside the [Document repo](https://github.com/JSAbrahams/mamba_doc)

