### PR TITLE
Fix code errors in README and elaborate usage section

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,15 +45,30 @@ For all the below, every merge is preceded by a Pull Request.
 -   Once approved, the new feature branch is merged with master.
 -   The new merged release is tagged, and a new release is published on GitHub and published to [Cargo](https://crates.io/crates/mamba).
 
-## 🔄 Continuous Integration Tools
+## 🔨 Tooling
 
-We use continuous integration tools to help ensure that no regression takes place.
-Therefore, when adding new functionality or fixing a bug, tests are greatly appreciated.
+Several tools are used to help maintain the quality of the codebase.
+These tools are used by the continuous integration tools to statically check submitted code.
+Therefore, to save time, it is a good idea to install these tools locally and run them before pushing your changes.
 
-Please read the tooling section in the [README](/README.md) to get more information on how to set up tooling locally, which are used by the CI tools.
-A pull request will only be merged if the builds pass.
+### Rustfmt
 
-The CI Tools use:
--   `cargo test` to check that all tests pass.
--   `cargo +nightly fmt --all -- --check` to check that there are no formatting errors.
--   `cargo clippy -- -D warnings` to use a collection of lints to check for common Rust mistakes.
+[Rustfmt](https://github.com/rust-lang/rustfmt) formats Rust code and ensures the formatting is consistent across the codebase.
+
+-   **To install** `rustup component add rustfmt --toolchain nightly`
+-   **To run** `cargo +nightly fmt`
+
+The configuration of `Rustfmt` can be found in `.rustfmt.toml`.
+
+*Note* The nightly build of `cargo` must be used (`rustup install nightly`).
+
+### Clippy
+
+[Clippy](https://github.com/rust-lang/rust-clippy) catches common mistakes made in Rust.
+
+-   **To install** `rustup component add clippy`
+-   **To run** `cargo clippy`
+
+The configuration of `Clippy` can be found in `.clippy.toml`.
+
+*Note* The stable build of `cargo` must be used (`rustup install stable`).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ We standardise the process of creating issues and pull requests to make it easie
 Please adhere to these standards.
 
 *Note* In general, it is better to only comment on open pull requests and issues.
-Comments on closed issues and pull requests are more likely to be read over.
+Comments on closed issues and pull requests are likely to be ignored.
 
 ### ❗ Submitting an Issue
 
@@ -33,6 +33,17 @@ Comments on closed issues and pull requests are more likely to be read over.
 -   Do make sure the build passes, ideally by running `rustfmt` and `clippy` locally before pushing.
 -   Do add tests when fixing a bug or adding new functionality.
 -   Do make sure that this PR is targets one single issue, as large pull requests are difficult to review and unlikely to get merged
+-   Do make sure that the base branch is the correct branch by observing the Git branching model.
+
+### Git Branching Model
+
+For all the below, every merge is preceded by a Pull Request.
+
+-   New featuers branch off and are merged with the development branch.
+-   Large features get their own branch, and sub-features branch from this branch and are merged with this branch, before the feature branch is merged with develop.
+-   Once develop has amassed enough features for a new release, we new branch is created where a release is staged (e.g. `v0.3.1`).
+-   Once approved, the new feature branch is merged with master.
+-   The new merged release is tagged, and a new release is published on GitHub and published to [Cargo](https://crates.io/crates/mamba).
 
 ## 🔄 Continuous Integration Tools
 

--- a/README.md
+++ b/README.md
@@ -23,15 +23,16 @@ The Documentation can be found [here](https://joelabrahams.nl/mamba_doc).
 This documentation outlines the different language features, and also contains a formal specification of the language.
 
 In short, Mamba is like Python, but with a few key features:
--   Strict typing rules, but with type inference so it doesn't get in the way too much, and type refinement features.
--   Null safety features.
--   More explicit error handling.
--   Clear distinction between mutability and immutability.
--   Pure functions, or, functions without side effects.
+-   Strict static typing rules, but with type inference so it doesn't get in the way too much
+-   Type refinement features
+-   Null safety
+-   Explicit error handling
+-   A distinction between mutability and immutability
+-   Pure functions, or, functions without side effects
 
-This is a transpiler, written in [Rust](https://www.rust-lang.org/), which converts Mamba source code to Python source files.
-Mamba code should therefore, in theory, be interoperable with Python code.
-Functions written in Python can be called in Mamba and vice versa.
+This is a transpiler, written in [Rust](https://www.rust-lang.org/), which converts Mamba source files to Python source files.
+Mamba code should therefore be interoperable with Python code.
+Functions written in Python can be called in Mamba and vice versa (from the generated Python files).
 
 ## ⌨️ Code Examples
 


### PR DESCRIPTION
### Summary
The syntax in some of the code examples was not consistent with the current state of the language.
As such the code examples now use the current syntax of the language.

We also update some wordy examples to make them more easily readable,
We also add examples for how to use the transpiler programmatically in addition to the command-line example.

Note: This README still uses postfix notation as we do intend to re-add it soon.
