### PR TITLE
Allow ignoring default arguments in functions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -89,6 +89,11 @@ version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "either"
+version = "1.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "escargot"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -106,6 +111,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "glob"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "itertools"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "either 1.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "itoa"
@@ -137,6 +150,7 @@ dependencies = [
  "assert_cmd 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "glob 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "itertools 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "leg 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "pathdiff 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "python-parser 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -463,9 +477,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5067f5bb2d80ef5d68b4c87db81601f0b75bca627bc2ef76b141d7b846a3c6d9"
 "checksum colored 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6cdb90b60f2927f8d76139c72dbde7e10c3a2bc47c8594c9c7a66529f2687c03"
 "checksum difference 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "524cbf6897b527295dff137cec09ecf3a05f4fddffd7dfcd1585403449e74198"
+"checksum either 1.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "bb1f6b1ce1c140482ea30ddd3335fc0024ac7ee112895426e0a629a6c20adfe3"
 "checksum escargot 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "19db1f7e74438642a5018cdf263bb1325b2e792f02dd0a3ca6d6c0f0d7b1d5a5"
 "checksum fuchsia-cprng 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 "checksum glob 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
+"checksum itertools 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f56a2d0bc861f9165be4eb3442afd3c236d8a98afd426f65d92324ae1091a484"
 "checksum itoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "501266b7edd0174f8530248f87f99c88fbe60ca4ef3dd486835b8d8d53136f7f"
 "checksum lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bc5729f27f159ddd61f4df6228e827e86643d4d3e7c32183cb30a1c08f604a14"
 "checksum leg 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "97f89b9784106c507bf5f370fb929b72d953ef70b78a79c7053fb6ca6c421748"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,3 +23,4 @@ clap = {version = "2.33", features = ["yaml"]}
 leg = "0.1.3"
 pathdiff = "0.1.0"
 glob = "0.3.0"
+itertools = "0.8.2"

--- a/src/type_checker/context/function_arg/concrete.rs
+++ b/src/type_checker/context/function_arg/concrete.rs
@@ -16,20 +16,22 @@ pub const SELF: &str = "self";
 
 #[derive(Debug, Clone, Eq, PartialEq, Hash)]
 pub struct FunctionArg {
-    pub is_py_type: bool,
-    pub name:       String,
-    pub vararg:     bool,
-    pub mutable:    bool,
-    pub ty:         Option<TypeName>
+    pub is_py_type:  bool,
+    pub name:        String,
+    pub has_default: bool,
+    pub vararg:      bool,
+    pub mutable:     bool,
+    pub ty:          Option<TypeName>
 }
 
 impl Display for FunctionArg {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         write!(
             f,
-            "{}{}",
+            "{}{}{}",
             self.name,
-            if let Some(ty) = &self.ty { format!(": {}", ty) } else { String::new() }
+            if let Some(ty) = &self.ty { format!(": {}", ty) } else { String::new() },
+            if self.has_default { "?" } else { "" }
         )
     }
 }
@@ -61,11 +63,12 @@ impl TryFrom<(&GenericFunctionArg, &HashMap<String, TypeName>, &Position)> for F
         (fun_arg, generics, pos): (&GenericFunctionArg, &HashMap<String, TypeName>, &Position)
     ) -> Result<Self, Self::Error> {
         Ok(FunctionArg {
-            is_py_type: fun_arg.is_py_type,
-            name:       fun_arg.name.clone(),
-            vararg:     fun_arg.vararg,
-            mutable:    fun_arg.mutable,
-            ty:         match &fun_arg.ty {
+            is_py_type:  fun_arg.is_py_type,
+            name:        fun_arg.name.clone(),
+            has_default: fun_arg.has_default,
+            vararg:      fun_arg.vararg,
+            mutable:     fun_arg.mutable,
+            ty:          match &fun_arg.ty {
                 Some(ty) => Some(ty.substitute(generics, pos)?),
                 None => None
             }

--- a/src/type_checker/context/function_arg/generic.rs
+++ b/src/type_checker/context/function_arg/generic.rs
@@ -18,12 +18,13 @@ pub struct ClassArgument {
 
 #[derive(Debug, Clone, Eq)]
 pub struct GenericFunctionArg {
-    pub is_py_type: bool,
-    pub name:       String,
-    pub pos:        Position,
-    pub vararg:     bool,
-    pub mutable:    bool,
-    pub ty:         Option<TypeName>
+    pub is_py_type:  bool,
+    pub name:        String,
+    pub pos:         Position,
+    pub has_default: bool,
+    pub vararg:      bool,
+    pub mutable:     bool,
+    pub ty:          Option<TypeName>
 }
 
 impl PartialEq for GenericFunctionArg {
@@ -91,12 +92,13 @@ impl TryFrom<&AST> for GenericFunctionArg {
                 Node::IdType { id, mutable, _type } => {
                     let name = argument_name(id.deref())?;
                     Ok(GenericFunctionArg {
-                        is_py_type: false,
-                        name:       name.clone(),
-                        vararg:     *vararg,
-                        mutable:    *mutable,
-                        pos:        node_pos.pos.clone(),
-                        ty:         match _type {
+                        is_py_type:  false,
+                        name:        name.clone(),
+                        has_default: default.is_some(),
+                        vararg:      *vararg,
+                        mutable:     *mutable,
+                        pos:         node_pos.pos.clone(),
+                        ty:          match _type {
                             Some(_type) => Some(TypeName::try_from(_type.deref())?),
                             None if name.as_str() == SELF => None,
                             None =>

--- a/src/type_checker/context/function_arg/python.rs
+++ b/src/type_checker/context/function_arg/python.rs
@@ -7,15 +7,16 @@ pub const SELF: &str = "self";
 
 impl From<(&String, &Option<Expression>, &Option<Expression>)> for GenericFunctionArg {
     fn from(
-        (name, ty, _): (&String, &Option<Expression>, &Option<Expression>)
+        (name, ty, default): (&String, &Option<Expression>, &Option<Expression>)
     ) -> GenericFunctionArg {
         GenericFunctionArg {
-            is_py_type: true,
-            name:       name.clone(),
-            pos:        Default::default(),
-            vararg:     false,
-            mutable:    false,
-            ty:         ty.clone().map(|e| TypeName::from(&e))
+            is_py_type:  true,
+            name:        name.clone(),
+            has_default: default.is_some(),
+            pos:         Default::default(),
+            vararg:      false,
+            mutable:     false,
+            ty:          ty.clone().map(|e| TypeName::from(&e))
         }
     }
 }

--- a/src/type_checker/context/ty/generic.rs
+++ b/src/type_checker/context/ty/generic.rs
@@ -85,12 +85,13 @@ impl TryFrom<&AST> for GenericType {
                     class_args
                 } else {
                     let mut new_args = vec![GenericFunctionArg {
-                        is_py_type: false,
-                        name:       String::from(function_arg::generic::SELF),
-                        pos:        Default::default(),
-                        vararg:     false,
-                        mutable:    false,
-                        ty:         Some(TypeName::from(&name))
+                        is_py_type:  false,
+                        name:        String::from(function_arg::generic::SELF),
+                        has_default: false,
+                        pos:         Default::default(),
+                        vararg:      false,
+                        mutable:     false,
+                        ty:          Some(TypeName::from(&name))
                     }];
                     new_args.append(&mut class_args);
                     new_args
@@ -112,12 +113,13 @@ impl TryFrom<&AST> for GenericType {
 
                 if class_args.is_empty() {
                     class_args.push(GenericFunctionArg {
-                        is_py_type: false,
-                        name:       String::from(function_arg::concrete::SELF),
-                        pos:        Default::default(),
-                        vararg:     false,
-                        mutable:    false,
-                        ty:         Option::from(TypeName::from(&name))
+                        is_py_type:  false,
+                        name:        String::from(function_arg::concrete::SELF),
+                        pos:         Default::default(),
+                        has_default: false,
+                        vararg:      false,
+                        mutable:     false,
+                        ty:          Option::from(TypeName::from(&name))
                     })
                 }
 

--- a/src/type_checker/resources/std_lib/collection.py
+++ b/src/type_checker/resources/std_lib/collection.py
@@ -1,4 +1,4 @@
-from typing import TypeVar, Generic
+from typing import TypeVar, Generic, Union
 
 class set(Generic[T]):
     def __init__(self): pass

--- a/src/type_checker/resources/std_lib/exception.py
+++ b/src/type_checker/resources/std_lib/exception.py
@@ -1,3 +1,4 @@
 class Exception:
-    def __init__(self): pass
+    def __init__(self, msg: str=''): pass
+
     def __str__(self) -> str: pass

--- a/tests/output/valid/error.rs
+++ b/tests/output/valid/error.rs
@@ -38,6 +38,34 @@ fn handle_ast_verify() -> Result<(), Vec<(String, String)>> {
 }
 
 #[test]
+fn exception_ast_verify() -> Result<(), Vec<(String, String)>> {
+    transpile_directory(
+        &Path::new(&resource_path(true, &["error"], "")),
+        Some("exception.mamba"),
+        None
+    )?;
+
+    let cmd = Command::new(PYTHON)
+        .arg("-m")
+        .arg("py_compile")
+        .arg(resource_path(true, &["error", "target"], "exception.py"))
+        .output()
+        .unwrap();
+    if cmd.status.code().unwrap() != 0 {
+        panic!("{}", String::from_utf8(cmd.stderr).unwrap());
+    }
+
+    let python_src = resource_content(true, &["error"], "exception_check.py");
+    let out_src = resource_content(true, &["error", "target"], "exception.py");
+
+    let python_ast = python_src_to_stmts(&python_src);
+    let out_ast = python_src_to_stmts(&out_src);
+
+    assert_eq!(out_ast, python_ast);
+    Ok(assert!(exists_and_delete(true, &["error", "target"], "exception.py")))
+}
+
+#[test]
 #[ignore]
 fn raise_ast_verify() -> Result<(), Vec<(String, String)>> {
     transpile_directory(

--- a/tests/output/valid/function.rs
+++ b/tests/output/valid/function.rs
@@ -66,3 +66,31 @@ fn definition_ast_verify() -> Result<(), Vec<(String, String)>> {
     assert_eq!(python_ast, out_ast);
     Ok(assert!(exists_and_delete(true, &["function", "target"], "definition.py")))
 }
+
+#[test]
+fn function_with_defaults_ast_verify() -> Result<(), Vec<(String, String)>> {
+    transpile_directory(
+        &Path::new(&resource_path(true, &["function"], "")),
+        Some("function_with_defaults.mamba"),
+        None
+    )?;
+
+    let cmd = Command::new(PYTHON)
+        .arg("-m")
+        .arg("py_compile")
+        .arg(resource_path(true, &["function", "target"], "function_with_defaults.py"))
+        .output()
+        .unwrap();
+    if cmd.status.code().unwrap() != 0 {
+        panic!("{}", String::from_utf8(cmd.stderr).unwrap());
+    }
+
+    let python_src = resource_content(true, &["function"], "function_with_defaults_check.py");
+    let out_src = resource_content(true, &["function", "target"], "function_with_defaults.py");
+
+    let python_ast = python_src_to_stmts(&python_src);
+    let out_ast = python_src_to_stmts(&out_src);
+
+    assert_eq!(python_ast, out_ast);
+    Ok(assert!(exists_and_delete(true, &["function", "target"], "function_with_defaults.py")))
+}

--- a/tests/resources/invalid/type/definition/argument_after_argument_with_default.mamba
+++ b/tests/resources/invalid/type/definition/argument_after_argument_with_default.mamba
@@ -1,0 +1,1 @@
+def my_fun(a: Int <- 10, b: Int) -> Int => a + b

--- a/tests/resources/valid/error/exception.mamba
+++ b/tests/resources/valid/error/exception.mamba
@@ -1,0 +1,2 @@
+def a <- Exception()
+def b <- Exception("b")

--- a/tests/resources/valid/error/exception_check.py
+++ b/tests/resources/valid/error/exception_check.py
@@ -1,0 +1,2 @@
+a = Exception()
+b = Exception("b")

--- a/tests/resources/valid/error/handle.mamba
+++ b/tests/resources/valid/error/handle.mamba
@@ -1,12 +1,12 @@
-class MyErr1 isa Exception
-class MyErr2 isa Exception
+class MyErr1 isa Exception("Something went wrong")
+class MyErr2(msg: String) isa Exception(msg)
 
 def f(x: Int) -> Int raises [MyErr1, MyErr2] =>
     if x < 0 then
         raise MyErr1()
     else
         if x > 10 then
-            raise MyErr2()
+            raise MyErr2("Greater than 10.")
         else
             return x + 2
 

--- a/tests/resources/valid/error/handle_check.py
+++ b/tests/resources/valid/error/handle_check.py
@@ -1,11 +1,11 @@
 class MyErr1(Exception):
     def __init__(self):
-        super(Exception, self).__init__()
+        super(Exception, self).__init__("Something went wrong")
 
 
 class MyErr2(Exception):
-    def __init__(self):
-        super(Exception, self).__init__()
+    def __init__(self, msg: str):
+        super(Exception, self).__init__(msg)
 
 
 def f(x: int) -> int:
@@ -13,7 +13,7 @@ def f(x: int) -> int:
         raise MyErr1()
     else:
         if x > 10:
-            raise MyErr2()
+            raise MyErr2("Greater than 10.")
         else:
             return x + 2
 

--- a/tests/resources/valid/function/function_with_defaults.mamba
+++ b/tests/resources/valid/function/function_with_defaults.mamba
@@ -1,0 +1,5 @@
+def my_fun(a: Int, b: Int <- 10, c: String <- "Hello") -> String => c + b + a
+
+my_fun(1, 2, "hello world")
+my_fun(1, 2)
+my_fun(1)

--- a/tests/resources/valid/function/function_with_defaults_check.py
+++ b/tests/resources/valid/function/function_with_defaults_check.py
@@ -1,0 +1,5 @@
+def my_fun(a: int, b: int = 10, c: str = "Hello") -> str: c + b + a
+
+my_fun(1, 2, "hello world")
+my_fun(1, 2)
+my_fun(1)

--- a/tests/type_checker/context/invalid/definition.rs
+++ b/tests/type_checker/context/invalid/definition.rs
@@ -4,6 +4,16 @@ use mamba::parser::parse;
 use mamba::type_checker::check_all;
 
 #[test]
+fn argument_after_argument_with_default() {
+    let source = resource_content(
+        false,
+        &["type", "definition"],
+        "argument_after_argument_with_default.mamba"
+    );
+    check_all(&[(*parse(&tokenize(&source).unwrap()).unwrap(), None, None)]).unwrap_err();
+}
+
+#[test]
 fn assign_wrong_type() {
     let source = resource_content(false, &["type", "definition"], "assign_wrong_type.mamba");
     check_all(&[(*parse(&tokenize(&source).unwrap()).unwrap(), None, None)]).unwrap_err();


### PR DESCRIPTION
### Relevant issues
Fixes #186 
Fixes #169 

### Summary
Functions arguments with default are now treated as optional, so we can opt not to pass an argument.
We also check that a function does not have arguments with defaults followed by arguments with no defaults.

### Added Tests
- *Happy* Not passing an argument to the constructor with default is allowed (in the case of `Exception`)
- *Sad* Argument with default followed by non-default argument gives an error
