### PR TITLE
Remove retry from language

### DIFF
--- a/src/desugar/node.rs
+++ b/src/desugar/node.rs
@@ -294,7 +294,6 @@ pub fn desugar_node(ast: &AST, imp: &mut Imports, state: &State) -> DesugarResul
         Node::Step { .. } => panic!("Step cannot be top level."),
         Node::Raises { expr_or_stmt, .. } => desugar_node(expr_or_stmt, imp, state)?,
         Node::Raise { error } => Core::Raise { error: Box::from(desugar_node(error, imp, state)?) },
-        Node::Retry { .. } => return Err(UnimplementedErr::new(ast, "retry")),
 
         Node::Handle { expr_or_stmt, cases } => {
             let assign_to = if let Node::VariableDef { id_maybe_type, .. } = &expr_or_stmt.node {

--- a/src/lexer/token.rs
+++ b/src/lexer/token.rs
@@ -97,7 +97,6 @@ pub enum Token {
 
     Raises,
     Raise,
-    Retry,
     When,
 
     While,
@@ -256,7 +255,6 @@ impl fmt::Display for Token {
             Token::Handle => String::from("handle"),
             Token::Raises => String::from("raises"),
             Token::Raise => String::from("raise"),
-            Token::Retry => String::from("retry"),
             Token::When => String::from("when"),
 
             Token::Pass => String::from("pass"),

--- a/src/lexer/tokenize.rs
+++ b/src/lexer/tokenize.rs
@@ -247,7 +247,6 @@ fn as_op_or_id(string: String) -> Token {
         "raises" => Token::Raises,
         "raise" => Token::Raise,
         "handle" => Token::Handle,
-        "retry" => Token::Retry,
         "when" => Token::When,
 
         "True" => Token::Bool(true),

--- a/src/parser/ast.rs
+++ b/src/parser/ast.rs
@@ -84,7 +84,6 @@ pub enum Node {
         expr_or_stmt: Box<AST>,
         cases:        Vec<AST>
     },
-    Retry,
     With {
         resource: Box<AST>,
         _as:      Option<Box<AST>>,

--- a/src/parser/statement.rs
+++ b/src/parser/statement.rs
@@ -23,10 +23,6 @@ pub fn parse_statement(it: &mut LexIterator) -> ParseResult {
                 let end = it.eat(&Token::Pass, "statement")?;
                 Ok(Box::from(AST::new(&end, Node::Pass)))
             }
-            Token::Retry => {
-                let end = it.eat(&Token::Retry, "statement")?;
-                Ok(Box::from(AST::new(&end, Node::Retry)))
-            }
             Token::Raise => {
                 it.eat(&Token::Raise, "statement")?;
                 let error = it.parse(&parse_expression, "statement", &lex.pos)?;
@@ -82,7 +78,6 @@ pub fn is_start_statement(tp: &Token) -> bool {
         | Token::Print
         | Token::For
         | Token::While
-        | Token::Retry
         | Token::Pass
         | Token::Raise
         | Token::With => true,

--- a/src/type_checker/infer/error.rs
+++ b/src/type_checker/infer/error.rs
@@ -43,13 +43,6 @@ pub fn infer_error(ast: &AST, env: &Environment, ctx: &Context) -> InferResult {
             }
         }
 
-        Node::Retry =>
-            if !env.state.in_handle {
-                Err(vec![TypeErr::new(&ast.pos, "Retry only possible in handle arm")])
-            } else {
-                Ok((InferType::default(), env.clone()))
-            },
-
         Node::With { resource, _as, expr } => {
             let (resource_ty, mut inner_env) = infer(resource, env, ctx)?;
 

--- a/src/type_checker/infer/mod.rs
+++ b/src/type_checker/infer/mod.rs
@@ -89,7 +89,6 @@ fn infer(ast: &AST, env: &Environment, ctx: &Context) -> InferResult {
 
         Node::Raises { .. } | Node::Raise { .. } => infer_error(ast, env, ctx),
         Node::Handle { .. } => infer_control_flow(ast, env, ctx),
-        Node::Retry => infer_error(ast, env, ctx),
 
         Node::With { .. } => infer_error(ast, env, ctx),
         Node::AnonFun { .. } => infer_op(ast, env, ctx),

--- a/src/type_checker/modify/mod.rs
+++ b/src/type_checker/modify/mod.rs
@@ -11,7 +11,7 @@ pub fn modify(ast: &AST, ctx: &Context) -> TypeResult<AST> {
 
     let mut ast = ast.clone();
     for modification in modifications {
-        ast = modification.modify(&ast, ctx)?;
+        ast = modification.modify(&ast, ctx)?.0;
     }
 
     Ok(ast)

--- a/src/type_checker/modify/modifications/mod.rs
+++ b/src/type_checker/modify/modifications/mod.rs
@@ -5,539 +5,412 @@ use crate::type_checker::type_result::TypeResult;
 pub mod constructor;
 
 pub trait Modification {
-    fn modify(&self, ast: &AST, ctx: &Context) -> TypeResult<AST>;
+    fn modify(&self, ast: &AST, ctx: &Context) -> TypeResult<(AST, bool)>;
 
-    fn recursion(&self, ast: &AST, ctx: &Context) -> TypeResult<AST> {
+    fn recursion(&self, ast: &AST, ctx: &Context) -> TypeResult<(AST, bool)> {
+        macro_rules! modify {
+            ($ast:expr) => {{
+                let (expr, m_expr) = self.modify($ast, ctx)?;
+                (Box::from(expr), m_expr)
+            }};
+        }
+
+        macro_rules! inner {
+            ($node:ident, $left:expr, $right:expr) => {{
+                let (left, m_left) = modify!($left);
+                let (right, m_right) = modify!($right);
+                Ok((AST { node: Node::$node { left, right }, ..ast.clone() }, m_left || m_right))
+            }};
+            ($node:ident, $expr:expr) => {{
+                let (expr, m_expr) = modify!($expr);
+                Ok((AST { node: Node::$node { expr }, ..ast.clone() }, m_expr))
+            }};
+        }
+
+        macro_rules! vec_recursion {
+            ($vec:expr) => {{
+                let scanned: Vec<(AST, bool)> =
+                    $vec.iter().map(|com| self.modify(com, ctx)).collect::<Result<_, _>>()?;
+                let (asts, modified): (Vec<AST>, Vec<bool>) = scanned.into_iter().unzip();
+                let modified = modified.iter().any(|b| b.clone());
+                (asts, modified)
+            }};
+        }
+
+        macro_rules! optional {
+            ($expr:expr) => {{
+                if let Some(expr) = $expr {
+                    let (expr, m_expr): (Box<AST>, bool) = modify!(expr);
+                    (Some(expr), m_expr)
+                } else {
+                    (None, false)
+                }
+            }};
+        }
+
         match &ast.node {
             Node::File { pure, comments, imports, modules } => {
-                let comments =
-                    comments.iter().map(|com| self.modify(com, ctx)).collect::<Result<_, _>>()?;
-                let imports =
-                    imports.iter().map(|imp| self.modify(imp, ctx)).collect::<Result<_, _>>()?;
-                let modules = modules
-                    .iter()
-                    .map(|module| self.modify(module, ctx))
-                    .collect::<Result<_, _>>()?;
-                Ok(AST {
-                    node: Node::File { comments, imports, modules, pure: *pure },
-                    ..ast.clone()
-                })
+                let (comments, m_comments) = vec_recursion!(comments);
+                let (imports, m_imports) = vec_recursion!(imports);
+                let (modules, m_modules) = vec_recursion!(modules);
+                Ok((
+                    AST {
+                        node: Node::File { comments, imports, modules, pure: *pure },
+                        ..ast.clone()
+                    },
+                    m_comments || m_imports || m_modules
+                ))
             }
             Node::Import { import, _as } => {
-                let import =
-                    import.iter().map(|imp| self.modify(imp, ctx)).collect::<Result<_, _>>()?;
-                let _as = _as.iter().map(|imp| self.modify(imp, ctx)).collect::<Result<_, _>>()?;
-                Ok(AST { node: Node::Import { import, _as }, ..ast.clone() })
+                let (import, m_import) = vec_recursion!(import);
+                let (_as, m_as) = vec_recursion!(_as);
+                Ok((AST { node: Node::Import { import, _as }, ..ast.clone() }, m_import || m_as))
             }
             Node::FromImport { id, import } => {
-                let id = Box::from(self.modify(id, ctx)?);
-                let import = Box::from(self.modify(import, ctx)?);
-                Ok(AST { node: Node::FromImport { id, import }, ..ast.clone() })
+                let (id, m_id) = modify!(id);
+                let (import, m_import) = modify!(import);
+                Ok((AST { node: Node::FromImport { id, import }, ..ast.clone() }, m_id || m_import))
             }
             Node::Class { _type, args, parents, body } => {
-                let _type = Box::from(self.modify(_type, ctx)?);
-                let args =
-                    args.iter().map(|arg| self.modify(arg, ctx)).collect::<Result<_, _>>()?;
-                let parents = parents
-                    .iter()
-                    .map(|parent| self.modify(parent, ctx))
-                    .collect::<Result<_, _>>()?;
-                let body = if let Some(body) = body {
-                    Some(Box::from(self.modify(body, ctx)?))
-                } else {
-                    None
-                };
-                Ok(AST { node: Node::Class { _type, args, parents, body }, ..ast.clone() })
+                let (_type, m_type) = modify!(_type);
+                let (args, m_args) = vec_recursion!(args);
+                let (parents, m_parents) = vec_recursion!(parents);
+                let (body, m_body) = optional!(body);
+                Ok((
+                    AST { node: Node::Class { _type, args, parents, body }, ..ast.clone() },
+                    m_type || m_args || m_parents || m_body
+                ))
             }
             Node::Generic { id, isa } => {
-                let id = Box::from(self.modify(id, ctx)?);
-                let isa = if let Some(isa) = isa {
-                    Some(Box::from(self.modify(isa, ctx)?))
-                } else {
-                    None
-                };
-                Ok(AST { node: Node::Generic { id, isa }, ..ast.clone() })
+                let (id, m_id) = modify!(id);
+                let (isa, m_isa) = optional!(isa);
+                Ok((AST { node: Node::Generic { id, isa }, ..ast.clone() }, m_id || m_isa))
             }
             Node::Parent { id, generics, args } => {
-                let id = Box::from(self.modify(id, ctx)?);
-                let generics = generics
-                    .iter()
-                    .map(|generic| self.modify(generic, ctx))
-                    .collect::<Result<_, _>>()?;
-                let args =
-                    args.iter().map(|arg| self.modify(arg, ctx)).collect::<Result<_, _>>()?;
-                Ok(AST { node: Node::Parent { id, generics, args }, ..ast.clone() })
+                let (id, m_id) = modify!(id);
+                let (generics, m_generics) = vec_recursion!(generics);
+                let (args, m_args) = vec_recursion!(args);
+                Ok((
+                    AST { node: Node::Parent { id, generics, args }, ..ast.clone() },
+                    m_id || m_generics || m_args
+                ))
             }
             Node::Script { statements } => {
-                let statements = statements
-                    .iter()
-                    .map(|stmt| self.modify(stmt, ctx))
-                    .collect::<Result<_, _>>()?;
-                Ok(AST { node: Node::Script { statements }, ..ast.clone() })
+                let (statements, m_statements) = vec_recursion!(statements);
+                Ok((AST { node: Node::Script { statements }, ..ast.clone() }, m_statements))
             }
-            Node::Init => Ok(ast.clone()),
+            Node::Init => Ok((ast.clone(), false)),
             Node::Reassign { left, right } => {
-                let left = Box::from(self.modify(left, ctx)?);
-                let right = Box::from(self.modify(right, ctx)?);
-                Ok(AST { node: Node::Reassign { left, right }, ..ast.clone() })
+                let (left, m_left) = modify!(left);
+                let (right, m_right) = modify!(right);
+                Ok((AST { node: Node::Reassign { left, right }, ..ast.clone() }, m_left || m_right))
             }
             Node::VariableDef { private, id_maybe_type, expression, forward } => {
-                let id_maybe_type = Box::from(self.modify(id_maybe_type, ctx)?);
-                let expression = if let Some(expression) = expression {
-                    Some(Box::from(self.modify(expression, ctx)?))
-                } else {
-                    None
-                };
-                let forward = forward
-                    .iter()
-                    .map(|forward| self.modify(forward, ctx))
-                    .collect::<Result<_, _>>()?;
-                Ok(AST {
-                    node: Node::VariableDef {
-                        private: *private,
-                        id_maybe_type,
-                        expression,
-                        forward
+                let (id_maybe_type, m_id_maybe_type) = modify!(id_maybe_type);
+                let (expression, m_expression) = optional!(expression);
+                let (forward, m_forward) = vec_recursion!(forward);
+                Ok((
+                    AST {
+                        node: Node::VariableDef {
+                            private: *private,
+                            id_maybe_type,
+                            expression,
+                            forward
+                        },
+                        ..ast.clone()
                     },
-                    ..ast.clone()
-                })
+                    m_id_maybe_type || m_expression || m_forward
+                ))
             }
             Node::FunDef { pure, private, id, fun_args, ret_ty, raises, body } => {
-                let id = Box::from(self.modify(id, ctx)?);
-                let fun_args =
-                    fun_args.iter().map(|arg| self.modify(arg, ctx)).collect::<Result<_, _>>()?;
-                let ret_ty = if let Some(ret_ty) = ret_ty {
-                    Some(Box::from(self.modify(ret_ty, ctx)?))
-                } else {
-                    None
-                };
-                let raises =
-                    raises.iter().map(|raise| self.modify(raise, ctx)).collect::<Result<_, _>>()?;
-                let body = if let Some(body) = body {
-                    Some(Box::from(self.modify(body, ctx)?))
-                } else {
-                    None
-                };
-                Ok(AST {
-                    node: Node::FunDef {
-                        pure: *pure,
-                        private: *private,
-                        id,
-                        fun_args,
-                        ret_ty,
-                        raises,
-                        body
+                let (id, m_id) = modify!(id);
+                let (fun_args, m_fun_args) = vec_recursion!(fun_args);
+                let (ret_ty, m_ret_ty) = optional!(ret_ty);
+                let (raises, m_raises) = vec_recursion!(raises);
+                let (body, m_body) = optional!(body);
+                Ok((
+                    AST {
+                        node: Node::FunDef {
+                            pure: *pure,
+                            private: *private,
+                            id,
+                            fun_args,
+                            ret_ty,
+                            raises,
+                            body
+                        },
+                        ..ast.clone()
                     },
-                    ..ast.clone()
-                })
+                    m_id || m_fun_args || m_ret_ty || m_raises || m_body
+                ))
             }
             Node::AnonFun { args, body } => {
-                let args =
-                    args.iter().map(|arg| self.modify(arg, ctx)).collect::<Result<_, _>>()?;
-                let body = Box::from(self.modify(body, ctx)?);
-                Ok(AST { node: Node::AnonFun { args, body }, ..ast.clone() })
+                let (args, m_args) = vec_recursion!(args);
+                let (body, m_body) = modify!(body);
+                Ok((AST { node: Node::AnonFun { args, body }, ..ast.clone() }, m_args || m_body))
             }
             Node::Raises { expr_or_stmt, errors } => {
-                let expr_or_stmt = Box::from(self.modify(expr_or_stmt, ctx)?);
-                let errors =
-                    errors.iter().map(|error| self.modify(error, ctx)).collect::<Result<_, _>>()?;
-                Ok(AST { node: Node::Raises { expr_or_stmt, errors }, ..ast.clone() })
+                let (expr_or_stmt, m_expr_or_stmt) = modify!(expr_or_stmt);
+                let (errors, m_errors) = vec_recursion!(errors);
+                Ok((
+                    AST { node: Node::Raises { expr_or_stmt, errors }, ..ast.clone() },
+                    m_expr_or_stmt || m_errors
+                ))
             }
             Node::Raise { error } => {
-                let error = Box::from(self.modify(error, ctx)?);
-                Ok(AST { node: Node::Raise { error }, ..ast.clone() })
+                let (error, m_error) = modify!(error);
+                Ok((AST { node: Node::Raise { error }, ..ast.clone() }, m_error))
             }
             Node::Handle { expr_or_stmt, cases } => {
-                let expr_or_stmt = Box::from(self.modify(expr_or_stmt, ctx)?);
-                let cases =
-                    cases.iter().map(|case| self.modify(case, ctx)).collect::<Result<_, _>>()?;
-                Ok(AST { node: Node::Handle { expr_or_stmt, cases }, ..ast.clone() })
+                let (expr_or_stmt, m_expr_or_stmt) = modify!(expr_or_stmt);
+                let (cases, m_cases) = vec_recursion!(cases);
+                Ok((
+                    AST { node: Node::Handle { expr_or_stmt, cases }, ..ast.clone() },
+                    m_expr_or_stmt || m_cases
+                ))
             }
-            Node::Retry => Ok(ast.clone()),
             Node::With { resource, _as, expr } => {
-                let resource = Box::from(self.modify(resource, ctx)?);
-                let _as = if let Some(_as) = _as {
-                    Some(Box::from(self.modify(_as, ctx)?))
-                } else {
-                    None
-                };
-                let expr = Box::from(self.modify(expr, ctx)?);
-                Ok(AST { node: Node::With { resource, _as, expr }, ..ast.clone() })
+                let (resource, m_resource) = modify!(resource);
+                let (_as, m_as) = optional!(_as);
+                let (expr, m_expr) = modify!(expr);
+                Ok((
+                    AST { node: Node::With { resource, _as, expr }, ..ast.clone() },
+                    m_resource || m_as || m_expr
+                ))
             }
             Node::ConstructorCall { name, args } => {
-                let name = Box::from(self.modify(name, ctx)?);
-                let args =
-                    args.iter().map(|arg| self.modify(arg, ctx)).collect::<Result<_, _>>()?;
-                Ok(AST { node: Node::ConstructorCall { name, args }, ..ast.clone() })
+                let (name, m_name) = modify!(name);
+                let (args, m_args) = vec_recursion!(args);
+                Ok((
+                    AST { node: Node::ConstructorCall { name, args }, ..ast.clone() },
+                    m_name || m_args
+                ))
             }
             Node::FunctionCall { name, args } => {
-                let name = Box::from(self.modify(name, ctx)?);
-                let args =
-                    args.iter().map(|arg| self.modify(arg, ctx)).collect::<Result<_, _>>()?;
-                Ok(AST { node: Node::FunctionCall { name, args }, ..ast.clone() })
+                let (name, m_name) = modify!(name);
+                let (args, m_args) = vec_recursion!(args);
+                Ok((
+                    AST { node: Node::FunctionCall { name, args }, ..ast.clone() },
+                    m_name || m_args
+                ))
             }
             Node::PropertyCall { instance, property } => {
-                let instance = Box::from(self.modify(instance, ctx)?);
-                let property = Box::from(self.modify(property, ctx)?);
-                Ok(AST { node: Node::PropertyCall { instance, property }, ..ast.clone() })
+                let (instance, m_instance) = modify!(instance);
+                let (property, m_property) = modify!(property);
+                Ok((
+                    AST { node: Node::PropertyCall { instance, property }, ..ast.clone() },
+                    m_instance || m_property
+                ))
             }
-            Node::Id { .. } => Ok(ast.clone()),
+            Node::Id { .. } => Ok((ast.clone(), false)),
             Node::IdType { id, mutable, _type } => {
-                let id = Box::from(self.modify(id, ctx)?);
-                let _type = if let Some(_type) = _type {
-                    Some(Box::from(self.modify(_type, ctx)?))
-                } else {
-                    None
-                };
-                Ok(AST { node: Node::IdType { mutable: *mutable, id, _type }, ..ast.clone() })
+                let (id, m_id) = modify!(id);
+                let (_type, m_type) = optional!(_type);
+                Ok((
+                    AST { node: Node::IdType { mutable: *mutable, id, _type }, ..ast.clone() },
+                    m_id || m_type
+                ))
             }
             Node::TypeDef { _type, isa, body } => {
-                let _type = Box::from(self.modify(_type, ctx)?);
-                let isa = if let Some(isa) = isa {
-                    Some(Box::from(self.modify(isa, ctx)?))
-                } else {
-                    None
-                };
-                let body = if let Some(body) = body {
-                    Some(Box::from(self.modify(body, ctx)?))
-                } else {
-                    None
-                };
-                Ok(AST { node: Node::TypeDef { _type, isa, body }, ..ast.clone() })
+                let (_type, m_type) = modify!(_type);
+                let (isa, m_isa) = optional!(isa);
+                let (body, m_body) = optional!(body);
+                Ok((
+                    AST { node: Node::TypeDef { _type, isa, body }, ..ast.clone() },
+                    m_type || m_isa || m_body
+                ))
             }
             Node::TypeAlias { _type, isa, conditions } => {
-                let _type = Box::from(self.modify(_type, ctx)?);
-                let isa = Box::from(self.modify(isa, ctx)?);
-                let conditions = conditions
-                    .iter()
-                    .map(|cond| self.modify(cond, ctx))
-                    .collect::<Result<_, _>>()?;
-                Ok(AST { node: Node::TypeAlias { _type, isa, conditions }, ..ast.clone() })
+                let (_type, m_type) = modify!(_type);
+                let (isa, m_isa) = modify!(isa);
+                let (conditions, m_conditions) = vec_recursion!(conditions);
+                Ok((
+                    AST { node: Node::TypeAlias { _type, isa, conditions }, ..ast.clone() },
+                    m_type || m_isa || m_conditions
+                ))
             }
             Node::TypeTup { types } => {
-                let types =
-                    types.iter().map(|ty| self.modify(ty, ctx)).collect::<Result<_, _>>()?;
-                Ok(AST { node: Node::TypeTup { types }, ..ast.clone() })
+                let (types, m_types) = vec_recursion!(types);
+                Ok((AST { node: Node::TypeTup { types }, ..ast.clone() }, m_types))
             }
             Node::TypeUnion { types } => {
-                let types =
-                    types.iter().map(|ty| self.modify(ty, ctx)).collect::<Result<_, _>>()?;
-                Ok(AST { node: Node::TypeUnion { types }, ..ast.clone() })
+                let (types, m_types) = vec_recursion!(types);
+                Ok((AST { node: Node::TypeUnion { types }, ..ast.clone() }, m_types))
             }
             Node::Type { id, generics } => {
-                let id = Box::from(self.modify(id, ctx)?);
-                let generics = generics
-                    .iter()
-                    .map(|generic| self.modify(generic, ctx))
-                    .collect::<Result<_, _>>()?;
-                Ok(AST { node: Node::Type { id, generics }, ..ast.clone() })
+                let (id, m_id) = modify!(id);
+                let (generics, m_generics) = vec_recursion!(generics);
+                Ok((AST { node: Node::Type { id, generics }, ..ast.clone() }, m_id || m_generics))
             }
             Node::TypeFun { args, ret_ty } => {
-                let args =
-                    args.iter().map(|arg| self.modify(arg, ctx)).collect::<Result<_, _>>()?;
-                let ret_ty = Box::from(self.modify(ret_ty, ctx)?);
-                Ok(AST { node: Node::TypeFun { args, ret_ty }, ..ast.clone() })
+                let (args, m_args) = vec_recursion!(args);
+                let (ret_ty, m_ret_ty) = modify!(ret_ty);
+                Ok((
+                    AST { node: Node::TypeFun { args, ret_ty }, ..ast.clone() },
+                    m_args || m_ret_ty
+                ))
             }
             Node::Condition { cond, _else } => {
-                let cond = Box::from(self.modify(cond, ctx)?);
-                let _else = if let Some(_else) = _else {
-                    Some(Box::from(self.modify(_else, ctx)?))
-                } else {
-                    None
-                };
-                Ok(AST { node: Node::Condition { cond, _else }, ..ast.clone() })
+                let (cond, m_cond) = modify!(cond);
+                let (_else, m_else) = optional!(_else);
+                Ok((AST { node: Node::Condition { cond, _else }, ..ast.clone() }, m_cond || m_else))
             }
             Node::FunArg { vararg, id_maybe_type, default } => {
-                let id_maybe_type = Box::from(self.modify(id_maybe_type, ctx)?);
-                let default = if let Some(default) = default {
-                    Some(Box::from(self.modify(default, ctx)?))
-                } else {
-                    None
-                };
-                Ok(AST {
-                    node: Node::FunArg { vararg: *vararg, id_maybe_type, default },
-                    ..ast.clone()
-                })
+                let (id_maybe_type, m_id_maybe_type) = modify!(id_maybe_type);
+                let (default, m_default) = optional!(default);
+                Ok((
+                    AST {
+                        node: Node::FunArg { vararg: *vararg, id_maybe_type, default },
+                        ..ast.clone()
+                    },
+                    m_id_maybe_type || m_default
+                ))
             }
-            Node::_Self => Ok(ast.clone()),
-            Node::AddOp => Ok(ast.clone()),
-            Node::SubOp => Ok(ast.clone()),
-            Node::SqrtOp => Ok(ast.clone()),
-            Node::MulOp => Ok(ast.clone()),
-            Node::FDivOp => Ok(ast.clone()),
-            Node::DivOp => Ok(ast.clone()),
-            Node::PowOp => Ok(ast.clone()),
-            Node::ModOp => Ok(ast.clone()),
-            Node::EqOp => Ok(ast.clone()),
-            Node::LeOp => Ok(ast.clone()),
-            Node::GeOp => Ok(ast.clone()),
+            Node::_Self => Ok((ast.clone(), false)),
+            Node::AddOp => Ok((ast.clone(), false)),
+            Node::SubOp => Ok((ast.clone(), false)),
+            Node::SqrtOp => Ok((ast.clone(), false)),
+            Node::MulOp => Ok((ast.clone(), false)),
+            Node::FDivOp => Ok((ast.clone(), false)),
+            Node::DivOp => Ok((ast.clone(), false)),
+            Node::PowOp => Ok((ast.clone(), false)),
+            Node::ModOp => Ok((ast.clone(), false)),
+            Node::EqOp => Ok((ast.clone(), false)),
+            Node::LeOp => Ok((ast.clone(), false)),
+            Node::GeOp => Ok((ast.clone(), false)),
             Node::SetBuilder { item, conditions } => {
-                let item = Box::from(self.modify(item, ctx)?);
-                let conditions = conditions
-                    .iter()
-                    .map(|cond| self.modify(cond, ctx))
-                    .collect::<Result<_, _>>()?;
-                Ok(AST { node: Node::SetBuilder { item, conditions }, ..ast.clone() })
+                let (item, m_item) = modify!(item);
+                let (conditions, m_conditions) = vec_recursion!(conditions);
+                Ok((
+                    AST { node: Node::SetBuilder { item, conditions }, ..ast.clone() },
+                    m_item || m_conditions
+                ))
             }
             Node::ListBuilder { item, conditions } => {
-                let item = Box::from(self.modify(item, ctx)?);
-                let conditions = conditions
-                    .iter()
-                    .map(|cond| self.modify(cond, ctx))
-                    .collect::<Result<_, _>>()?;
-                Ok(AST { node: Node::SetBuilder { item, conditions }, ..ast.clone() })
+                let (item, m_item) = modify!(item);
+                let (conditions, m_conditions) = vec_recursion!(conditions);
+                Ok((
+                    AST { node: Node::ListBuilder { item, conditions }, ..ast.clone() },
+                    m_item || m_conditions
+                ))
             }
             Node::Set { elements } => {
-                let elements =
-                    elements.iter().map(|el| self.modify(el, ctx)).collect::<Result<_, _>>()?;
-                Ok(AST { node: Node::Set { elements }, ..ast.clone() })
+                let (elements, m_elements) = vec_recursion!(elements);
+                Ok((AST { node: Node::Set { elements }, ..ast.clone() }, m_elements))
             }
             Node::List { elements } => {
-                let elements =
-                    elements.iter().map(|el| self.modify(el, ctx)).collect::<Result<_, _>>()?;
-                Ok(AST { node: Node::List { elements }, ..ast.clone() })
+                let (elements, m_elements) = vec_recursion!(elements);
+                Ok((AST { node: Node::List { elements }, ..ast.clone() }, m_elements))
             }
             Node::Tuple { elements } => {
-                let elements =
-                    elements.iter().map(|el| self.modify(el, ctx)).collect::<Result<_, _>>()?;
-                Ok(AST { node: Node::Tuple { elements }, ..ast.clone() })
+                let (elements, m_elements) = vec_recursion!(elements);
+                Ok((AST { node: Node::Tuple { elements }, ..ast.clone() }, m_elements))
             }
             Node::Range { from, to, inclusive, step } => {
-                let from = Box::from(self.modify(from, ctx)?);
-                let to = Box::from(self.modify(to, ctx)?);
-                let step = if let Some(step) = step {
-                    Some(Box::from(self.modify(step, ctx)?))
-                } else {
-                    None
-                };
-                Ok(AST {
-                    node: Node::Range { from, to, inclusive: *inclusive, step },
-                    ..ast.clone()
-                })
+                let (from, m_from) = modify!(from);
+                let (to, m_to) = modify!(to);
+                let (step, m_step) = optional!(step);
+                Ok((
+                    AST {
+                        node: Node::Range { from, to, inclusive: *inclusive, step },
+                        ..ast.clone()
+                    },
+                    m_from || m_to || m_step
+                ))
             }
             Node::Block { statements } => {
-                let statements = statements
-                    .iter()
-                    .map(|stmt| self.modify(stmt, ctx))
-                    .collect::<Result<_, _>>()?;
-                Ok(AST { node: Node::Block { statements }, ..ast.clone() })
+                let (statements, m_statements) = vec_recursion!(statements);
+                Ok((AST { node: Node::Block { statements }, ..ast.clone() }, m_statements))
             }
-            Node::Real { .. } => Ok(ast.clone()),
-            Node::Int { .. } => Ok(ast.clone()),
-            Node::ENum { .. } => Ok(ast.clone()),
+            Node::Real { .. } => Ok((ast.clone(), false)),
+            Node::Int { .. } => Ok((ast.clone(), false)),
+            Node::ENum { .. } => Ok((ast.clone(), false)),
             Node::Str { lit, expressions } => {
-                let expressions = expressions
-                    .iter()
-                    .map(|expr| self.modify(expr, ctx))
-                    .collect::<Result<_, _>>()?;
-                Ok(AST { node: Node::Str { lit: lit.clone(), expressions }, ..ast.clone() })
+                let (expressions, m_expressions) = vec_recursion!(expressions);
+                Ok((
+                    AST { node: Node::Str { lit: lit.clone(), expressions }, ..ast.clone() },
+                    m_expressions
+                ))
             }
-            Node::Bool { .. } => Ok(ast.clone()),
-            Node::Add { left, right } => {
-                let left = Box::from(self.modify(left, ctx)?);
-                let right = Box::from(self.modify(right, ctx)?);
-                Ok(AST { node: Node::Add { left, right }, ..ast.clone() })
-            }
-            Node::Sub { left, right } => {
-                let left = Box::from(self.modify(left, ctx)?);
-                let right = Box::from(self.modify(right, ctx)?);
-                Ok(AST { node: Node::Sub { left, right }, ..ast.clone() })
-            }
-            Node::Mul { left, right } => {
-                let left = Box::from(self.modify(left, ctx)?);
-                let right = Box::from(self.modify(right, ctx)?);
-                Ok(AST { node: Node::Mul { left, right }, ..ast.clone() })
-            }
-            Node::Div { left, right } => {
-                let left = Box::from(self.modify(left, ctx)?);
-                let right = Box::from(self.modify(right, ctx)?);
-                Ok(AST { node: Node::Div { left, right }, ..ast.clone() })
-            }
-            Node::FDiv { left, right } => {
-                let left = Box::from(self.modify(left, ctx)?);
-                let right = Box::from(self.modify(right, ctx)?);
-                Ok(AST { node: Node::FDiv { left, right }, ..ast.clone() })
-            }
-            Node::Mod { left, right } => {
-                let left = Box::from(self.modify(left, ctx)?);
-                let right = Box::from(self.modify(right, ctx)?);
-                Ok(AST { node: Node::Mod { left, right }, ..ast.clone() })
-            }
-            Node::Pow { left, right } => {
-                let left = Box::from(self.modify(left, ctx)?);
-                let right = Box::from(self.modify(right, ctx)?);
-                Ok(AST { node: Node::Pow { left, right }, ..ast.clone() })
-            }
-            Node::BAnd { left, right } => {
-                let left = Box::from(self.modify(left, ctx)?);
-                let right = Box::from(self.modify(right, ctx)?);
-                Ok(AST { node: Node::BAnd { left, right }, ..ast.clone() })
-            }
-            Node::BOr { left, right } => {
-                let left = Box::from(self.modify(left, ctx)?);
-                let right = Box::from(self.modify(right, ctx)?);
-                Ok(AST { node: Node::BOr { left, right }, ..ast.clone() })
-            }
-            Node::BXOr { left, right } => {
-                let left = Box::from(self.modify(left, ctx)?);
-                let right = Box::from(self.modify(right, ctx)?);
-                Ok(AST { node: Node::BXOr { left, right }, ..ast.clone() })
-            }
-            Node::BLShift { left, right } => {
-                let left = Box::from(self.modify(left, ctx)?);
-                let right = Box::from(self.modify(right, ctx)?);
-                Ok(AST { node: Node::BLShift { left, right }, ..ast.clone() })
-            }
-            Node::BRShift { left, right } => {
-                let left = Box::from(self.modify(left, ctx)?);
-                let right = Box::from(self.modify(right, ctx)?);
-                Ok(AST { node: Node::BRShift { left, right }, ..ast.clone() })
-            }
-            Node::Le { left, right } => {
-                let left = Box::from(self.modify(left, ctx)?);
-                let right = Box::from(self.modify(right, ctx)?);
-                Ok(AST { node: Node::Le { left, right }, ..ast.clone() })
-            }
-            Node::Ge { left, right } => {
-                let left = Box::from(self.modify(left, ctx)?);
-                let right = Box::from(self.modify(right, ctx)?);
-                Ok(AST { node: Node::Ge { left, right }, ..ast.clone() })
-            }
-            Node::Leq { left, right } => {
-                let left = Box::from(self.modify(left, ctx)?);
-                let right = Box::from(self.modify(right, ctx)?);
-                Ok(AST { node: Node::Leq { left, right }, ..ast.clone() })
-            }
-            Node::Geq { left, right } => {
-                let left = Box::from(self.modify(left, ctx)?);
-                let right = Box::from(self.modify(right, ctx)?);
-                Ok(AST { node: Node::Geq { left, right }, ..ast.clone() })
-            }
-            Node::Is { left, right } => {
-                let left = Box::from(self.modify(left, ctx)?);
-                let right = Box::from(self.modify(right, ctx)?);
-                Ok(AST { node: Node::Is { left, right }, ..ast.clone() })
-            }
-            Node::IsN { left, right } => {
-                let left = Box::from(self.modify(left, ctx)?);
-                let right = Box::from(self.modify(right, ctx)?);
-                Ok(AST { node: Node::IsN { left, right }, ..ast.clone() })
-            }
-            Node::Eq { left, right } => {
-                let left = Box::from(self.modify(left, ctx)?);
-                let right = Box::from(self.modify(right, ctx)?);
-                Ok(AST { node: Node::Eq { left, right }, ..ast.clone() })
-            }
-            Node::Neq { left, right } => {
-                let left = Box::from(self.modify(left, ctx)?);
-                let right = Box::from(self.modify(right, ctx)?);
-                Ok(AST { node: Node::Neq { left, right }, ..ast.clone() })
-            }
-            Node::IsA { left, right } => {
-                let left = Box::from(self.modify(left, ctx)?);
-                let right = Box::from(self.modify(right, ctx)?);
-                Ok(AST { node: Node::IsA { left, right }, ..ast.clone() })
-            }
-            Node::IsNA { left, right } => {
-                let left = Box::from(self.modify(left, ctx)?);
-                let right = Box::from(self.modify(right, ctx)?);
-                Ok(AST { node: Node::IsNA { left, right }, ..ast.clone() })
-            }
-            Node::And { left, right } => {
-                let left = Box::from(self.modify(left, ctx)?);
-                let right = Box::from(self.modify(right, ctx)?);
-                Ok(AST { node: Node::And { left, right }, ..ast.clone() })
-            }
-            Node::Or { left, right } => {
-                let left = Box::from(self.modify(left, ctx)?);
-                let right = Box::from(self.modify(right, ctx)?);
-                Ok(AST { node: Node::Or { left, right }, ..ast.clone() })
-            }
-            Node::BOneCmpl { expr } => {
-                let expr = Box::from(self.modify(expr, ctx)?);
-                Ok(AST { node: Node::BOneCmpl { expr }, ..ast.clone() })
-            }
-            Node::Sqrt { expr } => {
-                let expr = Box::from(self.modify(expr, ctx)?);
-                Ok(AST { node: Node::Sqrt { expr }, ..ast.clone() })
-            }
-            Node::SubU { expr } => {
-                let expr = Box::from(self.modify(expr, ctx)?);
-                Ok(AST { node: Node::SubU { expr }, ..ast.clone() })
-            }
-            Node::AddU { expr } => {
-                let expr = Box::from(self.modify(expr, ctx)?);
-                Ok(AST { node: Node::AddU { expr }, ..ast.clone() })
-            }
-            Node::Not { expr } => {
-                let expr = Box::from(self.modify(expr, ctx)?);
-                Ok(AST { node: Node::Not { expr }, ..ast.clone() })
-            }
+            Node::Bool { .. } => Ok((ast.clone(), false)),
+            Node::Add { left, right } => inner!(Add, left, right),
+            Node::Sub { left, right } => inner!(Sub, left, right),
+            Node::Mul { left, right } => inner!(Mul, left, right),
+            Node::Div { left, right } => inner!(Div, left, right),
+            Node::FDiv { left, right } => inner!(FDiv, left, right),
+            Node::Mod { left, right } => inner!(Mod, left, right),
+            Node::Pow { left, right } => inner!(Pow, left, right),
+            Node::BAnd { left, right } => inner!(BAnd, left, right),
+            Node::BOr { left, right } => inner!(BOr, left, right),
+            Node::BXOr { left, right } => inner!(BXOr, left, right),
+            Node::BLShift { left, right } => inner!(BLShift, left, right),
+            Node::BRShift { left, right } => inner!(BRShift, left, right),
+            Node::Le { left, right } => inner!(Le, left, right),
+            Node::Ge { left, right } => inner!(Ge, left, right),
+            Node::Leq { left, right } => inner!(Leq, left, right),
+            Node::Geq { left, right } => inner!(Geq, left, right),
+            Node::Is { left, right } => inner!(Is, left, right),
+            Node::IsN { left, right } => inner!(IsN, left, right),
+            Node::Eq { left, right } => inner!(Eq, left, right),
+            Node::Neq { left, right } => inner!(Neq, left, right),
+            Node::IsA { left, right } => inner!(IsA, left, right),
+            Node::IsNA { left, right } => inner!(IsNA, left, right),
+            Node::And { left, right } => inner!(And, left, right),
+            Node::Or { left, right } => inner!(Or, left, right),
+            Node::BOneCmpl { expr } => inner!(BOneCmpl, expr),
+            Node::Sqrt { expr } => inner!(Sqrt, expr),
+            Node::SubU { expr } => inner!(SubU, expr),
+            Node::AddU { expr } => inner!(AddU, expr),
+            Node::Not { expr } => inner!(Not, expr),
             Node::IfElse { cond, then, _else } => {
-                let cond = Box::from(self.modify(cond, ctx)?);
-                let then = Box::from(self.modify(then, ctx)?);
-                let _else = if let Some(_else) = _else {
-                    Some(Box::from(self.modify(_else, ctx)?))
-                } else {
-                    None
-                };
-                Ok(AST { node: Node::IfElse { cond, then, _else }, ..ast.clone() })
+                let (cond, m_cond) = modify!(cond);
+                let (then, m_then) = modify!(then);
+                let (_else, m_else) = optional!(_else);
+                Ok((
+                    AST { node: Node::IfElse { cond, then, _else }, ..ast.clone() },
+                    m_cond || m_then || m_else
+                ))
             }
             Node::Match { cond, cases } => {
-                let cond = Box::from(self.modify(cond, ctx)?);
-                let cases =
-                    cases.iter().map(|case| self.modify(case, ctx)).collect::<Result<_, _>>()?;
-                Ok(AST { node: Node::Match { cond, cases }, ..ast.clone() })
+                let (cond, m_cond) = modify!(cond);
+                let (cases, m_cases) = vec_recursion!(cases);
+                Ok((AST { node: Node::Match { cond, cases }, ..ast.clone() }, m_cond || m_cases))
             }
             Node::Case { cond, body } => {
-                let cond = Box::from(self.modify(cond, ctx)?);
-                let body = Box::from(self.modify(body, ctx)?);
-                Ok(AST { node: Node::Case { cond, body }, ..ast.clone() })
+                let (cond, m_cond) = modify!(cond);
+                let (body, m_body) = modify!(body);
+                Ok((AST { node: Node::Case { cond, body }, ..ast.clone() }, m_cond || m_body))
             }
             Node::For { expr, col, body } => {
-                let expr = Box::from(self.modify(expr, ctx)?);
-                let col = Box::from(self.modify(col, ctx)?);
-                let body = Box::from(self.modify(body, ctx)?);
-                Ok(AST { node: Node::For { expr, col, body }, ..ast.clone() })
+                let (expr, m_expr) = modify!(expr);
+                let (col, m_col) = modify!(col);
+                let (body, m_body) = modify!(body);
+                Ok((
+                    AST { node: Node::For { expr, col, body }, ..ast.clone() },
+                    m_expr || m_col || m_body
+                ))
             }
-            Node::In { left, right } => {
-                let left = Box::from(self.modify(left, ctx)?);
-                let right = Box::from(self.modify(right, ctx)?);
-                Ok(AST { node: Node::In { left, right }, ..ast.clone() })
-            }
+            Node::In { left, right } => inner!(In, left, right),
             Node::Step { amount } => {
-                let amount = Box::from(self.modify(amount, ctx)?);
-                Ok(AST { node: Node::Step { amount }, ..ast.clone() })
+                let (amount, modified) = modify!(amount);
+                Ok((AST { node: Node::Step { amount }, ..ast.clone() }, modified))
             }
             Node::While { cond, body } => {
-                let cond = Box::from(self.modify(cond, ctx)?);
-                let body = Box::from(self.modify(body, ctx)?);
-                Ok(AST { node: Node::While { cond, body }, ..ast.clone() })
+                let (cond, m_cond) = modify!(cond);
+                let (body, m_body) = modify!(body);
+                Ok((AST { node: Node::While { cond, body }, ..ast.clone() }, m_cond || m_body))
             }
-            Node::Break => Ok(ast.clone()),
-            Node::Continue => Ok(ast.clone()),
-            Node::Return { expr } => {
-                let expr = Box::from(self.modify(expr, ctx)?);
-                Ok(AST { node: Node::Return { expr }, ..ast.clone() })
-            }
-            Node::ReturnEmpty => Ok(ast.clone()),
-            Node::Underscore => Ok(ast.clone()),
-            Node::Undefined => Ok(ast.clone()),
-            Node::Pass => Ok(ast.clone()),
-            Node::Question { left, right } => {
-                let left = Box::from(self.modify(left, ctx)?);
-                let right = Box::from(self.modify(right, ctx)?);
-                Ok(AST { node: Node::Question { left, right }, ..ast.clone() })
-            }
-            Node::QuestionOp { expr } => {
-                let expr = Box::from(self.modify(expr, ctx)?);
-                Ok(AST { node: Node::QuestionOp { expr }, ..ast.clone() })
-            }
-            Node::Print { expr } => {
-                let expr = Box::from(self.modify(expr, ctx)?);
-                Ok(AST { node: Node::Print { expr }, ..ast.clone() })
-            }
-            Node::Comment { .. } => Ok(ast.clone())
+            Node::Break => Ok((ast.clone(), false)),
+            Node::Continue => Ok((ast.clone(), false)),
+            Node::Return { expr } => inner!(Return, expr),
+            Node::ReturnEmpty => Ok((ast.clone(), false)),
+            Node::Underscore => Ok((ast.clone(), false)),
+            Node::Undefined => Ok((ast.clone(), false)),
+            Node::Pass => Ok((ast.clone(), false)),
+            Node::Question { left, right } => inner!(Question, left, right),
+            Node::QuestionOp { expr } => inner!(QuestionOp, expr),
+            Node::Print { expr } => inner!(Print, expr),
+            Node::Comment { .. } => Ok((ast.clone(), false))
         }
     }
 }

--- a/tests/desugar/expression_and_statements.rs
+++ b/tests/desugar/expression_and_statements.rs
@@ -100,10 +100,3 @@ fn raises_empty_verify() {
     });
     assert_eq!(desugar(&type_def).unwrap(), Core::Id { lit: String::from("a") });
 }
-
-#[test]
-fn retry_verify() {
-    let retry = to_pos!(Node::Retry);
-    let result = desugar(&retry);
-    assert!(result.is_err());
-}

--- a/tests/parser/valid/expression_and_statement.rs
+++ b/tests/parser/valid/expression_and_statement.rs
@@ -126,19 +126,6 @@ fn return_verify() {
 }
 
 #[test]
-fn retry_verify() {
-    let source = String::from("retry");
-    let ast_tree = parse_direct(&tokenize(&source).unwrap()).unwrap();
-
-    let node_pos = match ast_tree.node {
-        Node::Script { statements, .. } => statements.first().expect("script empty.").clone(),
-        _ => panic!("ast_tree was not script.")
-    };
-
-    assert_eq!(node_pos.node, Node::Retry);
-}
-
-#[test]
 fn underscore_verify() {
     let source = String::from("_");
     let ast_tree = parse_direct(&tokenize(&source).unwrap()).unwrap();


### PR DESCRIPTION
### Relevant issues
resolves #107 

### Summary
Remove retry from language, which had little to no added value.

- Modify the modification stage such that a boolean is returned which indicates whether the AST was modified.