### PR TITLE
V0.2.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -145,7 +145,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "mamba"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "assert_cmd 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -132,7 +132,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "mamba"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "assert_cmd 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -89,6 +89,11 @@ version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "either"
+version = "1.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "escargot"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -106,6 +111,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "glob"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "itertools"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "either 1.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "itoa"
@@ -137,6 +150,7 @@ dependencies = [
  "assert_cmd 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "glob 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "itertools 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "leg 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "pathdiff 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "python-parser 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -463,9 +477,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5067f5bb2d80ef5d68b4c87db81601f0b75bca627bc2ef76b141d7b846a3c6d9"
 "checksum colored 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6cdb90b60f2927f8d76139c72dbde7e10c3a2bc47c8594c9c7a66529f2687c03"
 "checksum difference 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "524cbf6897b527295dff137cec09ecf3a05f4fddffd7dfcd1585403449e74198"
+"checksum either 1.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "bb1f6b1ce1c140482ea30ddd3335fc0024ac7ee112895426e0a629a6c20adfe3"
 "checksum escargot 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "19db1f7e74438642a5018cdf263bb1325b2e792f02dd0a3ca6d6c0f0d7b1d5a5"
 "checksum fuchsia-cprng 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 "checksum glob 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
+"checksum itertools 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f56a2d0bc861f9165be4eb3442afd3c236d8a98afd426f65d92324ae1091a484"
 "checksum itoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "501266b7edd0174f8530248f87f99c88fbe60ca4ef3dd486835b8d8d53136f7f"
 "checksum lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bc5729f27f159ddd61f4df6228e827e86643d4d3e7c32183cb30a1c08f604a14"
 "checksum leg 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "97f89b9784106c507bf5f370fb929b72d953ef70b78a79c7053fb6ca6c421748"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mamba"
-version = "0.2.1"
+version = "0.2.2"
 authors = ["Joel Abrahams <abrahamsjo@gmail.com>"]
 description = "A transpiler which translates Mamba to Python 3 files"
 edition = "2018"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,3 +23,4 @@ clap = {version = "2.33", features = ["yaml"]}
 leg = "0.1.3"
 pathdiff = "0.1.0"
 glob = "0.3.0"
+itertools = "0.8.2"

--- a/src/core/construct.rs
+++ b/src/core/construct.rs
@@ -77,6 +77,9 @@ pub enum Core {
         num: String,
         exp: String
     },
+    DocStr {
+        _str: String
+    },
     Str {
         _str: String
     },

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -53,6 +53,7 @@ fn to_py(core: &Core, ind: usize) -> String {
                 format!("{}[{}]", lit, comma_delimited(generics, ind))
             },
         Core::IdType { lit, ty } => format!("{}: {}", lit, to_py(ty, ind)),
+        Core::DocStr { _str } => format!("\"\"\"{}\"\"\"", _str),
         Core::Str { _str } => format!("\"{}\"", _str),
         Core::FStr { _str } => format!("f\"{}\"", _str),
         Core::Int { int } => int.clone(),

--- a/src/desugar/call.rs
+++ b/src/desugar/call.rs
@@ -17,6 +17,10 @@ pub fn desugar_call(ast: &AST, imp: &mut Imports, state: &State) -> DesugarResul
             function: Box::from(desugar_node(name, imp, state)?),
             args:     desugar_vec(args, imp, state)?
         },
+        Node::ConstructorCall { name, args } => Core::FunctionCall {
+            function: Box::from(desugar_node(name, imp, &state.is_constructor(true))?),
+            args:     desugar_vec(args, imp, state)?
+        },
         other => panic!("Expected call flow but was: {:?}.", other)
     })
 }

--- a/src/desugar/class.rs
+++ b/src/desugar/class.rs
@@ -108,7 +108,7 @@ pub fn desugar_class(ast: &AST, imp: &mut Imports, state: &State) -> DesugarResu
                             _ => false
                         });
                     stmts.append(&mut non_variables);
-                    final_definitions = stmts.clone();
+                    final_definitions = stmts;
 
                     Core::ClassDef {
                         name:        Box::from(desugar_node(id, imp, state)?),

--- a/src/desugar/definition.rs
+++ b/src/desugar/definition.rs
@@ -21,7 +21,7 @@ pub fn desugar_definition(ast: &AST, imp: &mut Imports, state: &State) -> Desuga
             Core::VarDef {
                 private: *private,
                 id:      Box::from(id.clone()),
-                right:   match (id.clone(), expression) {
+                right:   match (id, expression) {
                     (_, Some(expr)) => Box::from(desugar_node(&expr, imp, &state)?),
                     (Core::Tuple { elements }, None) =>
                         Box::from(Core::Tuple { elements: vec![Core::None; elements.len()] }),

--- a/src/desugar/node.rs
+++ b/src/desugar/node.rs
@@ -294,7 +294,6 @@ pub fn desugar_node(ast: &AST, imp: &mut Imports, state: &State) -> DesugarResul
         Node::Step { .. } => panic!("Step cannot be top level."),
         Node::Raises { expr_or_stmt, .. } => desugar_node(expr_or_stmt, imp, state)?,
         Node::Raise { error } => Core::Raise { error: Box::from(desugar_node(error, imp, state)?) },
-        Node::Retry { .. } => return Err(UnimplementedErr::new(ast, "retry")),
 
         Node::Handle { expr_or_stmt, cases } => {
             let assign_to = if let Node::VariableDef { id_maybe_type, .. } = &expr_or_stmt.node {

--- a/src/desugar/node.rs
+++ b/src/desugar/node.rs
@@ -49,6 +49,7 @@ pub fn desugar_node(ast: &AST, imp: &mut Imports, state: &State) -> DesugarResul
             num: num.clone(),
             exp: if exp.is_empty() { String::from("0") } else { exp.clone() }
         },
+        Node::DocStr { lit } => Core::DocStr { _str: lit.clone() },
         Node::Str { lit, expressions } =>
             if expressions.is_empty() {
                 Core::Str { _str: lit.clone() }
@@ -253,12 +254,9 @@ pub fn desugar_node(ast: &AST, imp: &mut Imports, state: &State) -> DesugarResul
         },
         Node::Script { statements } =>
             Core::Block { statements: desugar_vec(statements, imp, state)? },
-        Node::File { modules, imports, .. } => {
-            let mut imports = desugar_vec(imports, imp, state)?;
+        Node::File { modules, .. } => {
             let mut modules = desugar_vec(modules, imp, state)?;
-            imports.append(&mut imp.imports.clone().into_iter().collect());
-
-            let mut statements = imports;
+            let mut statements = imp.imports.clone();
             statements.append(&mut modules);
             Core::Block { statements }
         }

--- a/src/desugar/state.rs
+++ b/src/desugar/state.rs
@@ -3,20 +3,27 @@ use crate::core::construct::Core;
 // TODO remove expect_expr once type checker augments AST
 #[derive(Clone, Debug)]
 pub struct State {
-    pub tup:       usize,
+    pub tup: usize,
     pub interface: bool,
     pub expand_ty: bool,
+    pub is_constructor: bool,
     pub assign_to: Option<Core>
 }
 
 impl State {
-    pub fn new() -> State { State { tup: 1, interface: false, expand_ty: true, assign_to: None } }
+    pub fn new() -> State {
+        State { tup: 1, interface: false, expand_ty: true, assign_to: None, is_constructor: false }
+    }
 
     pub fn in_tup(&self, tup: usize) -> State { State { tup, ..self.clone() } }
 
     pub fn in_interface(&self, interface: bool) -> State { State { interface, ..self.clone() } }
 
     pub fn expand_ty(&self, expand_ty: bool) -> State { State { expand_ty, ..self.clone() } }
+
+    pub fn is_constructor(&self, is_constructor: bool) -> State {
+        State { is_constructor, ..self.clone() }
+    }
 
     pub fn assign_to(&self, assign_to: Option<&Core>) -> State {
         State { assign_to: assign_to.cloned(), ..self.clone() }

--- a/src/desugar/ty.rs
+++ b/src/desugar/ty.rs
@@ -27,10 +27,22 @@ pub fn desugar_type(ast: &AST, imp: &mut Imports, state: &State) -> DesugarResul
                             ty:  Box::from(desugar_node(ty, imp, state)?)
                         }
                     } else {
-                        Core::Id { lit: lit.clone() }
+                        Core::Id {
+                            lit: if state.is_constructor {
+                                concrete_to_python(lit)
+                            } else {
+                                lit.clone()
+                            }
+                        }
                     }
                 } else {
-                    Core::Id { lit: lit.clone() }
+                    Core::Id {
+                        lit: if state.is_constructor {
+                            concrete_to_python(lit)
+                        } else {
+                            lit.clone()
+                        }
+                    }
                 },
             Node::_Self => Core::Id { lit: String::from("self") },
             _ => desugar_node(id, imp, state)?

--- a/src/lexer/mod.rs
+++ b/src/lexer/mod.rs
@@ -1,14 +1,16 @@
 use std::path::PathBuf;
 
-use crate::lexer::common::State;
 use crate::lexer::lex_result::{LexResult, LexResults};
+use crate::lexer::pass::pass;
+use crate::lexer::state::State;
 use crate::lexer::tokenize::into_tokens;
 
 pub mod lex_result;
 pub mod token;
 
 #[macro_use]
-mod common;
+mod state;
+mod pass;
 mod tokenize;
 
 pub type TokenizeInput = (String, Option<PathBuf>);
@@ -57,6 +59,7 @@ pub fn tokenize(input: &str) -> LexResult {
     }
     tokens.append(&mut state.flush_indents());
 
+    let tokens = pass(&tokens);
     Ok(tokens)
 }
 

--- a/src/lexer/pass/docstring.rs
+++ b/src/lexer/pass/docstring.rs
@@ -1,0 +1,73 @@
+use crate::lexer::pass::Pass;
+use crate::lexer::token::{Lex, Token};
+
+pub struct DocString {
+    front:  Option<Lex>,
+    middle: Option<Lex>,
+    back:   Option<Lex>
+}
+
+impl DocString {
+    pub fn new() -> DocString { DocString { front: None, middle: None, back: None } }
+
+    fn add(&mut self, lex: &Lex) {
+        self.front = self.middle.clone();
+        self.middle = self.back.clone();
+        self.back = Some(lex.clone());
+    }
+
+    fn get(&mut self) -> Vec<Lex> {
+        match (self.front.clone(), self.middle.clone(), self.back.clone()) {
+            (Some(front), Some(middle), Some(back)) =>
+                match (front.token, middle.token, back.token) {
+                    (Token::Str(f_str, _), Token::Str(doc_str, _), Token::Str(b_str, _)) =>
+                        if f_str.is_empty() && b_str.is_empty()
+                            // No spaces in between
+                            && front.pos.end.pos == middle.pos.start.pos
+                            && middle.pos.end.pos == back.pos.start.pos
+                        {
+                            self.front = None;
+                            self.middle = None;
+                            self.back = None;
+                            return vec![Lex::new(&front.pos.start, Token::DocStr(doc_str))];
+                        },
+                    _ => {}
+                },
+            _ => {}
+        };
+
+        if let Some(lex) = &self.front.clone() {
+            self.front = None;
+            vec![lex.clone()]
+        } else {
+            vec![]
+        }
+    }
+
+    fn flush(&mut self) -> Vec<Lex> {
+        let mut remaining = vec![];
+        if let Some(lex) = &self.front {
+            remaining.push(lex.clone());
+        }
+        if let Some(lex) = &self.middle {
+            remaining.push(lex.clone());
+        }
+        if let Some(lex) = &self.back {
+            remaining.push(lex.clone());
+        }
+        remaining
+    }
+}
+
+impl Pass for DocString {
+    fn modify(&mut self, input: &[Lex]) -> Vec<Lex> {
+        let mut out = vec![];
+        for lex in input {
+            self.add(lex);
+            out.append(&mut self.get())
+        }
+
+        out.append(&mut self.flush());
+        out
+    }
+}

--- a/src/lexer/pass/mod.rs
+++ b/src/lexer/pass/mod.rs
@@ -1,0 +1,18 @@
+use crate::lexer::pass::docstring::DocString;
+use crate::lexer::token::Lex;
+
+mod docstring;
+
+pub fn pass(input: &[Lex]) -> Vec<Lex> {
+    let passes: Vec<Box<dyn Pass>> = vec![Box::from(DocString::new())];
+
+    let mut input = input.to_vec();
+    for mut pass in passes {
+        input = pass.modify(&input);
+    }
+    input
+}
+
+trait Pass {
+    fn modify(&mut self, input: &[Lex]) -> Vec<Lex>;
+}

--- a/src/lexer/state.rs
+++ b/src/lexer/state.rs
@@ -51,8 +51,15 @@ impl State {
         res.append(&mut self.newlines);
         res.push(Lex::new(&self.pos, token.clone()));
 
+        // TODO streamline application logic for multiline strings
         self.cur_indent = self.line_indent;
-        self.pos = self.pos.clone().offset_pos(token.width());
+        self.pos = self.pos.clone().offset_pos(token.clone().width());
+        if let Token::Str(_str, _) = &token {
+            self.pos = self.pos.clone().offset_line(_str.lines().count().clone() as i32);
+        } else if let Token::DocStr(_str) = &token {
+            self.pos = self.pos.clone().offset_line(_str.lines().count().clone() as i32);
+        }
+
         res
     }
 

--- a/src/lexer/token.rs
+++ b/src/lexer/token.rs
@@ -97,7 +97,6 @@ pub enum Token {
 
     Raises,
     Raise,
-    Retry,
     When,
 
     While,
@@ -256,7 +255,6 @@ impl fmt::Display for Token {
             Token::Handle => String::from("handle"),
             Token::Raises => String::from("raises"),
             Token::Raise => String::from("raise"),
-            Token::Retry => String::from("retry"),
             Token::When => String::from("when"),
 
             Token::Pass => String::from("pass"),

--- a/src/lexer/token.rs
+++ b/src/lexer/token.rs
@@ -178,12 +178,12 @@ impl fmt::Display for Token {
             Token::Assign => String::from("<-"),
             Token::Def => String::from("def"),
 
-            Token::Id(id) => id.clone(),
-            Token::Real(real) => real.clone(),
-            Token::Int(int) => int.clone(),
+            Token::Id(id) => id,
+            Token::Real(real) => real,
+            Token::Int(int) => int,
             Token::ENum(int, exp) =>
                 if exp.is_empty() {
-                    int.clone()
+                    int
                 } else {
                     format!("{}E{}", int, exp)
                 },

--- a/src/lexer/tokenize.rs
+++ b/src/lexer/tokenize.rs
@@ -247,7 +247,6 @@ fn as_op_or_id(string: String) -> Token {
         "raises" => Token::Raises,
         "raise" => Token::Raise,
         "handle" => Token::Handle,
-        "retry" => Token::Retry,
         "when" => Token::When,
 
         "True" => Token::Bool(true),

--- a/src/lexer/tokenize.rs
+++ b/src/lexer/tokenize.rs
@@ -2,8 +2,8 @@ use std::iter::Peekable;
 use std::str::Chars;
 
 use crate::common::position::CaretPos;
-use crate::lexer::common::State;
 use crate::lexer::lex_result::{LexErr, LexResult};
+use crate::lexer::state::State;
 use crate::lexer::token::{Lex, Token};
 use crate::lexer::tokenize;
 
@@ -143,7 +143,7 @@ pub fn into_tokens(c: char, it: &mut Peekable<Chars>, state: &mut State) -> LexR
 
                     if c == '{' {
                         if build_cur_expr == 0 {
-                            cur_offset = state.pos.clone().offset_pos(string.len() as i32);
+                            cur_offset = state.pos.clone().offset_pos(string.len() as i32 + 1);
                         }
                         build_cur_expr += 1;
                     } else if c == '}' {
@@ -163,18 +163,23 @@ pub fn into_tokens(c: char, it: &mut Peekable<Chars>, state: &mut State) -> LexR
                 back_slash = c == '\\';
             }
 
-            let tokens = exprs
-                .iter()
-                .map(|(offset, string)| match tokenize(string) {
-                    Ok(tokens) => Ok(tokens
-                        .iter()
-                        .map(|lex| Lex::new(&lex.pos.offset(offset).start, lex.token.clone()))
-                        .collect()),
-                    Err(err) => Err(err)
-                })
-                .collect::<Result<_, _>>()?;
+            if string.starts_with("\"\"") && string.ends_with("\"\"") {
+                let string = string.trim_start_matches("\"\"").trim_end_matches("\"\"");
+                create(state, Token::DocStr(String::from(string)))
+            } else {
+                let tokens = exprs
+                    .iter()
+                    .map(|(offset, string)| match tokenize(string) {
+                        Ok(tokens) => Ok(tokens
+                            .iter()
+                            .map(|lex| Lex::new(&lex.pos.offset(offset).start, lex.token.clone()))
+                            .collect()),
+                        Err(err) => Err(err)
+                    })
+                    .collect::<Result<_, _>>()?;
 
-            create(state, Token::Str(string, tokens))
+                create(state, Token::Str(string, tokens))
+            }
         }
         ' ' => {
             state.space();

--- a/src/parser/_type.rs
+++ b/src/parser/_type.rs
@@ -78,7 +78,7 @@ pub fn parse_type(it: &mut LexIterator) -> ParseResult {
                 let generics =
                     it.parse_vec_if(&Token::LSBrack, &parse_generics, "type generic", start)?;
                 let end = match (it.eat_if(&Token::RSBrack), generics.last()) {
-                    (Some(end), _) => end.clone(),
+                    (Some(end), _) => end,
                     (_, Some(generic)) => generic.pos.clone(),
                     _ => id.pos.clone()
                 };
@@ -100,7 +100,7 @@ pub fn parse_type(it: &mut LexIterator) -> ParseResult {
 
     let _type = if it.peek_if(&|lex| lex.token == Token::Question) {
         it.eat(&Token::Question, "optional type")?;
-        Box::from(AST { pos: _type.pos.clone(), node: Node::QuestionOp { expr: _type.clone() } })
+        Box::from(AST { pos: _type.pos.clone(), node: Node::QuestionOp { expr: _type } })
     } else {
         _type
     };
@@ -123,7 +123,7 @@ pub fn parse_type(it: &mut LexIterator) -> ParseResult {
 
     match res {
         Some(ast_node_pos) => Ok(ast_node_pos),
-        None => Ok(_type.clone())
+        None => Ok(_type)
     }
 }
 

--- a/src/parser/ast.rs
+++ b/src/parser/ast.rs
@@ -15,10 +15,8 @@ impl AST {
 #[derive(PartialEq, Eq, Hash, Debug, Clone)]
 pub enum Node {
     File {
-        pure:     bool,
-        comments: Vec<AST>,
-        imports:  Vec<AST>,
-        modules:  Vec<AST>
+        pure:    bool,
+        modules: Vec<AST>
     },
     Import {
         import: Vec<AST>,
@@ -201,6 +199,9 @@ pub enum Node {
     Str {
         lit:         String,
         expressions: Vec<AST>
+    },
+    DocStr {
+        lit: String
     },
     Bool {
         lit: bool

--- a/src/parser/ast.rs
+++ b/src/parser/ast.rs
@@ -84,7 +84,6 @@ pub enum Node {
         expr_or_stmt: Box<AST>,
         cases:        Vec<AST>
     },
-    Retry,
     With {
         resource: Box<AST>,
         _as:      Option<Box<AST>>,

--- a/src/parser/ast.rs
+++ b/src/parser/ast.rs
@@ -91,6 +91,10 @@ pub enum Node {
         expr:     Box<AST>
     },
 
+    ConstructorCall {
+        name: Box<AST>,
+        args: Vec<AST>
+    },
     FunctionCall {
         name: Box<AST>,
         args: Vec<AST>

--- a/src/parser/block.rs
+++ b/src/parser/block.rs
@@ -23,10 +23,15 @@ pub fn parse_statements(it: &mut LexIterator) -> ParseResult<Vec<AST>> {
                 statements.push(AST::new(&lex.pos.union(&end), node));
                 Ok(())
             }
+            Token::DocStr(doc_str) => {
+                let end = it.eat(&Token::DocStr(doc_str.clone()), "block")?;
+                let node = Node::DocStr { lit: doc_str.clone() };
+                statements.push(AST::new(&lex.pos.union(&end), node));
+                Ok(())
+            }
             _ => {
                 statements.push(*it.parse(&parse_expr_or_stmt, "block", &start)?);
                 if it.peek_if(&|lex| lex.token != Token::NL && lex.token != Token::Dedent) {
-                    // TODO pass actual current
                     Err(expected_one_of(&[Token::NL, Token::Dedent], lex, "block"))
                 } else {
                     Ok(())

--- a/src/parser/class.rs
+++ b/src/parser/class.rs
@@ -48,8 +48,7 @@ pub fn parse_class(it: &mut LexIterator) -> ParseResult {
     it.eat(&Token::NL, "class")?;
     let (body, pos) = if it.peek_if(&|lex| lex.token == Token::Indent) {
         let body = it.parse(&parse_block, "class", &start)?;
-        let pos = start.union(&body.pos);
-        (Some(body), pos)
+        (Some(body.clone()), start.union(&body.pos))
     } else {
         (None, start)
     };

--- a/src/parser/control_flow_expr.rs
+++ b/src/parser/control_flow_expr.rs
@@ -30,7 +30,7 @@ fn parse_if(it: &mut LexIterator) -> ParseResult {
 
     let pos =
         if let Some(_else) = &_else { start.union(&_else.pos) } else { start.union(&then.pos) };
-    let node = Node::IfElse { cond, then: then.clone(), _else };
+    let node = Node::IfElse { cond, then, _else };
 
     Ok(Box::from(AST::new(&pos, node)))
 }

--- a/src/parser/parse_result.rs
+++ b/src/parser/parse_result.rs
@@ -135,7 +135,7 @@ fn title_case(s: &str) -> String {
     if let Some(first) = tile_case.get_mut(0..1) {
         first.make_ascii_uppercase();
     }
-    tile_case.to_string()
+    tile_case
 }
 
 impl Display for ParseErr {

--- a/src/parser/statement.rs
+++ b/src/parser/statement.rs
@@ -23,10 +23,6 @@ pub fn parse_statement(it: &mut LexIterator) -> ParseResult {
                 let end = it.eat(&Token::Pass, "statement")?;
                 Ok(Box::from(AST::new(&end, Node::Pass)))
             }
-            Token::Retry => {
-                let end = it.eat(&Token::Retry, "statement")?;
-                Ok(Box::from(AST::new(&end, Node::Retry)))
-            }
             Token::Raise => {
                 it.eat(&Token::Raise, "statement")?;
                 let error = it.parse(&parse_expression, "statement", &lex.pos)?;
@@ -82,7 +78,6 @@ pub fn is_start_statement(tp: &Token) -> bool {
         | Token::Print
         | Token::For
         | Token::While
-        | Token::Retry
         | Token::Pass
         | Token::Raise
         | Token::With => true,

--- a/src/pipeline/io.rs
+++ b/src/pipeline/io.rs
@@ -31,6 +31,8 @@ pub fn write_source(source: &str, out_path: &PathBuf) -> Result<usize, (String, 
             )),
     };
 
+    // LF instead of CRLF line endings
+    let source = source.replace("\r\n", "\n");
     OpenOptions::new()
         .write(true)
         .create(true)

--- a/src/pipeline/mod.rs
+++ b/src/pipeline/mod.rs
@@ -94,13 +94,13 @@ pub fn mamba_to_python(
             .collect::<Vec<(String, String)>>()
     })?;
 
-    check_all(ast_trees.as_slice()).map_err(|errs| {
+    let modified_trees = check_all(ast_trees.as_slice()).map_err(|errs| {
         errs.iter()
             .map(|err| (String::from("type"), format!("{}", err)))
             .collect::<Vec<(String, String)>>()
     })?;
 
-    let core_tree = desugar_all(ast_trees.as_slice()).map_err(|errs| {
+    let core_tree = desugar_all(modified_trees.as_slice()).map_err(|errs| {
         errs.iter()
             .map(|err| (String::from("unimplemented"), format!("{}", err)))
             .collect::<Vec<(String, String)>>()

--- a/src/type_checker/context/function_arg/concrete.rs
+++ b/src/type_checker/context/function_arg/concrete.rs
@@ -7,6 +7,7 @@ use crate::common::position::Position;
 use crate::type_checker::context::function_arg::generic::GenericFunctionArg;
 use crate::type_checker::context::type_name::TypeName;
 use crate::type_checker::type_result::{TypeErr, TypeResult};
+use itertools::{EitherOrBoth, Itertools};
 
 // TODO make ty private again
 // TODO create second pass where we assign types to function arguments using
@@ -16,28 +17,41 @@ pub const SELF: &str = "self";
 
 #[derive(Debug, Clone, Eq, PartialEq, Hash)]
 pub struct FunctionArg {
-    pub is_py_type: bool,
-    pub name:       String,
-    pub vararg:     bool,
-    pub mutable:    bool,
-    pub ty:         Option<TypeName>
+    pub is_py_type:  bool,
+    pub name:        String,
+    pub has_default: bool,
+    pub vararg:      bool,
+    pub mutable:     bool,
+    pub ty:          Option<TypeName>
 }
 
 impl Display for FunctionArg {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         write!(
             f,
-            "{}{}",
+            "{}{}{}",
             self.name,
-            if let Some(ty) = &self.ty { format!(": {}", ty) } else { String::new() }
+            if let Some(ty) = &self.ty { format!(": {}", ty) } else { String::new() },
+            if self.has_default { "?" } else { "" }
         )
     }
 }
 
 pub fn args_compatible(fun_args: &[FunctionArg], args: &[TypeName]) -> bool {
-    let fun_args: Vec<Option<TypeName>> = fun_args.iter().map(|a| a.ty.clone()).collect();
-    let args: Vec<Option<TypeName>> = args.iter().map(|a| Some(a.clone())).collect();
-    args == fun_args
+    for pair in fun_args.iter().zip_longest(args.iter()) {
+        match pair {
+            EitherOrBoth::Both(fun_arg, arg) =>
+                if fun_arg.ty != Some(arg.clone()) {
+                    return false;
+                },
+            EitherOrBoth::Left(fun_arg) =>
+                if !fun_arg.has_default {
+                    return false;
+                },
+            EitherOrBoth::Right(_) => return false
+        }
+    }
+    true
 }
 
 impl FunctionArg {
@@ -61,11 +75,12 @@ impl TryFrom<(&GenericFunctionArg, &HashMap<String, TypeName>, &Position)> for F
         (fun_arg, generics, pos): (&GenericFunctionArg, &HashMap<String, TypeName>, &Position)
     ) -> Result<Self, Self::Error> {
         Ok(FunctionArg {
-            is_py_type: fun_arg.is_py_type,
-            name:       fun_arg.name.clone(),
-            vararg:     fun_arg.vararg,
-            mutable:    fun_arg.mutable,
-            ty:         match &fun_arg.ty {
+            is_py_type:  fun_arg.is_py_type,
+            name:        fun_arg.name.clone(),
+            has_default: fun_arg.has_default,
+            vararg:      fun_arg.vararg,
+            mutable:     fun_arg.mutable,
+            ty:          match &fun_arg.ty {
                 Some(ty) => Some(ty.substitute(generics, pos)?),
                 None => None
             }

--- a/src/type_checker/context/function_arg/generic.rs
+++ b/src/type_checker/context/function_arg/generic.rs
@@ -18,12 +18,13 @@ pub struct ClassArgument {
 
 #[derive(Debug, Clone, Eq)]
 pub struct GenericFunctionArg {
-    pub is_py_type: bool,
-    pub name:       String,
-    pub pos:        Position,
-    pub vararg:     bool,
-    pub mutable:    bool,
-    pub ty:         Option<TypeName>
+    pub is_py_type:  bool,
+    pub name:        String,
+    pub pos:         Position,
+    pub has_default: bool,
+    pub vararg:      bool,
+    pub mutable:     bool,
+    pub ty:          Option<TypeName>
 }
 
 impl PartialEq for GenericFunctionArg {
@@ -91,12 +92,13 @@ impl TryFrom<&AST> for GenericFunctionArg {
                 Node::IdType { id, mutable, _type } => {
                     let name = argument_name(id.deref())?;
                     Ok(GenericFunctionArg {
-                        is_py_type: false,
-                        name:       name.clone(),
-                        vararg:     *vararg,
-                        mutable:    *mutable,
-                        pos:        node_pos.pos.clone(),
-                        ty:         match _type {
+                        is_py_type:  false,
+                        name:        name.clone(),
+                        has_default: default.is_some(),
+                        vararg:      *vararg,
+                        mutable:     *mutable,
+                        pos:         node_pos.pos.clone(),
+                        ty:          match _type {
                             Some(_type) => Some(TypeName::try_from(_type.deref())?),
                             None if name.as_str() == SELF => None,
                             None =>

--- a/src/type_checker/context/function_arg/python.rs
+++ b/src/type_checker/context/function_arg/python.rs
@@ -7,15 +7,16 @@ pub const SELF: &str = "self";
 
 impl From<(&String, &Option<Expression>, &Option<Expression>)> for GenericFunctionArg {
     fn from(
-        (name, ty, _): (&String, &Option<Expression>, &Option<Expression>)
+        (name, ty, default): (&String, &Option<Expression>, &Option<Expression>)
     ) -> GenericFunctionArg {
         GenericFunctionArg {
-            is_py_type: true,
-            name:       name.clone(),
-            pos:        Default::default(),
-            vararg:     false,
-            mutable:    false,
-            ty:         ty.clone().map(|e| TypeName::from(&e))
+            is_py_type:  true,
+            name:        name.clone(),
+            has_default: default.is_some(),
+            pos:         Default::default(),
+            vararg:      false,
+            mutable:     false,
+            ty:          ty.clone().map(|e| TypeName::from(&e))
         }
     }
 }

--- a/src/type_checker/context/python.rs
+++ b/src/type_checker/context/python.rs
@@ -11,6 +11,7 @@ use crate::type_checker::context::ty::generic::GenericType;
 use crate::type_checker::type_result::{TypeErr, TypeResult};
 use python_parser::ast::{CompoundStatement, Statement};
 use std::collections::HashSet;
+use std::convert::TryFrom;
 use std::iter::FromIterator;
 
 pub fn python_files(
@@ -51,7 +52,7 @@ pub fn python_files(
                     CompoundStatement::Funcdef(func_def) =>
                         functions.push(GenericFunction::from(func_def)),
                     CompoundStatement::Classdef(class_def) =>
-                        types.push(GenericType::from(class_def)),
+                        types.push(GenericType::try_from(class_def)?),
                     _ => {}
                 },
                 _ => {}

--- a/src/type_checker/context/ty/generic.rs
+++ b/src/type_checker/context/ty/generic.rs
@@ -85,12 +85,13 @@ impl TryFrom<&AST> for GenericType {
                     class_args
                 } else {
                     let mut new_args = vec![GenericFunctionArg {
-                        is_py_type: false,
-                        name:       String::from(function_arg::generic::SELF),
-                        pos:        Default::default(),
-                        vararg:     false,
-                        mutable:    false,
-                        ty:         Some(TypeName::from(&name))
+                        is_py_type:  false,
+                        name:        String::from(function_arg::generic::SELF),
+                        has_default: false,
+                        pos:         Default::default(),
+                        vararg:      false,
+                        mutable:     false,
+                        ty:          Some(TypeName::from(&name))
                     }];
                     new_args.append(&mut class_args);
                     new_args
@@ -112,12 +113,13 @@ impl TryFrom<&AST> for GenericType {
 
                 if class_args.is_empty() {
                     class_args.push(GenericFunctionArg {
-                        is_py_type: false,
-                        name:       String::from(function_arg::concrete::SELF),
-                        pos:        Default::default(),
-                        vararg:     false,
-                        mutable:    false,
-                        ty:         Option::from(TypeName::from(&name))
+                        is_py_type:  false,
+                        name:        String::from(function_arg::concrete::SELF),
+                        pos:         Default::default(),
+                        has_default: false,
+                        vararg:      false,
+                        mutable:     false,
+                        ty:          Option::from(TypeName::from(&name))
                     })
                 }
 

--- a/src/type_checker/context/ty/generic.rs
+++ b/src/type_checker/context/ty/generic.rs
@@ -54,7 +54,7 @@ impl TryFrom<&AST> for GenericType {
     fn try_from(class: &AST) -> TypeResult<GenericType> {
         match &class.node {
             // TODO add pure classes
-            Node::Class { _type, args, parents, body } => {
+            Node::Class { _type, args, parents, body, .. } => {
                 let (name, generics) = get_name_and_generics(_type)?;
                 let statements = if let Some(body) = body {
                     match &body.node {
@@ -145,7 +145,7 @@ impl TryFrom<&AST> for GenericType {
                     parents: parents.into_iter().map(Result::unwrap).collect()
                 })
             }
-            Node::TypeDef { _type, isa, body } => {
+            Node::TypeDef { _type, isa, body, .. } => {
                 let (name, generics) = get_name_and_generics(_type)?;
                 let statements = if let Some(body) = body {
                     match &body.node {
@@ -249,7 +249,7 @@ fn get_fields_and_functions(
                     .collect::<Result<_, _>>()?;
                 fields = fields.union(&stmt_fields).cloned().collect();
             }
-            Node::Comment { .. } => {}
+            Node::Comment { .. } | Node::DocStr { .. } => {}
             _ =>
                 return Err(vec![TypeErr::new(
                     &statement.pos,

--- a/src/type_checker/environment/expression_type/actual_type.rs
+++ b/src/type_checker/environment/expression_type/actual_type.rs
@@ -5,6 +5,7 @@ use std::ops::Deref;
 use crate::common::position::Position;
 use crate::type_checker::context::field::concrete::Field;
 use crate::type_checker::context::function::concrete::Function;
+use crate::type_checker::context::function_arg::concrete::args_compatible;
 use crate::type_checker::context::ty::concrete::Type;
 use crate::type_checker::context::type_name::TypeName;
 use crate::type_checker::environment::expression_type::ExpressionType;
@@ -66,41 +67,19 @@ impl ActualType {
     pub fn constructor(&self, args: &[TypeName], pos: &Position) -> TypeResult<ActualType> {
         match &self {
             ActualType::Single { ty } => {
-                let args = match self {
-                    ActualType::Single { ty } => {
-                        let mut new_args = vec![TypeName::from(&ty.name)];
-                        new_args.append(&mut args.to_vec());
-                        new_args
-                    }
-                    _ =>
-                        return Err(vec![TypeErr::new(
-                            pos,
-                            "Can only call constructor on single type"
-                        )]),
-                };
+                let mut new_args = vec![TypeName::from(&ty.name)];
+                new_args.append(&mut args.to_vec());
 
-                // TODO handle default arguments
-                // TODO handle unknown types
-                let constructor_args: Vec<TypeName> = ty
-                    .args
-                    .iter()
-                    .map(|a| {
-                        a.ty.clone().ok_or_else(|| {
-                            TypeErr::new(pos, "Type constructor argument is unknown")
-                        })
-                    })
-                    .collect::<Result<_, _>>()?;
-
-                if constructor_args == args {
+                if args_compatible(&ty.args, &new_args) {
                     Ok(self.clone())
                 } else {
                     Err(vec![TypeErr::new(
                         pos,
                         &format!(
-                            "Attempted to pass ({}) to a {} which only takes ({})",
-                            comma_delimited(args),
-                            ty.name,
-                            comma_delimited(constructor_args)
+                            "{} only takes arguments ({}). Was given: ({}).",
+                            ty.clone(),
+                            comma_delimited(&ty.args),
+                            comma_delimited(new_args)
                         )
                     )])
                 }

--- a/src/type_checker/environment/expression_type/actual_type.rs
+++ b/src/type_checker/environment/expression_type/actual_type.rs
@@ -66,14 +66,31 @@ impl ActualType {
     pub fn constructor(&self, args: &[TypeName], pos: &Position) -> TypeResult<ActualType> {
         match &self {
             ActualType::Single { ty } => {
+                let args = match self {
+                    ActualType::Single { ty } => {
+                        let mut new_args = vec![TypeName::from(&ty.name)];
+                        new_args.append(&mut args.to_vec());
+                        new_args
+                    }
+                    _ =>
+                        return Err(vec![TypeErr::new(
+                            pos,
+                            "Can only call constructor on single type"
+                        )]),
+                };
+
                 // TODO handle default arguments
+                // TODO handle unknown types
                 let constructor_args: Vec<TypeName> = ty
                     .args
                     .iter()
-                    .map(|a| a.ty.clone().ok_or_else(|| TypeErr::new(pos, "Type is unknown")))
+                    .map(|a| {
+                        a.ty.clone().ok_or_else(|| {
+                            TypeErr::new(pos, "Type constructor argument is unknown")
+                        })
+                    })
                     .collect::<Result<_, _>>()?;
 
-                // TODO handle unknown types
                 if constructor_args == args {
                     Ok(self.clone())
                 } else {

--- a/src/type_checker/environment/expression_type/mod.rs
+++ b/src/type_checker/environment/expression_type/mod.rs
@@ -116,7 +116,7 @@ impl ExpressionType {
                 for ty in ret_tys {
                     ret_ty = ret_ty.union(&ty);
                 }
-                Ok(ret_ty.clone())
+                Ok(ret_ty)
             }
         }
     }
@@ -185,7 +185,7 @@ fn make_nullable_if_none(union: &HashSet<NullableType>) -> HashSet<NullableType>
     };
 
     if union.len() == 1 {
-        union.clone()
+        union
     } else {
         union
             .into_iter()

--- a/src/type_checker/infer/_type.rs
+++ b/src/type_checker/infer/_type.rs
@@ -11,7 +11,7 @@ use crate::type_checker::type_result::TypeErr;
 
 pub fn infer_type(ast: &AST, env: &Environment, ctx: &Context) -> InferResult {
     match &ast.node {
-        Node::TypeDef { isa, body, _type } => {
+        Node::TypeDef { isa, body, _type, .. } => {
             if let Some(isa) = isa {
                 infer(isa, env, ctx)?;
             }

--- a/src/type_checker/infer/assign.rs
+++ b/src/type_checker/infer/assign.rs
@@ -32,7 +32,7 @@ pub fn infer_assign(ast: &AST, env: &Environment, ctx: &Context) -> InferResult 
             let (right_ty, env) = infer(right, &env, ctx)?;
             let right_expr = right_ty.expr_ty(&right.pos)?;
 
-            let mut env = env.clone();
+            let mut env = env;
             let matched = match_name(&identifier, &right_expr, &env, &right.pos)?;
             for (id, (new_mutable, expr_ty)) in matched {
                 let (mutable, left_expr) = env.lookup_indirect(&id, &left.pos)?;

--- a/src/type_checker/infer/bitwise_operation.rs
+++ b/src/type_checker/infer/bitwise_operation.rs
@@ -19,12 +19,12 @@ pub fn infer_bitwise_op(ast: &AST, env: &Environment, ctx: &Context) -> InferRes
             let (right_ty, env) = infer(right, &env, ctx)?;
             left_ty.expr_ty(&ast.pos)?;
             right_ty.expr_ty(&ast.pos)?;
-            Ok((InferType::from(&int_ty).add_raises(&left_ty).add_raises(&right_ty), env.clone()))
+            Ok((InferType::from(&int_ty).add_raises(&left_ty).add_raises(&right_ty), env))
         }
         Node::BOneCmpl { expr } => {
             let (infer_ty, env) = infer(expr, env, ctx)?;
             infer_ty.expr_ty(&ast.pos)?;
-            Ok((InferType::from(&int_ty).add_raises(&infer_ty), env.clone()))
+            Ok((InferType::from(&int_ty).add_raises(&infer_ty), env))
         }
         _ => Err(vec![TypeErr::new(&ast.pos, "Expected bitwise operation")])
     }

--- a/src/type_checker/infer/call.rs
+++ b/src/type_checker/infer/call.rs
@@ -15,6 +15,23 @@ use crate::type_checker::type_result::TypeErr;
 
 pub fn infer_call(ast: &AST, env: &Environment, ctx: &Context) -> InferResult {
     match &ast.node {
+        // TODO split up application logic
+        Node::ConstructorCall { name, args } => {
+            let fun_name = TypeName::try_from(name.deref())?;
+            let mut arg_names = vec![];
+            let mut raises = HashSet::new();
+            let mut env = env.clone();
+            for arg in args {
+                let (ty, new_env) = infer(arg, &env, ctx)?;
+                arg_names.push(TypeName::from(&ty.expr_ty(&arg.pos)?));
+                env = new_env;
+                raises = raises.union(&ty.raises).cloned().collect();
+            }
+
+            let expr_ty = ctx.lookup(&fun_name, &name.pos)?;
+            expr_ty.constructor(&arg_names, &ast.pos)?;
+            Ok((InferType::from(&expr_ty).union_raises(&raises), env))
+        }
         Node::FunctionCall { name, args } => {
             let fun_name = TypeName::try_from(name.deref())?;
             let mut arg_names = vec![];
@@ -34,12 +51,7 @@ pub fn infer_call(ast: &AST, env: &Environment, ctx: &Context) -> InferResult {
                     env
                 )),
                 Err(_) => match ctx.lookup_fun(&fun_name, &arg_names, &ast.pos) {
-                    // else, see if constructor of type
-                    Err(_) => {
-                        let expr_ty = ctx.lookup(&fun_name, &name.pos)?;
-                        expr_ty.constructor(&arg_names, &ast.pos)?;
-                        Ok((InferType::from(&expr_ty).union_raises(&raises), env))
-                    }
+                    Err(err) => Err(err),
                     Ok(ok) => Ok((ok.union_raises(&raises), env))
                 }
             }

--- a/src/type_checker/infer/class.rs
+++ b/src/type_checker/infer/class.rs
@@ -12,7 +12,7 @@ use crate::type_checker::type_result::TypeErr;
 pub fn infer_class(ast: &AST, env: &Environment, ctx: &Context) -> InferResult {
     match &ast.node {
         Node::Init => Ok((InferType::default(), env.clone())),
-        Node::Class { _type, args, parents, body } => {
+        Node::Class { _type, args, parents, body, .. } => {
             // TODO type check arguments and constructor of parent
             for arg in args {
                 let id_maybe_type = match &arg.node {

--- a/src/type_checker/infer/error.rs
+++ b/src/type_checker/infer/error.rs
@@ -43,13 +43,6 @@ pub fn infer_error(ast: &AST, env: &Environment, ctx: &Context) -> InferResult {
             }
         }
 
-        Node::Retry =>
-            if !env.state.in_handle {
-                Err(vec![TypeErr::new(&ast.pos, "Retry only possible in handle arm")])
-            } else {
-                Ok((InferType::default(), env.clone()))
-            },
-
         Node::With { resource, _as, expr } => {
             let (resource_ty, mut inner_env) = infer(resource, env, ctx)?;
 

--- a/src/type_checker/infer/mod.rs
+++ b/src/type_checker/infer/mod.rs
@@ -139,6 +139,7 @@ fn infer(ast: &AST, env: &Environment, ctx: &Context) -> InferResult {
         | Node::ENum { .. }
         | Node::Str { .. }
         | Node::Bool { .. } => infer_literal(ast, env, ctx),
+        Node::DocStr { .. } => Ok((InferType::default(), env.clone())),
 
         Node::Add { .. } | Node::AddU { .. } => infer_op(ast, env, ctx),
         Node::Sub { .. } | Node::SubU { .. } => infer_op(ast, env, ctx),

--- a/src/type_checker/infer/mod.rs
+++ b/src/type_checker/infer/mod.rs
@@ -89,7 +89,6 @@ fn infer(ast: &AST, env: &Environment, ctx: &Context) -> InferResult {
 
         Node::Raises { .. } | Node::Raise { .. } => infer_error(ast, env, ctx),
         Node::Handle { .. } => infer_control_flow(ast, env, ctx),
-        Node::Retry => infer_error(ast, env, ctx),
 
         Node::With { .. } => infer_error(ast, env, ctx),
         Node::AnonFun { .. } => infer_op(ast, env, ctx),

--- a/src/type_checker/infer/mod.rs
+++ b/src/type_checker/infer/mod.rs
@@ -94,6 +94,7 @@ fn infer(ast: &AST, env: &Environment, ctx: &Context) -> InferResult {
         Node::With { .. } => infer_error(ast, env, ctx),
         Node::AnonFun { .. } => infer_op(ast, env, ctx),
         Node::FunctionCall { .. } | Node::PropertyCall { .. } => infer_call(ast, env, ctx),
+        Node::ConstructorCall { .. } => infer_call(ast, env, ctx),
 
         Node::IdType { .. } => infer_assign(ast, env, ctx),
 

--- a/src/type_checker/infer/operation.rs
+++ b/src/type_checker/infer/operation.rs
@@ -77,7 +77,7 @@ pub fn infer_op(ast: &AST, env: &Environment, ctx: &Context) -> InferResult {
             let ret_ty = ret_ty.expr_ty(&body.pos)?;
 
             let actual_ty = ActualType::AnonFun {
-                args:   arg_types.into_iter().map(|(_, (_, expr_ty))| expr_ty.clone()).collect(),
+                args:   arg_types.into_iter().map(|(_, (_, expr_ty))| expr_ty).collect(),
                 ret_ty: Box::from(ret_ty)
             };
             let nullable_type = NullableType::new(false, &actual_ty);

--- a/src/type_checker/mod.rs
+++ b/src/type_checker/mod.rs
@@ -4,12 +4,14 @@ use std::path::PathBuf;
 use crate::parser::ast::AST;
 use crate::type_checker::context::Context;
 use crate::type_checker::infer::infer_all;
+use crate::type_checker::modify::modify;
 use crate::type_checker::type_result::TypeResults;
 
 pub mod context;
 pub mod environment;
 
 mod infer;
+mod modify;
 mod util;
 
 pub mod type_result;
@@ -35,10 +37,14 @@ pub type CheckInput = (AST, Option<String>, Option<PathBuf>);
 /// // failure examples here
 pub fn check_all(inputs: &[CheckInput]) -> TypeResults {
     let context = Context::try_from(inputs)?.into_with_primitives()?.into_with_std_lib()?;
-    infer_all(inputs, &context)?;
-
-    Ok(inputs
+    let inputs: Vec<CheckInput> = inputs
         .iter()
-        .map(|(node_pos, source, path)| (node_pos.clone(), source.clone(), path.clone()))
-        .collect())
+        .map(|(ast, source, path)| match modify(ast, &context) {
+            Ok(ast) => Ok((ast, source.clone(), path.clone())),
+            Err(err) => Err(err)
+        })
+        .collect::<Result<_, _>>()?;
+
+    infer_all(&inputs, &context)?;
+    Ok(inputs)
 }

--- a/src/type_checker/modify/mod.rs
+++ b/src/type_checker/modify/mod.rs
@@ -1,0 +1,18 @@
+use crate::parser::ast::AST;
+use crate::type_checker::context::Context;
+use crate::type_checker::modify::modifications::constructor::Constructor;
+use crate::type_checker::modify::modifications::Modification;
+use crate::type_checker::type_result::TypeResult;
+
+mod modifications;
+
+pub fn modify(ast: &AST, ctx: &Context) -> TypeResult<AST> {
+    let modifications: Vec<Box<dyn Modification>> = vec![Box::from(Constructor::new())];
+
+    let mut ast = ast.clone();
+    for modification in modifications {
+        ast = modification.modify(&ast, ctx)?;
+    }
+
+    Ok(ast)
+}

--- a/src/type_checker/modify/mod.rs
+++ b/src/type_checker/modify/mod.rs
@@ -11,7 +11,7 @@ pub fn modify(ast: &AST, ctx: &Context) -> TypeResult<AST> {
 
     let mut ast = ast.clone();
     for modification in modifications {
-        ast = modification.modify(&ast, ctx)?;
+        ast = modification.modify(&ast, ctx)?.0;
     }
 
     Ok(ast)

--- a/src/type_checker/modify/modifications/constructor.rs
+++ b/src/type_checker/modify/modifications/constructor.rs
@@ -1,0 +1,38 @@
+use std::convert::TryFrom;
+use std::ops::Deref;
+
+use crate::parser::ast::{Node, AST};
+use crate::type_checker::context::type_name::TypeName;
+use crate::type_checker::context::Context;
+use crate::type_checker::modify::modifications::Modification;
+use crate::type_checker::type_result::TypeResult;
+
+pub struct Constructor;
+
+impl Constructor {
+    pub fn new() -> Constructor { Constructor {} }
+}
+
+impl Modification for Constructor {
+    fn modify(&self, ast: &AST, ctx: &Context) -> TypeResult<AST> {
+        match &ast.node {
+            Node::FunctionCall { name, args } => {
+                let type_name = TypeName::try_from(name.deref())?;
+                let args =
+                    args.iter().map(|arg| self.modify(arg, ctx)).collect::<Result<_, _>>()?;
+
+                match ctx.lookup(&type_name, &ast.pos) {
+                    Ok(_) => Ok(AST {
+                        node: Node::ConstructorCall { name: name.clone(), args },
+                        ..ast.clone()
+                    }),
+                    Err(_) => Ok(AST {
+                        node: Node::FunctionCall { name: name.clone(), args },
+                        ..ast.clone()
+                    })
+                }
+            }
+            _ => self.recursion(ast, &ctx)
+        }
+    }
+}

--- a/src/type_checker/modify/modifications/mod.rs
+++ b/src/type_checker/modify/modifications/mod.rs
@@ -1,0 +1,543 @@
+use crate::parser::ast::{Node, AST};
+use crate::type_checker::context::Context;
+use crate::type_checker::type_result::TypeResult;
+
+pub mod constructor;
+
+pub trait Modification {
+    fn modify(&self, ast: &AST, ctx: &Context) -> TypeResult<AST>;
+
+    fn recursion(&self, ast: &AST, ctx: &Context) -> TypeResult<AST> {
+        match &ast.node {
+            Node::File { pure, comments, imports, modules } => {
+                let comments =
+                    comments.iter().map(|com| self.modify(com, ctx)).collect::<Result<_, _>>()?;
+                let imports =
+                    imports.iter().map(|imp| self.modify(imp, ctx)).collect::<Result<_, _>>()?;
+                let modules = modules
+                    .iter()
+                    .map(|module| self.modify(module, ctx))
+                    .collect::<Result<_, _>>()?;
+                Ok(AST {
+                    node: Node::File { comments, imports, modules, pure: *pure },
+                    ..ast.clone()
+                })
+            }
+            Node::Import { import, _as } => {
+                let import =
+                    import.iter().map(|imp| self.modify(imp, ctx)).collect::<Result<_, _>>()?;
+                let _as = _as.iter().map(|imp| self.modify(imp, ctx)).collect::<Result<_, _>>()?;
+                Ok(AST { node: Node::Import { import, _as }, ..ast.clone() })
+            }
+            Node::FromImport { id, import } => {
+                let id = Box::from(self.modify(id, ctx)?);
+                let import = Box::from(self.modify(import, ctx)?);
+                Ok(AST { node: Node::FromImport { id, import }, ..ast.clone() })
+            }
+            Node::Class { _type, args, parents, body } => {
+                let _type = Box::from(self.modify(_type, ctx)?);
+                let args =
+                    args.iter().map(|arg| self.modify(arg, ctx)).collect::<Result<_, _>>()?;
+                let parents = parents
+                    .iter()
+                    .map(|parent| self.modify(parent, ctx))
+                    .collect::<Result<_, _>>()?;
+                let body = if let Some(body) = body {
+                    Some(Box::from(self.modify(body, ctx)?))
+                } else {
+                    None
+                };
+                Ok(AST { node: Node::Class { _type, args, parents, body }, ..ast.clone() })
+            }
+            Node::Generic { id, isa } => {
+                let id = Box::from(self.modify(id, ctx)?);
+                let isa = if let Some(isa) = isa {
+                    Some(Box::from(self.modify(isa, ctx)?))
+                } else {
+                    None
+                };
+                Ok(AST { node: Node::Generic { id, isa }, ..ast.clone() })
+            }
+            Node::Parent { id, generics, args } => {
+                let id = Box::from(self.modify(id, ctx)?);
+                let generics = generics
+                    .iter()
+                    .map(|generic| self.modify(generic, ctx))
+                    .collect::<Result<_, _>>()?;
+                let args =
+                    args.iter().map(|arg| self.modify(arg, ctx)).collect::<Result<_, _>>()?;
+                Ok(AST { node: Node::Parent { id, generics, args }, ..ast.clone() })
+            }
+            Node::Script { statements } => {
+                let statements = statements
+                    .iter()
+                    .map(|stmt| self.modify(stmt, ctx))
+                    .collect::<Result<_, _>>()?;
+                Ok(AST { node: Node::Script { statements }, ..ast.clone() })
+            }
+            Node::Init => Ok(ast.clone()),
+            Node::Reassign { left, right } => {
+                let left = Box::from(self.modify(left, ctx)?);
+                let right = Box::from(self.modify(right, ctx)?);
+                Ok(AST { node: Node::Reassign { left, right }, ..ast.clone() })
+            }
+            Node::VariableDef { private, id_maybe_type, expression, forward } => {
+                let id_maybe_type = Box::from(self.modify(id_maybe_type, ctx)?);
+                let expression = if let Some(expression) = expression {
+                    Some(Box::from(self.modify(expression, ctx)?))
+                } else {
+                    None
+                };
+                let forward = forward
+                    .iter()
+                    .map(|forward| self.modify(forward, ctx))
+                    .collect::<Result<_, _>>()?;
+                Ok(AST {
+                    node: Node::VariableDef {
+                        private: *private,
+                        id_maybe_type,
+                        expression,
+                        forward
+                    },
+                    ..ast.clone()
+                })
+            }
+            Node::FunDef { pure, private, id, fun_args, ret_ty, raises, body } => {
+                let id = Box::from(self.modify(id, ctx)?);
+                let fun_args =
+                    fun_args.iter().map(|arg| self.modify(arg, ctx)).collect::<Result<_, _>>()?;
+                let ret_ty = if let Some(ret_ty) = ret_ty {
+                    Some(Box::from(self.modify(ret_ty, ctx)?))
+                } else {
+                    None
+                };
+                let raises =
+                    raises.iter().map(|raise| self.modify(raise, ctx)).collect::<Result<_, _>>()?;
+                let body = if let Some(body) = body {
+                    Some(Box::from(self.modify(body, ctx)?))
+                } else {
+                    None
+                };
+                Ok(AST {
+                    node: Node::FunDef {
+                        pure: *pure,
+                        private: *private,
+                        id,
+                        fun_args,
+                        ret_ty,
+                        raises,
+                        body
+                    },
+                    ..ast.clone()
+                })
+            }
+            Node::AnonFun { args, body } => {
+                let args =
+                    args.iter().map(|arg| self.modify(arg, ctx)).collect::<Result<_, _>>()?;
+                let body = Box::from(self.modify(body, ctx)?);
+                Ok(AST { node: Node::AnonFun { args, body }, ..ast.clone() })
+            }
+            Node::Raises { expr_or_stmt, errors } => {
+                let expr_or_stmt = Box::from(self.modify(expr_or_stmt, ctx)?);
+                let errors =
+                    errors.iter().map(|error| self.modify(error, ctx)).collect::<Result<_, _>>()?;
+                Ok(AST { node: Node::Raises { expr_or_stmt, errors }, ..ast.clone() })
+            }
+            Node::Raise { error } => {
+                let error = Box::from(self.modify(error, ctx)?);
+                Ok(AST { node: Node::Raise { error }, ..ast.clone() })
+            }
+            Node::Handle { expr_or_stmt, cases } => {
+                let expr_or_stmt = Box::from(self.modify(expr_or_stmt, ctx)?);
+                let cases =
+                    cases.iter().map(|case| self.modify(case, ctx)).collect::<Result<_, _>>()?;
+                Ok(AST { node: Node::Handle { expr_or_stmt, cases }, ..ast.clone() })
+            }
+            Node::Retry => Ok(ast.clone()),
+            Node::With { resource, _as, expr } => {
+                let resource = Box::from(self.modify(resource, ctx)?);
+                let _as = if let Some(_as) = _as {
+                    Some(Box::from(self.modify(_as, ctx)?))
+                } else {
+                    None
+                };
+                let expr = Box::from(self.modify(expr, ctx)?);
+                Ok(AST { node: Node::With { resource, _as, expr }, ..ast.clone() })
+            }
+            Node::ConstructorCall { name, args } => {
+                let name = Box::from(self.modify(name, ctx)?);
+                let args =
+                    args.iter().map(|arg| self.modify(arg, ctx)).collect::<Result<_, _>>()?;
+                Ok(AST { node: Node::ConstructorCall { name, args }, ..ast.clone() })
+            }
+            Node::FunctionCall { name, args } => {
+                let name = Box::from(self.modify(name, ctx)?);
+                let args =
+                    args.iter().map(|arg| self.modify(arg, ctx)).collect::<Result<_, _>>()?;
+                Ok(AST { node: Node::FunctionCall { name, args }, ..ast.clone() })
+            }
+            Node::PropertyCall { instance, property } => {
+                let instance = Box::from(self.modify(instance, ctx)?);
+                let property = Box::from(self.modify(property, ctx)?);
+                Ok(AST { node: Node::PropertyCall { instance, property }, ..ast.clone() })
+            }
+            Node::Id { .. } => Ok(ast.clone()),
+            Node::IdType { id, mutable, _type } => {
+                let id = Box::from(self.modify(id, ctx)?);
+                let _type = if let Some(_type) = _type {
+                    Some(Box::from(self.modify(_type, ctx)?))
+                } else {
+                    None
+                };
+                Ok(AST { node: Node::IdType { mutable: *mutable, id, _type }, ..ast.clone() })
+            }
+            Node::TypeDef { _type, isa, body } => {
+                let _type = Box::from(self.modify(_type, ctx)?);
+                let isa = if let Some(isa) = isa {
+                    Some(Box::from(self.modify(isa, ctx)?))
+                } else {
+                    None
+                };
+                let body = if let Some(body) = body {
+                    Some(Box::from(self.modify(body, ctx)?))
+                } else {
+                    None
+                };
+                Ok(AST { node: Node::TypeDef { _type, isa, body }, ..ast.clone() })
+            }
+            Node::TypeAlias { _type, isa, conditions } => {
+                let _type = Box::from(self.modify(_type, ctx)?);
+                let isa = Box::from(self.modify(isa, ctx)?);
+                let conditions = conditions
+                    .iter()
+                    .map(|cond| self.modify(cond, ctx))
+                    .collect::<Result<_, _>>()?;
+                Ok(AST { node: Node::TypeAlias { _type, isa, conditions }, ..ast.clone() })
+            }
+            Node::TypeTup { types } => {
+                let types =
+                    types.iter().map(|ty| self.modify(ty, ctx)).collect::<Result<_, _>>()?;
+                Ok(AST { node: Node::TypeTup { types }, ..ast.clone() })
+            }
+            Node::TypeUnion { types } => {
+                let types =
+                    types.iter().map(|ty| self.modify(ty, ctx)).collect::<Result<_, _>>()?;
+                Ok(AST { node: Node::TypeUnion { types }, ..ast.clone() })
+            }
+            Node::Type { id, generics } => {
+                let id = Box::from(self.modify(id, ctx)?);
+                let generics = generics
+                    .iter()
+                    .map(|generic| self.modify(generic, ctx))
+                    .collect::<Result<_, _>>()?;
+                Ok(AST { node: Node::Type { id, generics }, ..ast.clone() })
+            }
+            Node::TypeFun { args, ret_ty } => {
+                let args =
+                    args.iter().map(|arg| self.modify(arg, ctx)).collect::<Result<_, _>>()?;
+                let ret_ty = Box::from(self.modify(ret_ty, ctx)?);
+                Ok(AST { node: Node::TypeFun { args, ret_ty }, ..ast.clone() })
+            }
+            Node::Condition { cond, _else } => {
+                let cond = Box::from(self.modify(cond, ctx)?);
+                let _else = if let Some(_else) = _else {
+                    Some(Box::from(self.modify(_else, ctx)?))
+                } else {
+                    None
+                };
+                Ok(AST { node: Node::Condition { cond, _else }, ..ast.clone() })
+            }
+            Node::FunArg { vararg, id_maybe_type, default } => {
+                let id_maybe_type = Box::from(self.modify(id_maybe_type, ctx)?);
+                let default = if let Some(default) = default {
+                    Some(Box::from(self.modify(default, ctx)?))
+                } else {
+                    None
+                };
+                Ok(AST {
+                    node: Node::FunArg { vararg: *vararg, id_maybe_type, default },
+                    ..ast.clone()
+                })
+            }
+            Node::_Self => Ok(ast.clone()),
+            Node::AddOp => Ok(ast.clone()),
+            Node::SubOp => Ok(ast.clone()),
+            Node::SqrtOp => Ok(ast.clone()),
+            Node::MulOp => Ok(ast.clone()),
+            Node::FDivOp => Ok(ast.clone()),
+            Node::DivOp => Ok(ast.clone()),
+            Node::PowOp => Ok(ast.clone()),
+            Node::ModOp => Ok(ast.clone()),
+            Node::EqOp => Ok(ast.clone()),
+            Node::LeOp => Ok(ast.clone()),
+            Node::GeOp => Ok(ast.clone()),
+            Node::SetBuilder { item, conditions } => {
+                let item = Box::from(self.modify(item, ctx)?);
+                let conditions = conditions
+                    .iter()
+                    .map(|cond| self.modify(cond, ctx))
+                    .collect::<Result<_, _>>()?;
+                Ok(AST { node: Node::SetBuilder { item, conditions }, ..ast.clone() })
+            }
+            Node::ListBuilder { item, conditions } => {
+                let item = Box::from(self.modify(item, ctx)?);
+                let conditions = conditions
+                    .iter()
+                    .map(|cond| self.modify(cond, ctx))
+                    .collect::<Result<_, _>>()?;
+                Ok(AST { node: Node::SetBuilder { item, conditions }, ..ast.clone() })
+            }
+            Node::Set { elements } => {
+                let elements =
+                    elements.iter().map(|el| self.modify(el, ctx)).collect::<Result<_, _>>()?;
+                Ok(AST { node: Node::Set { elements }, ..ast.clone() })
+            }
+            Node::List { elements } => {
+                let elements =
+                    elements.iter().map(|el| self.modify(el, ctx)).collect::<Result<_, _>>()?;
+                Ok(AST { node: Node::List { elements }, ..ast.clone() })
+            }
+            Node::Tuple { elements } => {
+                let elements =
+                    elements.iter().map(|el| self.modify(el, ctx)).collect::<Result<_, _>>()?;
+                Ok(AST { node: Node::Tuple { elements }, ..ast.clone() })
+            }
+            Node::Range { from, to, inclusive, step } => {
+                let from = Box::from(self.modify(from, ctx)?);
+                let to = Box::from(self.modify(to, ctx)?);
+                let step = if let Some(step) = step {
+                    Some(Box::from(self.modify(step, ctx)?))
+                } else {
+                    None
+                };
+                Ok(AST {
+                    node: Node::Range { from, to, inclusive: *inclusive, step },
+                    ..ast.clone()
+                })
+            }
+            Node::Block { statements } => {
+                let statements = statements
+                    .iter()
+                    .map(|stmt| self.modify(stmt, ctx))
+                    .collect::<Result<_, _>>()?;
+                Ok(AST { node: Node::Block { statements }, ..ast.clone() })
+            }
+            Node::Real { .. } => Ok(ast.clone()),
+            Node::Int { .. } => Ok(ast.clone()),
+            Node::ENum { .. } => Ok(ast.clone()),
+            Node::Str { lit, expressions } => {
+                let expressions = expressions
+                    .iter()
+                    .map(|expr| self.modify(expr, ctx))
+                    .collect::<Result<_, _>>()?;
+                Ok(AST { node: Node::Str { lit: lit.clone(), expressions }, ..ast.clone() })
+            }
+            Node::Bool { .. } => Ok(ast.clone()),
+            Node::Add { left, right } => {
+                let left = Box::from(self.modify(left, ctx)?);
+                let right = Box::from(self.modify(right, ctx)?);
+                Ok(AST { node: Node::Add { left, right }, ..ast.clone() })
+            }
+            Node::Sub { left, right } => {
+                let left = Box::from(self.modify(left, ctx)?);
+                let right = Box::from(self.modify(right, ctx)?);
+                Ok(AST { node: Node::Sub { left, right }, ..ast.clone() })
+            }
+            Node::Mul { left, right } => {
+                let left = Box::from(self.modify(left, ctx)?);
+                let right = Box::from(self.modify(right, ctx)?);
+                Ok(AST { node: Node::Mul { left, right }, ..ast.clone() })
+            }
+            Node::Div { left, right } => {
+                let left = Box::from(self.modify(left, ctx)?);
+                let right = Box::from(self.modify(right, ctx)?);
+                Ok(AST { node: Node::Div { left, right }, ..ast.clone() })
+            }
+            Node::FDiv { left, right } => {
+                let left = Box::from(self.modify(left, ctx)?);
+                let right = Box::from(self.modify(right, ctx)?);
+                Ok(AST { node: Node::FDiv { left, right }, ..ast.clone() })
+            }
+            Node::Mod { left, right } => {
+                let left = Box::from(self.modify(left, ctx)?);
+                let right = Box::from(self.modify(right, ctx)?);
+                Ok(AST { node: Node::Mod { left, right }, ..ast.clone() })
+            }
+            Node::Pow { left, right } => {
+                let left = Box::from(self.modify(left, ctx)?);
+                let right = Box::from(self.modify(right, ctx)?);
+                Ok(AST { node: Node::Pow { left, right }, ..ast.clone() })
+            }
+            Node::BAnd { left, right } => {
+                let left = Box::from(self.modify(left, ctx)?);
+                let right = Box::from(self.modify(right, ctx)?);
+                Ok(AST { node: Node::BAnd { left, right }, ..ast.clone() })
+            }
+            Node::BOr { left, right } => {
+                let left = Box::from(self.modify(left, ctx)?);
+                let right = Box::from(self.modify(right, ctx)?);
+                Ok(AST { node: Node::BOr { left, right }, ..ast.clone() })
+            }
+            Node::BXOr { left, right } => {
+                let left = Box::from(self.modify(left, ctx)?);
+                let right = Box::from(self.modify(right, ctx)?);
+                Ok(AST { node: Node::BXOr { left, right }, ..ast.clone() })
+            }
+            Node::BLShift { left, right } => {
+                let left = Box::from(self.modify(left, ctx)?);
+                let right = Box::from(self.modify(right, ctx)?);
+                Ok(AST { node: Node::BLShift { left, right }, ..ast.clone() })
+            }
+            Node::BRShift { left, right } => {
+                let left = Box::from(self.modify(left, ctx)?);
+                let right = Box::from(self.modify(right, ctx)?);
+                Ok(AST { node: Node::BRShift { left, right }, ..ast.clone() })
+            }
+            Node::Le { left, right } => {
+                let left = Box::from(self.modify(left, ctx)?);
+                let right = Box::from(self.modify(right, ctx)?);
+                Ok(AST { node: Node::Le { left, right }, ..ast.clone() })
+            }
+            Node::Ge { left, right } => {
+                let left = Box::from(self.modify(left, ctx)?);
+                let right = Box::from(self.modify(right, ctx)?);
+                Ok(AST { node: Node::Ge { left, right }, ..ast.clone() })
+            }
+            Node::Leq { left, right } => {
+                let left = Box::from(self.modify(left, ctx)?);
+                let right = Box::from(self.modify(right, ctx)?);
+                Ok(AST { node: Node::Leq { left, right }, ..ast.clone() })
+            }
+            Node::Geq { left, right } => {
+                let left = Box::from(self.modify(left, ctx)?);
+                let right = Box::from(self.modify(right, ctx)?);
+                Ok(AST { node: Node::Geq { left, right }, ..ast.clone() })
+            }
+            Node::Is { left, right } => {
+                let left = Box::from(self.modify(left, ctx)?);
+                let right = Box::from(self.modify(right, ctx)?);
+                Ok(AST { node: Node::Is { left, right }, ..ast.clone() })
+            }
+            Node::IsN { left, right } => {
+                let left = Box::from(self.modify(left, ctx)?);
+                let right = Box::from(self.modify(right, ctx)?);
+                Ok(AST { node: Node::IsN { left, right }, ..ast.clone() })
+            }
+            Node::Eq { left, right } => {
+                let left = Box::from(self.modify(left, ctx)?);
+                let right = Box::from(self.modify(right, ctx)?);
+                Ok(AST { node: Node::Eq { left, right }, ..ast.clone() })
+            }
+            Node::Neq { left, right } => {
+                let left = Box::from(self.modify(left, ctx)?);
+                let right = Box::from(self.modify(right, ctx)?);
+                Ok(AST { node: Node::Neq { left, right }, ..ast.clone() })
+            }
+            Node::IsA { left, right } => {
+                let left = Box::from(self.modify(left, ctx)?);
+                let right = Box::from(self.modify(right, ctx)?);
+                Ok(AST { node: Node::IsA { left, right }, ..ast.clone() })
+            }
+            Node::IsNA { left, right } => {
+                let left = Box::from(self.modify(left, ctx)?);
+                let right = Box::from(self.modify(right, ctx)?);
+                Ok(AST { node: Node::IsNA { left, right }, ..ast.clone() })
+            }
+            Node::And { left, right } => {
+                let left = Box::from(self.modify(left, ctx)?);
+                let right = Box::from(self.modify(right, ctx)?);
+                Ok(AST { node: Node::And { left, right }, ..ast.clone() })
+            }
+            Node::Or { left, right } => {
+                let left = Box::from(self.modify(left, ctx)?);
+                let right = Box::from(self.modify(right, ctx)?);
+                Ok(AST { node: Node::Or { left, right }, ..ast.clone() })
+            }
+            Node::BOneCmpl { expr } => {
+                let expr = Box::from(self.modify(expr, ctx)?);
+                Ok(AST { node: Node::BOneCmpl { expr }, ..ast.clone() })
+            }
+            Node::Sqrt { expr } => {
+                let expr = Box::from(self.modify(expr, ctx)?);
+                Ok(AST { node: Node::Sqrt { expr }, ..ast.clone() })
+            }
+            Node::SubU { expr } => {
+                let expr = Box::from(self.modify(expr, ctx)?);
+                Ok(AST { node: Node::SubU { expr }, ..ast.clone() })
+            }
+            Node::AddU { expr } => {
+                let expr = Box::from(self.modify(expr, ctx)?);
+                Ok(AST { node: Node::AddU { expr }, ..ast.clone() })
+            }
+            Node::Not { expr } => {
+                let expr = Box::from(self.modify(expr, ctx)?);
+                Ok(AST { node: Node::Not { expr }, ..ast.clone() })
+            }
+            Node::IfElse { cond, then, _else } => {
+                let cond = Box::from(self.modify(cond, ctx)?);
+                let then = Box::from(self.modify(then, ctx)?);
+                let _else = if let Some(_else) = _else {
+                    Some(Box::from(self.modify(_else, ctx)?))
+                } else {
+                    None
+                };
+                Ok(AST { node: Node::IfElse { cond, then, _else }, ..ast.clone() })
+            }
+            Node::Match { cond, cases } => {
+                let cond = Box::from(self.modify(cond, ctx)?);
+                let cases =
+                    cases.iter().map(|case| self.modify(case, ctx)).collect::<Result<_, _>>()?;
+                Ok(AST { node: Node::Match { cond, cases }, ..ast.clone() })
+            }
+            Node::Case { cond, body } => {
+                let cond = Box::from(self.modify(cond, ctx)?);
+                let body = Box::from(self.modify(body, ctx)?);
+                Ok(AST { node: Node::Case { cond, body }, ..ast.clone() })
+            }
+            Node::For { expr, col, body } => {
+                let expr = Box::from(self.modify(expr, ctx)?);
+                let col = Box::from(self.modify(col, ctx)?);
+                let body = Box::from(self.modify(body, ctx)?);
+                Ok(AST { node: Node::For { expr, col, body }, ..ast.clone() })
+            }
+            Node::In { left, right } => {
+                let left = Box::from(self.modify(left, ctx)?);
+                let right = Box::from(self.modify(right, ctx)?);
+                Ok(AST { node: Node::In { left, right }, ..ast.clone() })
+            }
+            Node::Step { amount } => {
+                let amount = Box::from(self.modify(amount, ctx)?);
+                Ok(AST { node: Node::Step { amount }, ..ast.clone() })
+            }
+            Node::While { cond, body } => {
+                let cond = Box::from(self.modify(cond, ctx)?);
+                let body = Box::from(self.modify(body, ctx)?);
+                Ok(AST { node: Node::While { cond, body }, ..ast.clone() })
+            }
+            Node::Break => Ok(ast.clone()),
+            Node::Continue => Ok(ast.clone()),
+            Node::Return { expr } => {
+                let expr = Box::from(self.modify(expr, ctx)?);
+                Ok(AST { node: Node::Return { expr }, ..ast.clone() })
+            }
+            Node::ReturnEmpty => Ok(ast.clone()),
+            Node::Underscore => Ok(ast.clone()),
+            Node::Undefined => Ok(ast.clone()),
+            Node::Pass => Ok(ast.clone()),
+            Node::Question { left, right } => {
+                let left = Box::from(self.modify(left, ctx)?);
+                let right = Box::from(self.modify(right, ctx)?);
+                Ok(AST { node: Node::Question { left, right }, ..ast.clone() })
+            }
+            Node::QuestionOp { expr } => {
+                let expr = Box::from(self.modify(expr, ctx)?);
+                Ok(AST { node: Node::QuestionOp { expr }, ..ast.clone() })
+            }
+            Node::Print { expr } => {
+                let expr = Box::from(self.modify(expr, ctx)?);
+                Ok(AST { node: Node::Print { expr }, ..ast.clone() })
+            }
+            Node::Comment { .. } => Ok(ast.clone())
+        }
+    }
+}

--- a/src/type_checker/modify/modifications/mod.rs
+++ b/src/type_checker/modify/modifications/mod.rs
@@ -49,17 +49,9 @@ pub trait Modification {
         }
 
         match &ast.node {
-            Node::File { pure, comments, imports, modules } => {
-                let (comments, m_comments) = vec_recursion!(comments);
-                let (imports, m_imports) = vec_recursion!(imports);
+            Node::File { pure, modules } => {
                 let (modules, m_modules) = vec_recursion!(modules);
-                Ok((
-                    AST {
-                        node: Node::File { comments, imports, modules, pure: *pure },
-                        ..ast.clone()
-                    },
-                    m_comments || m_imports || m_modules
-                ))
+                Ok((AST { node: Node::File { modules, pure: *pure }, ..ast.clone() }, m_modules))
             }
             Node::Import { import, _as } => {
                 let (import, m_import) = vec_recursion!(import);
@@ -410,7 +402,8 @@ pub trait Modification {
             Node::Question { left, right } => inner!(Question, left, right),
             Node::QuestionOp { expr } => inner!(QuestionOp, expr),
             Node::Print { expr } => inner!(Print, expr),
-            Node::Comment { .. } => Ok((ast.clone(), false))
+            Node::Comment { .. } => Ok((ast.clone(), false)),
+            Node::DocStr { .. } => Ok((ast.clone(), false))
         }
     }
 }

--- a/src/type_checker/modify/modifications/mod.rs
+++ b/src/type_checker/modify/modifications/mod.rs
@@ -5,539 +5,412 @@ use crate::type_checker::type_result::TypeResult;
 pub mod constructor;
 
 pub trait Modification {
-    fn modify(&self, ast: &AST, ctx: &Context) -> TypeResult<AST>;
+    fn modify(&self, ast: &AST, ctx: &Context) -> TypeResult<(AST, bool)>;
 
-    fn recursion(&self, ast: &AST, ctx: &Context) -> TypeResult<AST> {
+    fn recursion(&self, ast: &AST, ctx: &Context) -> TypeResult<(AST, bool)> {
+        macro_rules! modify {
+            ($ast:expr) => {{
+                let (expr, m_expr) = self.modify($ast, ctx)?;
+                (Box::from(expr), m_expr)
+            }};
+        }
+
+        macro_rules! inner {
+            ($node:ident, $left:expr, $right:expr) => {{
+                let (left, m_left) = modify!($left);
+                let (right, m_right) = modify!($right);
+                Ok((AST { node: Node::$node { left, right }, ..ast.clone() }, m_left || m_right))
+            }};
+            ($node:ident, $expr:expr) => {{
+                let (expr, m_expr) = modify!($expr);
+                Ok((AST { node: Node::$node { expr }, ..ast.clone() }, m_expr))
+            }};
+        }
+
+        macro_rules! vec_recursion {
+            ($vec:expr) => {{
+                let scanned: Vec<(AST, bool)> =
+                    $vec.iter().map(|com| self.modify(com, ctx)).collect::<Result<_, _>>()?;
+                let (asts, modified): (Vec<AST>, Vec<bool>) = scanned.into_iter().unzip();
+                let modified = modified.iter().any(|b| b.clone());
+                (asts, modified)
+            }};
+        }
+
+        macro_rules! optional {
+            ($expr:expr) => {{
+                if let Some(expr) = $expr {
+                    let (expr, m_expr): (Box<AST>, bool) = modify!(expr);
+                    (Some(expr), m_expr)
+                } else {
+                    (None, false)
+                }
+            }};
+        }
+
         match &ast.node {
             Node::File { pure, comments, imports, modules } => {
-                let comments =
-                    comments.iter().map(|com| self.modify(com, ctx)).collect::<Result<_, _>>()?;
-                let imports =
-                    imports.iter().map(|imp| self.modify(imp, ctx)).collect::<Result<_, _>>()?;
-                let modules = modules
-                    .iter()
-                    .map(|module| self.modify(module, ctx))
-                    .collect::<Result<_, _>>()?;
-                Ok(AST {
-                    node: Node::File { comments, imports, modules, pure: *pure },
-                    ..ast.clone()
-                })
+                let (comments, m_comments) = vec_recursion!(comments);
+                let (imports, m_imports) = vec_recursion!(imports);
+                let (modules, m_modules) = vec_recursion!(modules);
+                Ok((
+                    AST {
+                        node: Node::File { comments, imports, modules, pure: *pure },
+                        ..ast.clone()
+                    },
+                    m_comments || m_imports || m_modules
+                ))
             }
             Node::Import { import, _as } => {
-                let import =
-                    import.iter().map(|imp| self.modify(imp, ctx)).collect::<Result<_, _>>()?;
-                let _as = _as.iter().map(|imp| self.modify(imp, ctx)).collect::<Result<_, _>>()?;
-                Ok(AST { node: Node::Import { import, _as }, ..ast.clone() })
+                let (import, m_import) = vec_recursion!(import);
+                let (_as, m_as) = vec_recursion!(_as);
+                Ok((AST { node: Node::Import { import, _as }, ..ast.clone() }, m_import || m_as))
             }
             Node::FromImport { id, import } => {
-                let id = Box::from(self.modify(id, ctx)?);
-                let import = Box::from(self.modify(import, ctx)?);
-                Ok(AST { node: Node::FromImport { id, import }, ..ast.clone() })
+                let (id, m_id) = modify!(id);
+                let (import, m_import) = modify!(import);
+                Ok((AST { node: Node::FromImport { id, import }, ..ast.clone() }, m_id || m_import))
             }
             Node::Class { _type, args, parents, body } => {
-                let _type = Box::from(self.modify(_type, ctx)?);
-                let args =
-                    args.iter().map(|arg| self.modify(arg, ctx)).collect::<Result<_, _>>()?;
-                let parents = parents
-                    .iter()
-                    .map(|parent| self.modify(parent, ctx))
-                    .collect::<Result<_, _>>()?;
-                let body = if let Some(body) = body {
-                    Some(Box::from(self.modify(body, ctx)?))
-                } else {
-                    None
-                };
-                Ok(AST { node: Node::Class { _type, args, parents, body }, ..ast.clone() })
+                let (_type, m_type) = modify!(_type);
+                let (args, m_args) = vec_recursion!(args);
+                let (parents, m_parents) = vec_recursion!(parents);
+                let (body, m_body) = optional!(body);
+                Ok((
+                    AST { node: Node::Class { _type, args, parents, body }, ..ast.clone() },
+                    m_type || m_args || m_parents || m_body
+                ))
             }
             Node::Generic { id, isa } => {
-                let id = Box::from(self.modify(id, ctx)?);
-                let isa = if let Some(isa) = isa {
-                    Some(Box::from(self.modify(isa, ctx)?))
-                } else {
-                    None
-                };
-                Ok(AST { node: Node::Generic { id, isa }, ..ast.clone() })
+                let (id, m_id) = modify!(id);
+                let (isa, m_isa) = optional!(isa);
+                Ok((AST { node: Node::Generic { id, isa }, ..ast.clone() }, m_id || m_isa))
             }
             Node::Parent { id, generics, args } => {
-                let id = Box::from(self.modify(id, ctx)?);
-                let generics = generics
-                    .iter()
-                    .map(|generic| self.modify(generic, ctx))
-                    .collect::<Result<_, _>>()?;
-                let args =
-                    args.iter().map(|arg| self.modify(arg, ctx)).collect::<Result<_, _>>()?;
-                Ok(AST { node: Node::Parent { id, generics, args }, ..ast.clone() })
+                let (id, m_id) = modify!(id);
+                let (generics, m_generics) = vec_recursion!(generics);
+                let (args, m_args) = vec_recursion!(args);
+                Ok((
+                    AST { node: Node::Parent { id, generics, args }, ..ast.clone() },
+                    m_id || m_generics || m_args
+                ))
             }
             Node::Script { statements } => {
-                let statements = statements
-                    .iter()
-                    .map(|stmt| self.modify(stmt, ctx))
-                    .collect::<Result<_, _>>()?;
-                Ok(AST { node: Node::Script { statements }, ..ast.clone() })
+                let (statements, m_statements) = vec_recursion!(statements);
+                Ok((AST { node: Node::Script { statements }, ..ast.clone() }, m_statements))
             }
-            Node::Init => Ok(ast.clone()),
+            Node::Init => Ok((ast.clone(), false)),
             Node::Reassign { left, right } => {
-                let left = Box::from(self.modify(left, ctx)?);
-                let right = Box::from(self.modify(right, ctx)?);
-                Ok(AST { node: Node::Reassign { left, right }, ..ast.clone() })
+                let (left, m_left) = modify!(left);
+                let (right, m_right) = modify!(right);
+                Ok((AST { node: Node::Reassign { left, right }, ..ast.clone() }, m_left || m_right))
             }
             Node::VariableDef { private, id_maybe_type, expression, forward } => {
-                let id_maybe_type = Box::from(self.modify(id_maybe_type, ctx)?);
-                let expression = if let Some(expression) = expression {
-                    Some(Box::from(self.modify(expression, ctx)?))
-                } else {
-                    None
-                };
-                let forward = forward
-                    .iter()
-                    .map(|forward| self.modify(forward, ctx))
-                    .collect::<Result<_, _>>()?;
-                Ok(AST {
-                    node: Node::VariableDef {
-                        private: *private,
-                        id_maybe_type,
-                        expression,
-                        forward
+                let (id_maybe_type, m_id_maybe_type) = modify!(id_maybe_type);
+                let (expression, m_expression) = optional!(expression);
+                let (forward, m_forward) = vec_recursion!(forward);
+                Ok((
+                    AST {
+                        node: Node::VariableDef {
+                            private: *private,
+                            id_maybe_type,
+                            expression,
+                            forward
+                        },
+                        ..ast.clone()
                     },
-                    ..ast.clone()
-                })
+                    m_id_maybe_type || m_expression || m_forward
+                ))
             }
             Node::FunDef { pure, private, id, fun_args, ret_ty, raises, body } => {
-                let id = Box::from(self.modify(id, ctx)?);
-                let fun_args =
-                    fun_args.iter().map(|arg| self.modify(arg, ctx)).collect::<Result<_, _>>()?;
-                let ret_ty = if let Some(ret_ty) = ret_ty {
-                    Some(Box::from(self.modify(ret_ty, ctx)?))
-                } else {
-                    None
-                };
-                let raises =
-                    raises.iter().map(|raise| self.modify(raise, ctx)).collect::<Result<_, _>>()?;
-                let body = if let Some(body) = body {
-                    Some(Box::from(self.modify(body, ctx)?))
-                } else {
-                    None
-                };
-                Ok(AST {
-                    node: Node::FunDef {
-                        pure: *pure,
-                        private: *private,
-                        id,
-                        fun_args,
-                        ret_ty,
-                        raises,
-                        body
+                let (id, m_id) = modify!(id);
+                let (fun_args, m_fun_args) = vec_recursion!(fun_args);
+                let (ret_ty, m_ret_ty) = optional!(ret_ty);
+                let (raises, m_raises) = vec_recursion!(raises);
+                let (body, m_body) = optional!(body);
+                Ok((
+                    AST {
+                        node: Node::FunDef {
+                            pure: *pure,
+                            private: *private,
+                            id,
+                            fun_args,
+                            ret_ty,
+                            raises,
+                            body
+                        },
+                        ..ast.clone()
                     },
-                    ..ast.clone()
-                })
+                    m_id || m_fun_args || m_ret_ty || m_raises || m_body
+                ))
             }
             Node::AnonFun { args, body } => {
-                let args =
-                    args.iter().map(|arg| self.modify(arg, ctx)).collect::<Result<_, _>>()?;
-                let body = Box::from(self.modify(body, ctx)?);
-                Ok(AST { node: Node::AnonFun { args, body }, ..ast.clone() })
+                let (args, m_args) = vec_recursion!(args);
+                let (body, m_body) = modify!(body);
+                Ok((AST { node: Node::AnonFun { args, body }, ..ast.clone() }, m_args || m_body))
             }
             Node::Raises { expr_or_stmt, errors } => {
-                let expr_or_stmt = Box::from(self.modify(expr_or_stmt, ctx)?);
-                let errors =
-                    errors.iter().map(|error| self.modify(error, ctx)).collect::<Result<_, _>>()?;
-                Ok(AST { node: Node::Raises { expr_or_stmt, errors }, ..ast.clone() })
+                let (expr_or_stmt, m_expr_or_stmt) = modify!(expr_or_stmt);
+                let (errors, m_errors) = vec_recursion!(errors);
+                Ok((
+                    AST { node: Node::Raises { expr_or_stmt, errors }, ..ast.clone() },
+                    m_expr_or_stmt || m_errors
+                ))
             }
             Node::Raise { error } => {
-                let error = Box::from(self.modify(error, ctx)?);
-                Ok(AST { node: Node::Raise { error }, ..ast.clone() })
+                let (error, m_error) = modify!(error);
+                Ok((AST { node: Node::Raise { error }, ..ast.clone() }, m_error))
             }
             Node::Handle { expr_or_stmt, cases } => {
-                let expr_or_stmt = Box::from(self.modify(expr_or_stmt, ctx)?);
-                let cases =
-                    cases.iter().map(|case| self.modify(case, ctx)).collect::<Result<_, _>>()?;
-                Ok(AST { node: Node::Handle { expr_or_stmt, cases }, ..ast.clone() })
+                let (expr_or_stmt, m_expr_or_stmt) = modify!(expr_or_stmt);
+                let (cases, m_cases) = vec_recursion!(cases);
+                Ok((
+                    AST { node: Node::Handle { expr_or_stmt, cases }, ..ast.clone() },
+                    m_expr_or_stmt || m_cases
+                ))
             }
-            Node::Retry => Ok(ast.clone()),
             Node::With { resource, _as, expr } => {
-                let resource = Box::from(self.modify(resource, ctx)?);
-                let _as = if let Some(_as) = _as {
-                    Some(Box::from(self.modify(_as, ctx)?))
-                } else {
-                    None
-                };
-                let expr = Box::from(self.modify(expr, ctx)?);
-                Ok(AST { node: Node::With { resource, _as, expr }, ..ast.clone() })
+                let (resource, m_resource) = modify!(resource);
+                let (_as, m_as) = optional!(_as);
+                let (expr, m_expr) = modify!(expr);
+                Ok((
+                    AST { node: Node::With { resource, _as, expr }, ..ast.clone() },
+                    m_resource || m_as || m_expr
+                ))
             }
             Node::ConstructorCall { name, args } => {
-                let name = Box::from(self.modify(name, ctx)?);
-                let args =
-                    args.iter().map(|arg| self.modify(arg, ctx)).collect::<Result<_, _>>()?;
-                Ok(AST { node: Node::ConstructorCall { name, args }, ..ast.clone() })
+                let (name, m_name) = modify!(name);
+                let (args, m_args) = vec_recursion!(args);
+                Ok((
+                    AST { node: Node::ConstructorCall { name, args }, ..ast.clone() },
+                    m_name || m_args
+                ))
             }
             Node::FunctionCall { name, args } => {
-                let name = Box::from(self.modify(name, ctx)?);
-                let args =
-                    args.iter().map(|arg| self.modify(arg, ctx)).collect::<Result<_, _>>()?;
-                Ok(AST { node: Node::FunctionCall { name, args }, ..ast.clone() })
+                let (name, m_name) = modify!(name);
+                let (args, m_args) = vec_recursion!(args);
+                Ok((
+                    AST { node: Node::FunctionCall { name, args }, ..ast.clone() },
+                    m_name || m_args
+                ))
             }
             Node::PropertyCall { instance, property } => {
-                let instance = Box::from(self.modify(instance, ctx)?);
-                let property = Box::from(self.modify(property, ctx)?);
-                Ok(AST { node: Node::PropertyCall { instance, property }, ..ast.clone() })
+                let (instance, m_instance) = modify!(instance);
+                let (property, m_property) = modify!(property);
+                Ok((
+                    AST { node: Node::PropertyCall { instance, property }, ..ast.clone() },
+                    m_instance || m_property
+                ))
             }
-            Node::Id { .. } => Ok(ast.clone()),
+            Node::Id { .. } => Ok((ast.clone(), false)),
             Node::IdType { id, mutable, _type } => {
-                let id = Box::from(self.modify(id, ctx)?);
-                let _type = if let Some(_type) = _type {
-                    Some(Box::from(self.modify(_type, ctx)?))
-                } else {
-                    None
-                };
-                Ok(AST { node: Node::IdType { mutable: *mutable, id, _type }, ..ast.clone() })
+                let (id, m_id) = modify!(id);
+                let (_type, m_type) = optional!(_type);
+                Ok((
+                    AST { node: Node::IdType { mutable: *mutable, id, _type }, ..ast.clone() },
+                    m_id || m_type
+                ))
             }
             Node::TypeDef { _type, isa, body } => {
-                let _type = Box::from(self.modify(_type, ctx)?);
-                let isa = if let Some(isa) = isa {
-                    Some(Box::from(self.modify(isa, ctx)?))
-                } else {
-                    None
-                };
-                let body = if let Some(body) = body {
-                    Some(Box::from(self.modify(body, ctx)?))
-                } else {
-                    None
-                };
-                Ok(AST { node: Node::TypeDef { _type, isa, body }, ..ast.clone() })
+                let (_type, m_type) = modify!(_type);
+                let (isa, m_isa) = optional!(isa);
+                let (body, m_body) = optional!(body);
+                Ok((
+                    AST { node: Node::TypeDef { _type, isa, body }, ..ast.clone() },
+                    m_type || m_isa || m_body
+                ))
             }
             Node::TypeAlias { _type, isa, conditions } => {
-                let _type = Box::from(self.modify(_type, ctx)?);
-                let isa = Box::from(self.modify(isa, ctx)?);
-                let conditions = conditions
-                    .iter()
-                    .map(|cond| self.modify(cond, ctx))
-                    .collect::<Result<_, _>>()?;
-                Ok(AST { node: Node::TypeAlias { _type, isa, conditions }, ..ast.clone() })
+                let (_type, m_type) = modify!(_type);
+                let (isa, m_isa) = modify!(isa);
+                let (conditions, m_conditions) = vec_recursion!(conditions);
+                Ok((
+                    AST { node: Node::TypeAlias { _type, isa, conditions }, ..ast.clone() },
+                    m_type || m_isa || m_conditions
+                ))
             }
             Node::TypeTup { types } => {
-                let types =
-                    types.iter().map(|ty| self.modify(ty, ctx)).collect::<Result<_, _>>()?;
-                Ok(AST { node: Node::TypeTup { types }, ..ast.clone() })
+                let (types, m_types) = vec_recursion!(types);
+                Ok((AST { node: Node::TypeTup { types }, ..ast.clone() }, m_types))
             }
             Node::TypeUnion { types } => {
-                let types =
-                    types.iter().map(|ty| self.modify(ty, ctx)).collect::<Result<_, _>>()?;
-                Ok(AST { node: Node::TypeUnion { types }, ..ast.clone() })
+                let (types, m_types) = vec_recursion!(types);
+                Ok((AST { node: Node::TypeUnion { types }, ..ast.clone() }, m_types))
             }
             Node::Type { id, generics } => {
-                let id = Box::from(self.modify(id, ctx)?);
-                let generics = generics
-                    .iter()
-                    .map(|generic| self.modify(generic, ctx))
-                    .collect::<Result<_, _>>()?;
-                Ok(AST { node: Node::Type { id, generics }, ..ast.clone() })
+                let (id, m_id) = modify!(id);
+                let (generics, m_generics) = vec_recursion!(generics);
+                Ok((AST { node: Node::Type { id, generics }, ..ast.clone() }, m_id || m_generics))
             }
             Node::TypeFun { args, ret_ty } => {
-                let args =
-                    args.iter().map(|arg| self.modify(arg, ctx)).collect::<Result<_, _>>()?;
-                let ret_ty = Box::from(self.modify(ret_ty, ctx)?);
-                Ok(AST { node: Node::TypeFun { args, ret_ty }, ..ast.clone() })
+                let (args, m_args) = vec_recursion!(args);
+                let (ret_ty, m_ret_ty) = modify!(ret_ty);
+                Ok((
+                    AST { node: Node::TypeFun { args, ret_ty }, ..ast.clone() },
+                    m_args || m_ret_ty
+                ))
             }
             Node::Condition { cond, _else } => {
-                let cond = Box::from(self.modify(cond, ctx)?);
-                let _else = if let Some(_else) = _else {
-                    Some(Box::from(self.modify(_else, ctx)?))
-                } else {
-                    None
-                };
-                Ok(AST { node: Node::Condition { cond, _else }, ..ast.clone() })
+                let (cond, m_cond) = modify!(cond);
+                let (_else, m_else) = optional!(_else);
+                Ok((AST { node: Node::Condition { cond, _else }, ..ast.clone() }, m_cond || m_else))
             }
             Node::FunArg { vararg, id_maybe_type, default } => {
-                let id_maybe_type = Box::from(self.modify(id_maybe_type, ctx)?);
-                let default = if let Some(default) = default {
-                    Some(Box::from(self.modify(default, ctx)?))
-                } else {
-                    None
-                };
-                Ok(AST {
-                    node: Node::FunArg { vararg: *vararg, id_maybe_type, default },
-                    ..ast.clone()
-                })
+                let (id_maybe_type, m_id_maybe_type) = modify!(id_maybe_type);
+                let (default, m_default) = optional!(default);
+                Ok((
+                    AST {
+                        node: Node::FunArg { vararg: *vararg, id_maybe_type, default },
+                        ..ast.clone()
+                    },
+                    m_id_maybe_type || m_default
+                ))
             }
-            Node::_Self => Ok(ast.clone()),
-            Node::AddOp => Ok(ast.clone()),
-            Node::SubOp => Ok(ast.clone()),
-            Node::SqrtOp => Ok(ast.clone()),
-            Node::MulOp => Ok(ast.clone()),
-            Node::FDivOp => Ok(ast.clone()),
-            Node::DivOp => Ok(ast.clone()),
-            Node::PowOp => Ok(ast.clone()),
-            Node::ModOp => Ok(ast.clone()),
-            Node::EqOp => Ok(ast.clone()),
-            Node::LeOp => Ok(ast.clone()),
-            Node::GeOp => Ok(ast.clone()),
+            Node::_Self => Ok((ast.clone(), false)),
+            Node::AddOp => Ok((ast.clone(), false)),
+            Node::SubOp => Ok((ast.clone(), false)),
+            Node::SqrtOp => Ok((ast.clone(), false)),
+            Node::MulOp => Ok((ast.clone(), false)),
+            Node::FDivOp => Ok((ast.clone(), false)),
+            Node::DivOp => Ok((ast.clone(), false)),
+            Node::PowOp => Ok((ast.clone(), false)),
+            Node::ModOp => Ok((ast.clone(), false)),
+            Node::EqOp => Ok((ast.clone(), false)),
+            Node::LeOp => Ok((ast.clone(), false)),
+            Node::GeOp => Ok((ast.clone(), false)),
             Node::SetBuilder { item, conditions } => {
-                let item = Box::from(self.modify(item, ctx)?);
-                let conditions = conditions
-                    .iter()
-                    .map(|cond| self.modify(cond, ctx))
-                    .collect::<Result<_, _>>()?;
-                Ok(AST { node: Node::SetBuilder { item, conditions }, ..ast.clone() })
+                let (item, m_item) = modify!(item);
+                let (conditions, m_conditions) = vec_recursion!(conditions);
+                Ok((
+                    AST { node: Node::SetBuilder { item, conditions }, ..ast.clone() },
+                    m_item || m_conditions
+                ))
             }
             Node::ListBuilder { item, conditions } => {
-                let item = Box::from(self.modify(item, ctx)?);
-                let conditions = conditions
-                    .iter()
-                    .map(|cond| self.modify(cond, ctx))
-                    .collect::<Result<_, _>>()?;
-                Ok(AST { node: Node::SetBuilder { item, conditions }, ..ast.clone() })
+                let (item, m_item) = modify!(item);
+                let (conditions, m_conditions) = vec_recursion!(conditions);
+                Ok((
+                    AST { node: Node::ListBuilder { item, conditions }, ..ast.clone() },
+                    m_item || m_conditions
+                ))
             }
             Node::Set { elements } => {
-                let elements =
-                    elements.iter().map(|el| self.modify(el, ctx)).collect::<Result<_, _>>()?;
-                Ok(AST { node: Node::Set { elements }, ..ast.clone() })
+                let (elements, m_elements) = vec_recursion!(elements);
+                Ok((AST { node: Node::Set { elements }, ..ast.clone() }, m_elements))
             }
             Node::List { elements } => {
-                let elements =
-                    elements.iter().map(|el| self.modify(el, ctx)).collect::<Result<_, _>>()?;
-                Ok(AST { node: Node::List { elements }, ..ast.clone() })
+                let (elements, m_elements) = vec_recursion!(elements);
+                Ok((AST { node: Node::List { elements }, ..ast.clone() }, m_elements))
             }
             Node::Tuple { elements } => {
-                let elements =
-                    elements.iter().map(|el| self.modify(el, ctx)).collect::<Result<_, _>>()?;
-                Ok(AST { node: Node::Tuple { elements }, ..ast.clone() })
+                let (elements, m_elements) = vec_recursion!(elements);
+                Ok((AST { node: Node::Tuple { elements }, ..ast.clone() }, m_elements))
             }
             Node::Range { from, to, inclusive, step } => {
-                let from = Box::from(self.modify(from, ctx)?);
-                let to = Box::from(self.modify(to, ctx)?);
-                let step = if let Some(step) = step {
-                    Some(Box::from(self.modify(step, ctx)?))
-                } else {
-                    None
-                };
-                Ok(AST {
-                    node: Node::Range { from, to, inclusive: *inclusive, step },
-                    ..ast.clone()
-                })
+                let (from, m_from) = modify!(from);
+                let (to, m_to) = modify!(to);
+                let (step, m_step) = optional!(step);
+                Ok((
+                    AST {
+                        node: Node::Range { from, to, inclusive: *inclusive, step },
+                        ..ast.clone()
+                    },
+                    m_from || m_to || m_step
+                ))
             }
             Node::Block { statements } => {
-                let statements = statements
-                    .iter()
-                    .map(|stmt| self.modify(stmt, ctx))
-                    .collect::<Result<_, _>>()?;
-                Ok(AST { node: Node::Block { statements }, ..ast.clone() })
+                let (statements, m_statements) = vec_recursion!(statements);
+                Ok((AST { node: Node::Block { statements }, ..ast.clone() }, m_statements))
             }
-            Node::Real { .. } => Ok(ast.clone()),
-            Node::Int { .. } => Ok(ast.clone()),
-            Node::ENum { .. } => Ok(ast.clone()),
+            Node::Real { .. } => Ok((ast.clone(), false)),
+            Node::Int { .. } => Ok((ast.clone(), false)),
+            Node::ENum { .. } => Ok((ast.clone(), false)),
             Node::Str { lit, expressions } => {
-                let expressions = expressions
-                    .iter()
-                    .map(|expr| self.modify(expr, ctx))
-                    .collect::<Result<_, _>>()?;
-                Ok(AST { node: Node::Str { lit: lit.clone(), expressions }, ..ast.clone() })
+                let (expressions, m_expressions) = vec_recursion!(expressions);
+                Ok((
+                    AST { node: Node::Str { lit: lit.clone(), expressions }, ..ast.clone() },
+                    m_expressions
+                ))
             }
-            Node::Bool { .. } => Ok(ast.clone()),
-            Node::Add { left, right } => {
-                let left = Box::from(self.modify(left, ctx)?);
-                let right = Box::from(self.modify(right, ctx)?);
-                Ok(AST { node: Node::Add { left, right }, ..ast.clone() })
-            }
-            Node::Sub { left, right } => {
-                let left = Box::from(self.modify(left, ctx)?);
-                let right = Box::from(self.modify(right, ctx)?);
-                Ok(AST { node: Node::Sub { left, right }, ..ast.clone() })
-            }
-            Node::Mul { left, right } => {
-                let left = Box::from(self.modify(left, ctx)?);
-                let right = Box::from(self.modify(right, ctx)?);
-                Ok(AST { node: Node::Mul { left, right }, ..ast.clone() })
-            }
-            Node::Div { left, right } => {
-                let left = Box::from(self.modify(left, ctx)?);
-                let right = Box::from(self.modify(right, ctx)?);
-                Ok(AST { node: Node::Div { left, right }, ..ast.clone() })
-            }
-            Node::FDiv { left, right } => {
-                let left = Box::from(self.modify(left, ctx)?);
-                let right = Box::from(self.modify(right, ctx)?);
-                Ok(AST { node: Node::FDiv { left, right }, ..ast.clone() })
-            }
-            Node::Mod { left, right } => {
-                let left = Box::from(self.modify(left, ctx)?);
-                let right = Box::from(self.modify(right, ctx)?);
-                Ok(AST { node: Node::Mod { left, right }, ..ast.clone() })
-            }
-            Node::Pow { left, right } => {
-                let left = Box::from(self.modify(left, ctx)?);
-                let right = Box::from(self.modify(right, ctx)?);
-                Ok(AST { node: Node::Pow { left, right }, ..ast.clone() })
-            }
-            Node::BAnd { left, right } => {
-                let left = Box::from(self.modify(left, ctx)?);
-                let right = Box::from(self.modify(right, ctx)?);
-                Ok(AST { node: Node::BAnd { left, right }, ..ast.clone() })
-            }
-            Node::BOr { left, right } => {
-                let left = Box::from(self.modify(left, ctx)?);
-                let right = Box::from(self.modify(right, ctx)?);
-                Ok(AST { node: Node::BOr { left, right }, ..ast.clone() })
-            }
-            Node::BXOr { left, right } => {
-                let left = Box::from(self.modify(left, ctx)?);
-                let right = Box::from(self.modify(right, ctx)?);
-                Ok(AST { node: Node::BXOr { left, right }, ..ast.clone() })
-            }
-            Node::BLShift { left, right } => {
-                let left = Box::from(self.modify(left, ctx)?);
-                let right = Box::from(self.modify(right, ctx)?);
-                Ok(AST { node: Node::BLShift { left, right }, ..ast.clone() })
-            }
-            Node::BRShift { left, right } => {
-                let left = Box::from(self.modify(left, ctx)?);
-                let right = Box::from(self.modify(right, ctx)?);
-                Ok(AST { node: Node::BRShift { left, right }, ..ast.clone() })
-            }
-            Node::Le { left, right } => {
-                let left = Box::from(self.modify(left, ctx)?);
-                let right = Box::from(self.modify(right, ctx)?);
-                Ok(AST { node: Node::Le { left, right }, ..ast.clone() })
-            }
-            Node::Ge { left, right } => {
-                let left = Box::from(self.modify(left, ctx)?);
-                let right = Box::from(self.modify(right, ctx)?);
-                Ok(AST { node: Node::Ge { left, right }, ..ast.clone() })
-            }
-            Node::Leq { left, right } => {
-                let left = Box::from(self.modify(left, ctx)?);
-                let right = Box::from(self.modify(right, ctx)?);
-                Ok(AST { node: Node::Leq { left, right }, ..ast.clone() })
-            }
-            Node::Geq { left, right } => {
-                let left = Box::from(self.modify(left, ctx)?);
-                let right = Box::from(self.modify(right, ctx)?);
-                Ok(AST { node: Node::Geq { left, right }, ..ast.clone() })
-            }
-            Node::Is { left, right } => {
-                let left = Box::from(self.modify(left, ctx)?);
-                let right = Box::from(self.modify(right, ctx)?);
-                Ok(AST { node: Node::Is { left, right }, ..ast.clone() })
-            }
-            Node::IsN { left, right } => {
-                let left = Box::from(self.modify(left, ctx)?);
-                let right = Box::from(self.modify(right, ctx)?);
-                Ok(AST { node: Node::IsN { left, right }, ..ast.clone() })
-            }
-            Node::Eq { left, right } => {
-                let left = Box::from(self.modify(left, ctx)?);
-                let right = Box::from(self.modify(right, ctx)?);
-                Ok(AST { node: Node::Eq { left, right }, ..ast.clone() })
-            }
-            Node::Neq { left, right } => {
-                let left = Box::from(self.modify(left, ctx)?);
-                let right = Box::from(self.modify(right, ctx)?);
-                Ok(AST { node: Node::Neq { left, right }, ..ast.clone() })
-            }
-            Node::IsA { left, right } => {
-                let left = Box::from(self.modify(left, ctx)?);
-                let right = Box::from(self.modify(right, ctx)?);
-                Ok(AST { node: Node::IsA { left, right }, ..ast.clone() })
-            }
-            Node::IsNA { left, right } => {
-                let left = Box::from(self.modify(left, ctx)?);
-                let right = Box::from(self.modify(right, ctx)?);
-                Ok(AST { node: Node::IsNA { left, right }, ..ast.clone() })
-            }
-            Node::And { left, right } => {
-                let left = Box::from(self.modify(left, ctx)?);
-                let right = Box::from(self.modify(right, ctx)?);
-                Ok(AST { node: Node::And { left, right }, ..ast.clone() })
-            }
-            Node::Or { left, right } => {
-                let left = Box::from(self.modify(left, ctx)?);
-                let right = Box::from(self.modify(right, ctx)?);
-                Ok(AST { node: Node::Or { left, right }, ..ast.clone() })
-            }
-            Node::BOneCmpl { expr } => {
-                let expr = Box::from(self.modify(expr, ctx)?);
-                Ok(AST { node: Node::BOneCmpl { expr }, ..ast.clone() })
-            }
-            Node::Sqrt { expr } => {
-                let expr = Box::from(self.modify(expr, ctx)?);
-                Ok(AST { node: Node::Sqrt { expr }, ..ast.clone() })
-            }
-            Node::SubU { expr } => {
-                let expr = Box::from(self.modify(expr, ctx)?);
-                Ok(AST { node: Node::SubU { expr }, ..ast.clone() })
-            }
-            Node::AddU { expr } => {
-                let expr = Box::from(self.modify(expr, ctx)?);
-                Ok(AST { node: Node::AddU { expr }, ..ast.clone() })
-            }
-            Node::Not { expr } => {
-                let expr = Box::from(self.modify(expr, ctx)?);
-                Ok(AST { node: Node::Not { expr }, ..ast.clone() })
-            }
+            Node::Bool { .. } => Ok((ast.clone(), false)),
+            Node::Add { left, right } => inner!(Add, left, right),
+            Node::Sub { left, right } => inner!(Sub, left, right),
+            Node::Mul { left, right } => inner!(Mul, left, right),
+            Node::Div { left, right } => inner!(Div, left, right),
+            Node::FDiv { left, right } => inner!(FDiv, left, right),
+            Node::Mod { left, right } => inner!(Mod, left, right),
+            Node::Pow { left, right } => inner!(Pow, left, right),
+            Node::BAnd { left, right } => inner!(BAnd, left, right),
+            Node::BOr { left, right } => inner!(BOr, left, right),
+            Node::BXOr { left, right } => inner!(BXOr, left, right),
+            Node::BLShift { left, right } => inner!(BLShift, left, right),
+            Node::BRShift { left, right } => inner!(BRShift, left, right),
+            Node::Le { left, right } => inner!(Le, left, right),
+            Node::Ge { left, right } => inner!(Ge, left, right),
+            Node::Leq { left, right } => inner!(Leq, left, right),
+            Node::Geq { left, right } => inner!(Geq, left, right),
+            Node::Is { left, right } => inner!(Is, left, right),
+            Node::IsN { left, right } => inner!(IsN, left, right),
+            Node::Eq { left, right } => inner!(Eq, left, right),
+            Node::Neq { left, right } => inner!(Neq, left, right),
+            Node::IsA { left, right } => inner!(IsA, left, right),
+            Node::IsNA { left, right } => inner!(IsNA, left, right),
+            Node::And { left, right } => inner!(And, left, right),
+            Node::Or { left, right } => inner!(Or, left, right),
+            Node::BOneCmpl { expr } => inner!(BOneCmpl, expr),
+            Node::Sqrt { expr } => inner!(Sqrt, expr),
+            Node::SubU { expr } => inner!(SubU, expr),
+            Node::AddU { expr } => inner!(AddU, expr),
+            Node::Not { expr } => inner!(Not, expr),
             Node::IfElse { cond, then, _else } => {
-                let cond = Box::from(self.modify(cond, ctx)?);
-                let then = Box::from(self.modify(then, ctx)?);
-                let _else = if let Some(_else) = _else {
-                    Some(Box::from(self.modify(_else, ctx)?))
-                } else {
-                    None
-                };
-                Ok(AST { node: Node::IfElse { cond, then, _else }, ..ast.clone() })
+                let (cond, m_cond) = modify!(cond);
+                let (then, m_then) = modify!(then);
+                let (_else, m_else) = optional!(_else);
+                Ok((
+                    AST { node: Node::IfElse { cond, then, _else }, ..ast.clone() },
+                    m_cond || m_then || m_else
+                ))
             }
             Node::Match { cond, cases } => {
-                let cond = Box::from(self.modify(cond, ctx)?);
-                let cases =
-                    cases.iter().map(|case| self.modify(case, ctx)).collect::<Result<_, _>>()?;
-                Ok(AST { node: Node::Match { cond, cases }, ..ast.clone() })
+                let (cond, m_cond) = modify!(cond);
+                let (cases, m_cases) = vec_recursion!(cases);
+                Ok((AST { node: Node::Match { cond, cases }, ..ast.clone() }, m_cond || m_cases))
             }
             Node::Case { cond, body } => {
-                let cond = Box::from(self.modify(cond, ctx)?);
-                let body = Box::from(self.modify(body, ctx)?);
-                Ok(AST { node: Node::Case { cond, body }, ..ast.clone() })
+                let (cond, m_cond) = modify!(cond);
+                let (body, m_body) = modify!(body);
+                Ok((AST { node: Node::Case { cond, body }, ..ast.clone() }, m_cond || m_body))
             }
             Node::For { expr, col, body } => {
-                let expr = Box::from(self.modify(expr, ctx)?);
-                let col = Box::from(self.modify(col, ctx)?);
-                let body = Box::from(self.modify(body, ctx)?);
-                Ok(AST { node: Node::For { expr, col, body }, ..ast.clone() })
+                let (expr, m_expr) = modify!(expr);
+                let (col, m_col) = modify!(col);
+                let (body, m_body) = modify!(body);
+                Ok((
+                    AST { node: Node::For { expr, col, body }, ..ast.clone() },
+                    m_expr || m_col || m_body
+                ))
             }
-            Node::In { left, right } => {
-                let left = Box::from(self.modify(left, ctx)?);
-                let right = Box::from(self.modify(right, ctx)?);
-                Ok(AST { node: Node::In { left, right }, ..ast.clone() })
-            }
+            Node::In { left, right } => inner!(In, left, right),
             Node::Step { amount } => {
-                let amount = Box::from(self.modify(amount, ctx)?);
-                Ok(AST { node: Node::Step { amount }, ..ast.clone() })
+                let (amount, modified) = modify!(amount);
+                Ok((AST { node: Node::Step { amount }, ..ast.clone() }, modified))
             }
             Node::While { cond, body } => {
-                let cond = Box::from(self.modify(cond, ctx)?);
-                let body = Box::from(self.modify(body, ctx)?);
-                Ok(AST { node: Node::While { cond, body }, ..ast.clone() })
+                let (cond, m_cond) = modify!(cond);
+                let (body, m_body) = modify!(body);
+                Ok((AST { node: Node::While { cond, body }, ..ast.clone() }, m_cond || m_body))
             }
-            Node::Break => Ok(ast.clone()),
-            Node::Continue => Ok(ast.clone()),
-            Node::Return { expr } => {
-                let expr = Box::from(self.modify(expr, ctx)?);
-                Ok(AST { node: Node::Return { expr }, ..ast.clone() })
-            }
-            Node::ReturnEmpty => Ok(ast.clone()),
-            Node::Underscore => Ok(ast.clone()),
-            Node::Undefined => Ok(ast.clone()),
-            Node::Pass => Ok(ast.clone()),
-            Node::Question { left, right } => {
-                let left = Box::from(self.modify(left, ctx)?);
-                let right = Box::from(self.modify(right, ctx)?);
-                Ok(AST { node: Node::Question { left, right }, ..ast.clone() })
-            }
-            Node::QuestionOp { expr } => {
-                let expr = Box::from(self.modify(expr, ctx)?);
-                Ok(AST { node: Node::QuestionOp { expr }, ..ast.clone() })
-            }
-            Node::Print { expr } => {
-                let expr = Box::from(self.modify(expr, ctx)?);
-                Ok(AST { node: Node::Print { expr }, ..ast.clone() })
-            }
-            Node::Comment { .. } => Ok(ast.clone())
+            Node::Break => Ok((ast.clone(), false)),
+            Node::Continue => Ok((ast.clone(), false)),
+            Node::Return { expr } => inner!(Return, expr),
+            Node::ReturnEmpty => Ok((ast.clone(), false)),
+            Node::Underscore => Ok((ast.clone(), false)),
+            Node::Undefined => Ok((ast.clone(), false)),
+            Node::Pass => Ok((ast.clone(), false)),
+            Node::Question { left, right } => inner!(Question, left, right),
+            Node::QuestionOp { expr } => inner!(QuestionOp, expr),
+            Node::Print { expr } => inner!(Print, expr),
+            Node::Comment { .. } => Ok((ast.clone(), false))
         }
     }
 }

--- a/src/type_checker/resources/primitives/bool.py
+++ b/src/type_checker/resources/primitives/bool.py
@@ -1,5 +1,5 @@
 class bool:
-    def __init__(self): pass
+    def __init__(self, arg: bool): pass
 
     def __bool__(self) -> bool: pass
     def __str__(self) -> str: pass

--- a/src/type_checker/resources/primitives/float.py
+++ b/src/type_checker/resources/primitives/float.py
@@ -1,4 +1,6 @@
 class float:
+    def __init__(self, arg: float): pass
+
     def __add__(self, other: int) -> float: pass
     def __add__(self, other: float) -> float: pass
     def __add__(self, other: complex) -> complex: pass

--- a/src/type_checker/resources/primitives/int.py
+++ b/src/type_checker/resources/primitives/int.py
@@ -1,4 +1,6 @@
 class int:
+    def __init__(self, arg: int): pass
+
     def __add__(self, other: int) -> int: pass
     def __add__(self, other: float) -> float: pass
     def __add__(self, other: complex) -> complex: pass

--- a/src/type_checker/resources/primitives/string.py
+++ b/src/type_checker/resources/primitives/string.py
@@ -1,9 +1,11 @@
 class str:
-    def __add__(self, other: int) -> string: pass
-    def __add__(self, other: float) -> string: pass
-    def __add__(self, other: complex) -> string: pass
-    def __add__(self, other: bool) -> string: pass
-    def __add__(self, other: string) -> string: pass
+    def __init__(self, arg: str): pass
+
+    def __add__(self, other: int) -> str: pass
+    def __add__(self, other: float) -> str: pass
+    def __add__(self, other: complex) -> str: pass
+    def __add__(self, other: bool) -> str: pass
+    def __add__(self, other: string) -> str: pass
     def __str__(self) -> str: pass
 
     def __iter__(self) -> str_iterator: pass

--- a/src/type_checker/resources/std_lib/collection.py
+++ b/src/type_checker/resources/std_lib/collection.py
@@ -1,4 +1,4 @@
-from typing import TypeVar, Generic
+from typing import TypeVar, Generic, Union
 
 class set(Generic[T]):
     def __init__(self): pass

--- a/src/type_checker/resources/std_lib/exception.py
+++ b/src/type_checker/resources/std_lib/exception.py
@@ -1,3 +1,4 @@
 class Exception:
-    def __init__(self): pass
+    def __init__(self, msg: str=''): pass
+
     def __str__(self) -> str: pass

--- a/tests/desugar/expression_and_statements.rs
+++ b/tests/desugar/expression_and_statements.rs
@@ -100,10 +100,3 @@ fn raises_empty_verify() {
     });
     assert_eq!(desugar(&type_def).unwrap(), Core::Id { lit: String::from("a") });
 }
-
-#[test]
-fn retry_verify() {
-    let retry = to_pos!(Node::Retry);
-    let result = desugar(&retry);
-    assert!(result.is_err());
-}

--- a/tests/lexer/lexer.rs
+++ b/tests/lexer/lexer.rs
@@ -95,9 +95,9 @@ fn fstring() {
     let source = String::from("\"my string {my_var}\"");
     let tokens = tokenize(&source).unwrap();
     assert_eq!(tokens, vec![Lex {
-        pos:   Position::new(&CaretPos::new(1, 1), &CaretPos::new(1, 19)),
+        pos:   Position::new(&CaretPos::new(1, 1), &CaretPos::new(1, 21)),
         token: Token::Str(String::from("my string {my_var}"), vec![vec![Lex {
-            pos:   Position::new(&CaretPos::new(1, 12), &CaretPos::new(1, 18)),
+            pos:   Position::new(&CaretPos::new(1, 13), &CaretPos::new(1, 19)),
             token: Token::Id(String::from("my_var"))
         }]],)
     },]);
@@ -108,26 +108,26 @@ fn fstring_set() {
     let source = String::from("\"{{a, b}}\"");
     let tokens = tokenize(&source).unwrap();
     assert_eq!(tokens, vec![Lex {
-        pos:   Position::new(&CaretPos::new(1, 1), &CaretPos::new(1, 9)),
+        pos:   Position::new(&CaretPos::new(1, 1), &CaretPos::new(1, 11)),
         token: Token::Str(String::from("{{a, b}}"), vec![vec![
             Lex {
-                pos:   Position::new(&CaretPos::new(1, 2), &CaretPos::new(1, 3)),
+                pos:   Position::new(&CaretPos::new(1, 3), &CaretPos::new(1, 4)),
                 token: Token::LCBrack
             },
             Lex {
-                pos:   Position::new(&CaretPos::new(1, 3), &CaretPos::new(1, 4)),
+                pos:   Position::new(&CaretPos::new(1, 4), &CaretPos::new(1, 5)),
                 token: Token::Id(String::from("a"))
             },
             Lex {
-                pos:   Position::new(&CaretPos::new(1, 4), &CaretPos::new(1, 5)),
+                pos:   Position::new(&CaretPos::new(1, 5), &CaretPos::new(1, 6)),
                 token: Token::Comma
             },
             Lex {
-                pos:   Position::new(&CaretPos::new(1, 6), &CaretPos::new(1, 7)),
+                pos:   Position::new(&CaretPos::new(1, 7), &CaretPos::new(1, 8)),
                 token: Token::Id(String::from("b"))
             },
             Lex {
-                pos:   Position::new(&CaretPos::new(1, 7), &CaretPos::new(1, 8)),
+                pos:   Position::new(&CaretPos::new(1, 8), &CaretPos::new(1, 9)),
                 token: Token::RCBrack
             }
         ]])
@@ -139,18 +139,18 @@ fn fstring_operation() {
     let source = String::from("\"{a + b}\"");
     let tokens = tokenize(&source).unwrap();
     assert_eq!(tokens, vec![Lex {
-        pos:   Position::new(&CaretPos::new(1, 1), &CaretPos::new(1, 8)),
+        pos:   Position::new(&CaretPos::new(1, 1), &CaretPos::new(1, 10)),
         token: Token::Str(String::from("{a + b}"), vec![vec![
             Lex {
-                pos:   Position::new(&CaretPos::new(1, 2), &CaretPos::new(1, 3)),
+                pos:   Position::new(&CaretPos::new(1, 3), &CaretPos::new(1, 4)),
                 token: Token::Id(String::from("a"))
             },
             Lex {
-                pos:   Position::new(&CaretPos::new(1, 4), &CaretPos::new(1, 5)),
+                pos:   Position::new(&CaretPos::new(1, 5), &CaretPos::new(1, 6)),
                 token: Token::Add
             },
             Lex {
-                pos:   Position::new(&CaretPos::new(1, 6), &CaretPos::new(1, 7)),
+                pos:   Position::new(&CaretPos::new(1, 7), &CaretPos::new(1, 8)),
                 token: Token::Id(String::from("b"))
             }
         ]])

--- a/tests/output/mod.rs
+++ b/tests/output/mod.rs
@@ -1,3 +1,40 @@
+use crate::common::{exists_and_delete, python_src_to_stmts, resource_content, resource_path};
+use crate::output::common::PYTHON;
+use mamba::pipeline::transpile_directory;
+use std::path::Path;
+use std::process::Command;
+
 mod common;
 
 pub mod valid;
+
+fn test_directory(
+    valid: bool,
+    input: &[&str],
+    output: &[&str],
+    file_name: &str
+) -> Result<(), Vec<(String, String)>> {
+    transpile_directory(
+        &Path::new(&resource_path(valid, input, "")),
+        Some(&format!("{}.mamba", file_name)),
+        None
+    )?;
+
+    let cmd = Command::new(PYTHON)
+        .arg("-m")
+        .arg("py_compile")
+        .arg(resource_path(true, output, &format!("{}.py", file_name)))
+        .output()
+        .unwrap();
+    if cmd.status.code().unwrap() != 0 {
+        panic!("{}", String::from_utf8(cmd.stderr).unwrap());
+    }
+
+    let python_src = resource_content(true, input, &format!("{}_check.py", file_name));
+    let out_src = resource_content(true, output, &format!("{}.py", file_name));
+    let python_ast = python_src_to_stmts(&python_src);
+    let out_ast = python_src_to_stmts(&out_src);
+
+    assert_eq!(out_ast, python_ast);
+    Ok(assert!(exists_and_delete(true, output, &format!("{}.py", file_name))))
+}

--- a/tests/output/valid/class.rs
+++ b/tests/output/valid/class.rs
@@ -1,122 +1,27 @@
-extern crate python_parser;
-
-use crate::common::exists_and_delete;
-use crate::common::python_src_to_stmts;
-use crate::common::resource_content;
-use crate::common::resource_path;
-use crate::output::common::PYTHON;
-use mamba::pipeline::transpile_directory;
-use std::path::Path;
-use std::process::Command;
+use crate::output::test_directory;
 
 #[test]
 #[ignore]
 fn generics_ast_verify() -> Result<(), Vec<(String, String)>> {
-    transpile_directory(
-        &Path::new(&resource_path(true, &["class"], "")),
-        Some("generics.mamba"),
-        None
-    )?;
-    let cmd = Command::new(PYTHON)
-        .arg("-m")
-        .arg("py_compile")
-        .arg(resource_path(true, &["class", "target"], "generics.py"))
-        .output()
-        .unwrap();
-    if cmd.status.code().unwrap() != 0 {
-        panic!("{}", String::from_utf8(cmd.stderr).unwrap());
-    }
-
-    let python_src = resource_content(true, &["class"], "generics_check.py");
-    let out_src = resource_content(true, &["class", "target"], "generics.py");
-
-    let python_ast = python_src_to_stmts(&python_src);
-    let out_ast = python_src_to_stmts(&out_src);
-
-    assert_eq!(python_ast, out_ast);
-    Ok(assert!(exists_and_delete(true, &["class", "target"], "generics.py")))
+    test_directory(true, &["class"], &["class", "target"], "generics")
 }
 
 #[test]
 fn import_ast_verify() -> Result<(), Vec<(String, String)>> {
-    transpile_directory(
-        &Path::new(resource_path(true, &["class"], "").as_str()),
-        Some("import.mamba"),
-        None
-    )?;
+    test_directory(true, &["class"], &["class", "target"], "import")
+}
 
-    let cmd = Command::new(PYTHON)
-        .arg("-m")
-        .arg("py_compile")
-        .arg(resource_path(true, &["class", "target"], "import.py"))
-        .output()
-        .unwrap();
-    if cmd.status.code().unwrap() != 0 {
-        panic!("{}", String::from_utf8(cmd.stderr).unwrap());
-    }
-
-    let python_src = resource_content(true, &["class"], "import_check.py");
-    let out_src = resource_content(true, &["class", "target"], "import.py");
-
-    let python_ast = python_src_to_stmts(&python_src);
-    let out_ast = python_src_to_stmts(&out_src);
-
-    assert_eq!(python_ast, out_ast);
-    Ok(assert!(exists_and_delete(true, &["class", "target"], "import.py")))
+#[test]
+fn doc_strings_ast_verify() -> Result<(), Vec<(String, String)>> {
+    test_directory(true, &["class"], &["class", "target"], "doc_strings")
 }
 
 #[test]
 fn parent_ast_verify() -> Result<(), Vec<(String, String)>> {
-    transpile_directory(
-        &Path::new(resource_path(true, &["class"], "").as_str()),
-        Some("parent.mamba"),
-        None
-    )?;
-
-    let cmd = Command::new(PYTHON)
-        .arg("-m")
-        .arg("py_compile")
-        .arg(resource_path(true, &["class", "target"], "parent.py"))
-        .output()
-        .unwrap();
-    if cmd.status.code().unwrap() != 0 {
-        panic!("{}", String::from_utf8(cmd.stderr).unwrap());
-    }
-
-    let python_src = resource_content(true, &["class"], "parent_check.py");
-    let out_src = resource_content(true, &["class", "target"], "parent.py");
-
-    let python_ast = python_src_to_stmts(&python_src);
-    let out_ast = python_src_to_stmts(&out_src);
-
-    assert_eq!(python_ast, out_ast);
-    Ok(assert!(exists_and_delete(true, &["class", "target"], "parent.py")))
+    test_directory(true, &["class"], &["class", "target"], "parent")
 }
 
 #[test]
 fn types_ast_verify() -> Result<(), Vec<(String, String)>> {
-    transpile_directory(
-        &Path::new(resource_path(true, &["class"], "").as_str()),
-        Some("types.mamba"),
-        None
-    )?;
-
-    let cmd = Command::new(PYTHON)
-        .arg("-m")
-        .arg("py_compile")
-        .arg(resource_path(true, &["class", "target"], "types.py"))
-        .output()
-        .unwrap();
-    if cmd.status.code().unwrap() != 0 {
-        panic!("{}", String::from_utf8(cmd.stderr).unwrap());
-    }
-
-    let python_src = resource_content(true, &["class"], "types_check.py");
-    let out_src = resource_content(true, &["class", "target"], "types.py");
-
-    let python_ast = python_src_to_stmts(&python_src);
-    let out_ast = python_src_to_stmts(&out_src);
-
-    assert_eq!(python_ast, out_ast);
-    Ok(assert!(exists_and_delete(true, &["class", "target"], "types.py")))
+    test_directory(true, &["class"], &["class", "target"], "types")
 }

--- a/tests/output/valid/control_flow.rs
+++ b/tests/output/valid/control_flow.rs
@@ -1,122 +1,21 @@
-extern crate python_parser;
-
-use crate::common::exists_and_delete;
-use crate::common::python_src_to_stmts;
-use crate::common::resource_content;
-use crate::common::resource_path;
-use crate::output::common::PYTHON;
-use mamba::pipeline::transpile_directory;
-use std::path::Path;
-use std::process::Command;
+use crate::output::test_directory;
 
 #[test]
 fn for_ast_verify() -> Result<(), Vec<(String, String)>> {
-    transpile_directory(
-        &Path::new(&resource_path(true, &["control_flow"], "")),
-        Some("for_statements.mamba"),
-        None
-    )?;
-
-    let cmd = Command::new(PYTHON)
-        .arg("-m")
-        .arg("py_compile")
-        .arg(resource_path(true, &["control_flow", "target"], "for_statements.py"))
-        .output()
-        .unwrap();
-    if cmd.status.code().unwrap() != 0 {
-        panic!("{}", String::from_utf8(cmd.stderr).unwrap());
-    }
-
-    let python_src = resource_content(true, &["control_flow"], "for_statements_check.py");
-    let out_src = resource_content(true, &["control_flow", "target"], "for_statements.py");
-
-    let python_ast = python_src_to_stmts(&python_src);
-    let out_ast = python_src_to_stmts(&out_src);
-
-    assert_eq!(python_ast, out_ast);
-    Ok(assert!(exists_and_delete(true, &["control_flow", "target"], "for_statements.py")))
+    test_directory(true, &["control_flow"], &["control_flow", "target"], "for_statements")
 }
 
 #[test]
 fn if_ast_verify() -> Result<(), Vec<(String, String)>> {
-    transpile_directory(
-        &Path::new(&resource_path(true, &["control_flow"], "")),
-        Some("if.mamba"),
-        None
-    )?;
-
-    let cmd = Command::new(PYTHON)
-        .arg("-m")
-        .arg("py_compile")
-        .arg(resource_path(true, &["control_flow", "target"], "if.py"))
-        .output()
-        .unwrap();
-    if cmd.status.code().unwrap() != 0 {
-        panic!("{}", String::from_utf8(cmd.stderr).unwrap());
-    }
-
-    let python_src = resource_content(true, &["control_flow"], "if_check.py");
-    let out_src = resource_content(true, &["control_flow", "target"], "if.py");
-
-    let python_ast = python_src_to_stmts(&python_src);
-    let out_ast = python_src_to_stmts(&out_src);
-
-    assert_eq!(python_ast, out_ast);
-    Ok(assert!(exists_and_delete(true, &["control_flow", "target"], "if.py")))
+    test_directory(true, &["control_flow"], &["control_flow", "target"], "if")
 }
 
 #[test]
 fn while_ast_verify() -> Result<(), Vec<(String, String)>> {
-    transpile_directory(
-        &Path::new(&resource_path(true, &["control_flow"], "")),
-        Some("while.mamba"),
-        None
-    )?;
-
-    let cmd = Command::new(PYTHON)
-        .arg("-m")
-        .arg("py_compile")
-        .arg(resource_path(true, &["control_flow", "target"], "while.py"))
-        .output()
-        .unwrap();
-    if cmd.status.code().unwrap() != 0 {
-        panic!("{}", String::from_utf8(cmd.stderr).unwrap());
-    }
-
-    let python_src = resource_content(true, &["control_flow"], "while_check.py");
-    let out_src = resource_content(true, &["control_flow", "target"], "while.py");
-
-    let python_ast = python_src_to_stmts(&python_src);
-    let out_ast = python_src_to_stmts(&out_src);
-
-    assert_eq!(python_ast, out_ast);
-    Ok(assert!(exists_and_delete(true, &["control_flow", "target"], "while.py")))
+    test_directory(true, &["control_flow"], &["control_flow", "target"], "while")
 }
 
 #[test]
 fn match_ast_verify() -> Result<(), Vec<(String, String)>> {
-    transpile_directory(
-        &Path::new(&resource_path(true, &["control_flow"], "")),
-        Some("match.mamba"),
-        None
-    )?;
-
-    let cmd = Command::new(PYTHON)
-        .arg("-m")
-        .arg("py_compile")
-        .arg(resource_path(true, &["control_flow", "target"], "match.py"))
-        .output()
-        .unwrap();
-    if cmd.status.code().unwrap() != 0 {
-        panic!("{}", String::from_utf8(cmd.stderr).unwrap());
-    }
-
-    let python_src = resource_content(true, &["control_flow"], "match_check.py");
-    let out_src = resource_content(true, &["control_flow", "target"], "match.py");
-
-    let python_ast = python_src_to_stmts(&python_src);
-    let out_ast = python_src_to_stmts(&out_src);
-
-    assert_eq!(python_ast, out_ast);
-    Ok(assert!(exists_and_delete(true, &["control_flow", "target"], "match.py")))
+    test_directory(true, &["control_flow"], &["control_flow", "target"], "match")
 }

--- a/tests/output/valid/definition.rs
+++ b/tests/output/valid/definition.rs
@@ -1,33 +1,6 @@
-use crate::common::{exists_and_delete, python_src_to_stmts, resource_content, resource_path};
-use crate::output::common::PYTHON;
-use mamba::pipeline::transpile_directory;
-use std::path::Path;
-use std::process::Command;
+use crate::output::test_directory;
 
 #[test]
 fn long_f_string() -> Result<(), Vec<(String, String)>> {
-    transpile_directory(
-        &Path::new(resource_path(true, &["definition"], "").as_str()),
-        Some("long_f_string.mamba"),
-        None
-    )?;
-
-    let cmd = Command::new(PYTHON)
-        .arg("-m")
-        .arg("py_compile")
-        .arg(resource_path(true, &["definition", "target"], "long_f_string.py"))
-        .output()
-        .unwrap();
-    if cmd.status.code().unwrap() != 0 {
-        panic!("{}", String::from_utf8(cmd.stderr).unwrap());
-    }
-
-    let python_src = resource_content(true, &["definition"], "long_f_string_check.py");
-    let out_src = resource_content(true, &["definition", "target"], "long_f_string.py");
-
-    let python_ast = python_src_to_stmts(&python_src);
-    let out_ast = python_src_to_stmts(&out_src);
-
-    assert_eq!(python_ast, out_ast);
-    Ok(assert!(exists_and_delete(true, &["definition", "target"], "long_f_string.py")))
+    test_directory(true, &["definition"], &["definition", "target"], "long_f_string")
 }

--- a/tests/output/valid/error.rs
+++ b/tests/output/valid/error.rs
@@ -38,6 +38,34 @@ fn handle_ast_verify() -> Result<(), Vec<(String, String)>> {
 }
 
 #[test]
+fn exception_ast_verify() -> Result<(), Vec<(String, String)>> {
+    transpile_directory(
+        &Path::new(&resource_path(true, &["error"], "")),
+        Some("exception.mamba"),
+        None
+    )?;
+
+    let cmd = Command::new(PYTHON)
+        .arg("-m")
+        .arg("py_compile")
+        .arg(resource_path(true, &["error", "target"], "exception.py"))
+        .output()
+        .unwrap();
+    if cmd.status.code().unwrap() != 0 {
+        panic!("{}", String::from_utf8(cmd.stderr).unwrap());
+    }
+
+    let python_src = resource_content(true, &["error"], "exception_check.py");
+    let out_src = resource_content(true, &["error", "target"], "exception.py");
+
+    let python_ast = python_src_to_stmts(&python_src);
+    let out_ast = python_src_to_stmts(&out_src);
+
+    assert_eq!(out_ast, python_ast);
+    Ok(assert!(exists_and_delete(true, &["error", "target"], "exception.py")))
+}
+
+#[test]
 #[ignore]
 fn raise_ast_verify() -> Result<(), Vec<(String, String)>> {
     transpile_directory(

--- a/tests/output/valid/error.rs
+++ b/tests/output/valid/error.rs
@@ -1,123 +1,22 @@
-extern crate python_parser;
-
-use crate::common::exists_and_delete;
-use crate::common::python_src_to_stmts;
-use crate::common::resource_content;
-use crate::common::resource_path;
-use crate::output::common::PYTHON;
-use mamba::pipeline::transpile_directory;
-use std::path::Path;
-use std::process::Command;
+use crate::output::test_directory;
 
 #[test]
 fn handle_ast_verify() -> Result<(), Vec<(String, String)>> {
-    transpile_directory(
-        &Path::new(&resource_path(true, &["error"], "")),
-        Some("handle.mamba"),
-        None
-    )?;
-
-    let cmd = Command::new(PYTHON)
-        .arg("-m")
-        .arg("py_compile")
-        .arg(resource_path(true, &["error", "target"], "handle.py"))
-        .output()
-        .unwrap();
-    if cmd.status.code().unwrap() != 0 {
-        panic!("{}", String::from_utf8(cmd.stderr).unwrap());
-    }
-
-    let python_src = resource_content(true, &["error"], "handle_check.py");
-    let out_src = resource_content(true, &["error", "target"], "handle.py");
-
-    let python_ast = python_src_to_stmts(&python_src);
-    let out_ast = python_src_to_stmts(&out_src);
-
-    assert_eq!(out_ast, python_ast);
-    Ok(assert!(exists_and_delete(true, &["error", "target"], "handle.py")))
+    test_directory(true, &["error"], &["error", "target"], "handle")
 }
 
 #[test]
 fn exception_ast_verify() -> Result<(), Vec<(String, String)>> {
-    transpile_directory(
-        &Path::new(&resource_path(true, &["error"], "")),
-        Some("exception.mamba"),
-        None
-    )?;
-
-    let cmd = Command::new(PYTHON)
-        .arg("-m")
-        .arg("py_compile")
-        .arg(resource_path(true, &["error", "target"], "exception.py"))
-        .output()
-        .unwrap();
-    if cmd.status.code().unwrap() != 0 {
-        panic!("{}", String::from_utf8(cmd.stderr).unwrap());
-    }
-
-    let python_src = resource_content(true, &["error"], "exception_check.py");
-    let out_src = resource_content(true, &["error", "target"], "exception.py");
-
-    let python_ast = python_src_to_stmts(&python_src);
-    let out_ast = python_src_to_stmts(&out_src);
-
-    assert_eq!(out_ast, python_ast);
-    Ok(assert!(exists_and_delete(true, &["error", "target"], "exception.py")))
+    test_directory(true, &["error"], &["error", "target"], "exception")
 }
 
 #[test]
 #[ignore]
 fn raise_ast_verify() -> Result<(), Vec<(String, String)>> {
-    transpile_directory(
-        &Path::new(&resource_path(true, &["error"], "")),
-        Some("raise.mamba"),
-        None
-    )?;
-
-    let cmd = Command::new(PYTHON)
-        .arg("-m")
-        .arg("py_compile")
-        .arg(resource_path(true, &["error", "target"], "raise.py"))
-        .output()
-        .unwrap();
-    if cmd.status.code().unwrap() != 0 {
-        panic!("{}", String::from_utf8(cmd.stderr).unwrap());
-    }
-
-    let python_src = resource_content(true, &["error"], "raise_check.py");
-    let out_src = resource_content(true, &["error", "target"], "raise.py");
-
-    let python_ast = python_src_to_stmts(&python_src);
-    let out_ast = python_src_to_stmts(&out_src);
-
-    assert_eq!(out_ast, python_ast);
-    Ok(assert!(exists_and_delete(true, &["error", "target"], "raise.py")))
+    test_directory(true, &["error"], &["error", "target"], "raise")
 }
 
 #[test]
 fn with_ast_verify() -> Result<(), Vec<(String, String)>> {
-    transpile_directory(
-        &Path::new(&resource_path(true, &["error"], "")),
-        Some("with.mamba"),
-        None
-    )?;
-
-    let cmd = Command::new(PYTHON)
-        .arg("-m")
-        .arg("py_compile")
-        .arg(resource_path(true, &["error", "target"], "with.py"))
-        .output()
-        .unwrap();
-    if cmd.status.code().unwrap() != 0 {
-        panic!("{}", String::from_utf8(cmd.stderr).unwrap());
-    }
-
-    let python_src = resource_content(true, &["error"], "with_check.py");
-    let out_src = resource_content(true, &["error", "target"], "with.py");
-
-    let python_ast = python_src_to_stmts(&python_src);
-    let out_ast = python_src_to_stmts(&out_src);
-
-    assert_eq!(out_ast, python_ast);
-    Ok(assert!(exists_and_delete(true, &["error", "target"], "with.py")))
+    test_directory(true, &["error"], &["error", "target"], "with")
 }

--- a/tests/output/valid/function.rs
+++ b/tests/output/valid/function.rs
@@ -66,3 +66,31 @@ fn definition_ast_verify() -> Result<(), Vec<(String, String)>> {
     assert_eq!(python_ast, out_ast);
     Ok(assert!(exists_and_delete(true, &["function", "target"], "definition.py")))
 }
+
+#[test]
+fn function_with_defaults_ast_verify() -> Result<(), Vec<(String, String)>> {
+    transpile_directory(
+        &Path::new(&resource_path(true, &["function"], "")),
+        Some("function_with_defaults.mamba"),
+        None
+    )?;
+
+    let cmd = Command::new(PYTHON)
+        .arg("-m")
+        .arg("py_compile")
+        .arg(resource_path(true, &["function", "target"], "function_with_defaults.py"))
+        .output()
+        .unwrap();
+    if cmd.status.code().unwrap() != 0 {
+        panic!("{}", String::from_utf8(cmd.stderr).unwrap());
+    }
+
+    let python_src = resource_content(true, &["function"], "function_with_defaults_check.py");
+    let out_src = resource_content(true, &["function", "target"], "function_with_defaults.py");
+
+    let python_ast = python_src_to_stmts(&python_src);
+    let out_ast = python_src_to_stmts(&out_src);
+
+    assert_eq!(python_ast, out_ast);
+    Ok(assert!(exists_and_delete(true, &["function", "target"], "function_with_defaults.py")))
+}

--- a/tests/output/valid/function.rs
+++ b/tests/output/valid/function.rs
@@ -1,96 +1,16 @@
-extern crate python_parser;
-
-use std::path::Path;
-use std::process::Command;
-
-use mamba::pipeline::transpile_directory;
-
-use crate::common::exists_and_delete;
-use crate::common::python_src_to_stmts;
-use crate::common::resource_content;
-use crate::common::resource_path;
-use crate::output::common::PYTHON;
+use crate::output::test_directory;
 
 #[test]
 fn call_ast_verify() -> Result<(), Vec<(String, String)>> {
-    transpile_directory(
-        &Path::new(&resource_path(true, &["function"], "")),
-        Some("calls.mamba"),
-        None
-    )?;
-
-    let cmd = Command::new(PYTHON)
-        .arg("-m")
-        .arg("py_compile")
-        .arg(resource_path(true, &["function", "target"], "calls.py"))
-        .output()
-        .unwrap();
-    if cmd.status.code().unwrap() != 0 {
-        panic!("{}", String::from_utf8(cmd.stderr).unwrap());
-    }
-
-    let python_src = resource_content(true, &["function"], "calls_check.py");
-    let out_src = resource_content(true, &["function", "target"], "calls.py");
-
-    let python_ast = python_src_to_stmts(&python_src);
-    let out_ast = python_src_to_stmts(&out_src);
-
-    assert_eq!(python_ast, out_ast);
-    Ok(assert!(exists_and_delete(true, &["function", "target"], "calls.py")))
+    test_directory(true, &["function"], &["function", "target"], "calls")
 }
 
 #[test]
 fn definition_ast_verify() -> Result<(), Vec<(String, String)>> {
-    transpile_directory(
-        &Path::new(&resource_path(true, &["function"], "")),
-        Some("definition.mamba"),
-        None
-    )?;
-
-    let cmd = Command::new(PYTHON)
-        .arg("-m")
-        .arg("py_compile")
-        .arg(resource_path(true, &["function", "target"], "definition.py"))
-        .output()
-        .unwrap();
-    if cmd.status.code().unwrap() != 0 {
-        panic!("{}", String::from_utf8(cmd.stderr).unwrap());
-    }
-
-    let python_src = resource_content(true, &["function"], "definition_check.py");
-    let out_src = resource_content(true, &["function", "target"], "definition.py");
-
-    let python_ast = python_src_to_stmts(&python_src);
-    let out_ast = python_src_to_stmts(&out_src);
-
-    assert_eq!(python_ast, out_ast);
-    Ok(assert!(exists_and_delete(true, &["function", "target"], "definition.py")))
+    test_directory(true, &["function"], &["function", "target"], "definition")
 }
 
 #[test]
 fn function_with_defaults_ast_verify() -> Result<(), Vec<(String, String)>> {
-    transpile_directory(
-        &Path::new(&resource_path(true, &["function"], "")),
-        Some("function_with_defaults.mamba"),
-        None
-    )?;
-
-    let cmd = Command::new(PYTHON)
-        .arg("-m")
-        .arg("py_compile")
-        .arg(resource_path(true, &["function", "target"], "function_with_defaults.py"))
-        .output()
-        .unwrap();
-    if cmd.status.code().unwrap() != 0 {
-        panic!("{}", String::from_utf8(cmd.stderr).unwrap());
-    }
-
-    let python_src = resource_content(true, &["function"], "function_with_defaults_check.py");
-    let out_src = resource_content(true, &["function", "target"], "function_with_defaults.py");
-
-    let python_ast = python_src_to_stmts(&python_src);
-    let out_ast = python_src_to_stmts(&out_src);
-
-    assert_eq!(python_ast, out_ast);
-    Ok(assert!(exists_and_delete(true, &["function", "target"], "function_with_defaults.py")))
+    test_directory(true, &["function"], &["function", "target"], "function_with_defaults")
 }

--- a/tests/output/valid/operation.rs
+++ b/tests/output/valid/operation.rs
@@ -38,6 +38,34 @@ fn arithmetic_ast_verify() -> Result<(), Vec<(String, String)>> {
 }
 
 #[test]
+fn primitives_ast_verify() -> Result<(), Vec<(String, String)>> {
+    transpile_directory(
+        &Path::new(&resource_path(true, &["operation"], "")),
+        Some("primitives.mamba"),
+        None
+    )?;
+
+    let cmd = Command::new(PYTHON)
+        .arg("-m")
+        .arg("py_compile")
+        .arg(resource_path(true, &["operation", "target"], "primitives.py"))
+        .output()
+        .unwrap();
+    if cmd.status.code().unwrap() != 0 {
+        panic!("{}", String::from_utf8(cmd.stderr).unwrap());
+    }
+
+    let python_src = resource_content(true, &["operation"], "primitives_check.py");
+    let out_src = resource_content(true, &["operation", "target"], "primitives.py");
+
+    let python_ast = python_src_to_stmts(&python_src);
+    let out_ast = python_src_to_stmts(&out_src);
+
+    assert_eq!(python_ast, out_ast);
+    Ok(assert!(exists_and_delete(true, &["operation", "target"], "primitives.py")))
+}
+
+#[test]
 fn bitwise_ast_verify() -> Result<(), Vec<(String, String)>> {
     transpile_directory(
         &Path::new(&resource_path(true, &["operation"], "")),
@@ -89,6 +117,6 @@ fn boolean_ast_verify() -> Result<(), Vec<(String, String)>> {
     let python_ast = python_src_to_stmts(&python_src);
     let out_ast = python_src_to_stmts(&out_src);
 
-    assert_eq!(python_ast, out_ast);
+    assert_eq!(out_ast, python_ast);
     Ok(assert!(exists_and_delete(true, &["operation", "target"], "boolean.py")))
 }

--- a/tests/output/valid/operation.rs
+++ b/tests/output/valid/operation.rs
@@ -1,122 +1,21 @@
-extern crate python_parser;
-
-use crate::common::exists_and_delete;
-use crate::common::python_src_to_stmts;
-use crate::common::resource_content;
-use crate::common::resource_path;
-use crate::output::common::PYTHON;
-use mamba::pipeline::transpile_directory;
-use std::path::Path;
-use std::process::Command;
+use crate::output::test_directory;
 
 #[test]
 fn arithmetic_ast_verify() -> Result<(), Vec<(String, String)>> {
-    transpile_directory(
-        &Path::new(&resource_path(true, &["operation"], "")),
-        Some("arithmetic.mamba"),
-        None
-    )?;
-
-    let cmd = Command::new(PYTHON)
-        .arg("-m")
-        .arg("py_compile")
-        .arg(resource_path(true, &["operation", "target"], "arithmetic.py"))
-        .output()
-        .unwrap();
-    if cmd.status.code().unwrap() != 0 {
-        panic!("{}", String::from_utf8(cmd.stderr).unwrap());
-    }
-
-    let python_src = resource_content(true, &["operation"], "arithmetic_check.py");
-    let out_src = resource_content(true, &["operation", "target"], "arithmetic.py");
-
-    let python_ast = python_src_to_stmts(&python_src);
-    let out_ast = python_src_to_stmts(&out_src);
-
-    assert_eq!(python_ast, out_ast);
-    Ok(assert!(exists_and_delete(true, &["operation", "target"], "arithmetic.py")))
+    test_directory(true, &["operation"], &["operation", "target"], "arithmetic")
 }
 
 #[test]
 fn primitives_ast_verify() -> Result<(), Vec<(String, String)>> {
-    transpile_directory(
-        &Path::new(&resource_path(true, &["operation"], "")),
-        Some("primitives.mamba"),
-        None
-    )?;
-
-    let cmd = Command::new(PYTHON)
-        .arg("-m")
-        .arg("py_compile")
-        .arg(resource_path(true, &["operation", "target"], "primitives.py"))
-        .output()
-        .unwrap();
-    if cmd.status.code().unwrap() != 0 {
-        panic!("{}", String::from_utf8(cmd.stderr).unwrap());
-    }
-
-    let python_src = resource_content(true, &["operation"], "primitives_check.py");
-    let out_src = resource_content(true, &["operation", "target"], "primitives.py");
-
-    let python_ast = python_src_to_stmts(&python_src);
-    let out_ast = python_src_to_stmts(&out_src);
-
-    assert_eq!(python_ast, out_ast);
-    Ok(assert!(exists_and_delete(true, &["operation", "target"], "primitives.py")))
+    test_directory(true, &["operation"], &["operation", "target"], "primitives")
 }
 
 #[test]
 fn bitwise_ast_verify() -> Result<(), Vec<(String, String)>> {
-    transpile_directory(
-        &Path::new(&resource_path(true, &["operation"], "")),
-        Some("bitwise.mamba"),
-        None
-    )?;
-
-    let cmd = Command::new(PYTHON)
-        .arg("-m")
-        .arg("py_compile")
-        .arg(resource_path(true, &["operation", "target"], "bitwise.py"))
-        .output()
-        .unwrap();
-    if cmd.status.code().unwrap() != 0 {
-        panic!("{}", String::from_utf8(cmd.stderr).unwrap());
-    }
-
-    let python_src = resource_content(true, &["operation"], "bitwise_check.py");
-    let out_src = resource_content(true, &["operation", "target"], "bitwise.py");
-
-    let python_ast = python_src_to_stmts(&python_src);
-    let out_ast = python_src_to_stmts(&out_src);
-
-    assert_eq!(python_ast, out_ast);
-    Ok(assert!(exists_and_delete(true, &["operation", "target"], "bitwise.py")))
+    test_directory(true, &["operation"], &["operation", "target"], "bitwise")
 }
 
 #[test]
 fn boolean_ast_verify() -> Result<(), Vec<(String, String)>> {
-    transpile_directory(
-        &Path::new(&resource_path(true, &["operation"], "")),
-        Some("boolean.mamba"),
-        None
-    )?;
-
-    let cmd = Command::new(PYTHON)
-        .arg("-m")
-        .arg("py_compile")
-        .arg(resource_path(true, &["operation", "target"], "boolean.py"))
-        .output()
-        .unwrap();
-    if cmd.status.code().unwrap() != 0 {
-        panic!("{:#?}", String::from_utf8(cmd.stderr).unwrap());
-    }
-
-    let python_src = resource_content(true, &["operation"], "boolean_check.py");
-    let out_src = resource_content(true, &["operation", "target"], "boolean.py");
-
-    let python_ast = python_src_to_stmts(&python_src);
-    let out_ast = python_src_to_stmts(&out_src);
-
-    assert_eq!(out_ast, python_ast);
-    Ok(assert!(exists_and_delete(true, &["operation", "target"], "boolean.py")))
+    test_directory(true, &["operation"], &["operation", "target"], "boolean")
 }

--- a/tests/parser/valid/class.rs
+++ b/tests/parser/valid/class.rs
@@ -22,7 +22,7 @@ fn import_verify() {
     let ast_tree = parse(&tokenize(&source).unwrap()).unwrap();
 
     let (import, _as) = match ast_tree.node {
-        Node::File { imports, .. } => match &imports.first().expect("script empty.").node {
+        Node::File { modules, .. } => match &modules.first().expect("script empty.").node {
             Node::Import { import, _as } => (import.clone(), _as.clone()),
             _ => panic!("first element script was not list.")
         },
@@ -40,7 +40,7 @@ fn import_as_verify() {
     let ast_tree = parse(&tokenize(&source).unwrap()).unwrap();
 
     let (import, _as) = match ast_tree.node {
-        Node::File { imports, .. } => match &imports.first().expect("script empty.").node {
+        Node::File { modules, .. } => match &modules.first().expect("script empty.").node {
             Node::Import { import, _as } => (import.clone(), _as.clone()),
             other => panic!("first element script was not import: {:?}.", other)
         },
@@ -59,7 +59,7 @@ fn from_import_as_verify() {
     let ast_tree = parse(&tokenize(&source).unwrap()).unwrap();
 
     let (from, import, _as) = match ast_tree.node {
-        Node::File { imports, .. } => match &imports.first().expect("script empty.").node {
+        Node::File { modules, .. } => match &modules.first().expect("script empty.").node {
             Node::FromImport { id, import } => match &import.node {
                 Node::Import { import, _as } => (id.clone(), import.clone(), _as.clone()),
                 other => panic!("not import: {:?}.", other)

--- a/tests/parser/valid/definition.rs
+++ b/tests/parser/valid/definition.rs
@@ -10,7 +10,7 @@ macro_rules! unwrap_func_definition {
         };
 
         match definition.node {
-            Node::FunDef { id, private, pure, fun_args, ret_ty, raises, body } =>
+            Node::FunDef { id, private, pure, fun_args, ret_ty, raises, body, .. } =>
                 (private, pure, id, fun_args, ret_ty, raises, body),
             other => panic!("Expected variabledef but was {:?}.", other)
         }

--- a/tests/parser/valid/expression_and_statement.rs
+++ b/tests/parser/valid/expression_and_statement.rs
@@ -126,19 +126,6 @@ fn return_verify() {
 }
 
 #[test]
-fn retry_verify() {
-    let source = String::from("retry");
-    let ast_tree = parse_direct(&tokenize(&source).unwrap()).unwrap();
-
-    let node_pos = match ast_tree.node {
-        Node::Script { statements, .. } => statements.first().expect("script empty.").clone(),
-        _ => panic!("ast_tree was not script.")
-    };
-
-    assert_eq!(node_pos.node, Node::Retry);
-}
-
-#[test]
 fn underscore_verify() {
     let source = String::from("_");
     let ast_tree = parse_direct(&tokenize(&source).unwrap()).unwrap();

--- a/tests/parser/valid/expression_and_statement.rs
+++ b/tests/parser/valid/expression_and_statement.rs
@@ -157,7 +157,7 @@ fn from_import_verify() {
     let ast_tree = parse(&tokenize(&source).unwrap()).unwrap();
 
     let imports = match ast_tree.node {
-        Node::File { imports, .. } => imports,
+        Node::File { modules, .. } => modules,
         _ => panic!("ast_tree was not file.")
     };
 
@@ -182,7 +182,7 @@ fn import_verify() {
     let ast_tree = parse(&tokenize(&source).unwrap()).unwrap();
 
     let imports = match ast_tree.node {
-        Node::File { imports, .. } => imports,
+        Node::File { modules, .. } => modules,
         _ => panic!("ast_tree was not file.")
     };
 
@@ -203,7 +203,7 @@ fn import_as_verify() {
     let ast_tree = parse(&tokenize(&source).unwrap()).unwrap();
 
     let imports = match ast_tree.node {
-        Node::File { imports, .. } => imports,
+        Node::File { modules, .. } => modules,
         _ => panic!("ast_tree was not file.")
     };
 

--- a/tests/resources/invalid/type/definition/argument_after_argument_with_default.mamba
+++ b/tests/resources/invalid/type/definition/argument_after_argument_with_default.mamba
@@ -1,0 +1,1 @@
+def my_fun(a: Int <- 10, b: Int) -> Int => a + b

--- a/tests/resources/valid/class/doc_strings.mamba
+++ b/tests/resources/valid/class/doc_strings.mamba
@@ -1,0 +1,16 @@
+"""This is my file
+
+It can do many thing
+"""
+
+class MyClass
+    """This is my class
+
+    It can do many things
+    """
+
+    def my_fun(self) -> Int =>
+        """
+        This is my function, it can't do so much
+        """
+        200

--- a/tests/resources/valid/class/doc_strings_check.py
+++ b/tests/resources/valid/class/doc_strings_check.py
@@ -1,0 +1,16 @@
+"""This is my file
+
+It can do many thing
+"""
+
+class MyClass:
+    """This is my class
+
+    It can do many things
+    """
+
+    def my_fun(self) -> int:
+        """
+        This is my function, it can't do so much
+        """
+        200

--- a/tests/resources/valid/error/exception.mamba
+++ b/tests/resources/valid/error/exception.mamba
@@ -1,0 +1,2 @@
+def a <- Exception()
+def b <- Exception("b")

--- a/tests/resources/valid/error/exception_check.py
+++ b/tests/resources/valid/error/exception_check.py
@@ -1,0 +1,2 @@
+a = Exception()
+b = Exception("b")

--- a/tests/resources/valid/error/handle.mamba
+++ b/tests/resources/valid/error/handle.mamba
@@ -1,12 +1,12 @@
-class MyErr1 isa Exception
-class MyErr2 isa Exception
+class MyErr1 isa Exception("Something went wrong")
+class MyErr2(msg: String) isa Exception(msg)
 
 def f(x: Int) -> Int raises [MyErr1, MyErr2] =>
     if x < 0 then
         raise MyErr1()
     else
         if x > 10 then
-            raise MyErr2()
+            raise MyErr2("Greater than 10.")
         else
             return x + 2
 

--- a/tests/resources/valid/error/handle_check.py
+++ b/tests/resources/valid/error/handle_check.py
@@ -1,11 +1,11 @@
 class MyErr1(Exception):
     def __init__(self):
-        super(Exception, self).__init__()
+        super(Exception, self).__init__("Something went wrong")
 
 
 class MyErr2(Exception):
-    def __init__(self):
-        super(Exception, self).__init__()
+    def __init__(self, msg: str):
+        super(Exception, self).__init__(msg)
 
 
 def f(x: int) -> int:
@@ -13,7 +13,7 @@ def f(x: int) -> int:
         raise MyErr1()
     else:
         if x > 10:
-            raise MyErr2()
+            raise MyErr2("Greater than 10.")
         else:
             return x + 2
 

--- a/tests/resources/valid/function/function_with_defaults.mamba
+++ b/tests/resources/valid/function/function_with_defaults.mamba
@@ -1,0 +1,5 @@
+def my_fun(a: Int, b: Int <- 10, c: String <- "Hello") -> String => c + b + a
+
+my_fun(1, 2, "hello world")
+my_fun(1, 2)
+my_fun(1)

--- a/tests/resources/valid/function/function_with_defaults_check.py
+++ b/tests/resources/valid/function/function_with_defaults_check.py
@@ -1,0 +1,5 @@
+def my_fun(a: int, b: int = 10, c: str = "Hello") -> str: c + b + a
+
+my_fun(1, 2, "hello world")
+my_fun(1, 2)
+my_fun(1)

--- a/tests/resources/valid/operation/primitives.mamba
+++ b/tests/resources/valid/operation/primitives.mamba
@@ -1,0 +1,6 @@
+def a <- Complex(10.0, 20.0)
+def b <- Int(10)
+def c <- Float(2.3)
+
+def d <- Bool(True)
+def e <- String("hello world")

--- a/tests/resources/valid/operation/primitives_check.py
+++ b/tests/resources/valid/operation/primitives_check.py
@@ -1,0 +1,6 @@
+a = complex(10.0, 20.0)
+b = int(10)
+c = float(2.3)
+
+d = bool(True)
+e = str("hello world")

--- a/tests/type_checker/context/invalid/definition.rs
+++ b/tests/type_checker/context/invalid/definition.rs
@@ -4,6 +4,16 @@ use mamba::parser::parse;
 use mamba::type_checker::check_all;
 
 #[test]
+fn argument_after_argument_with_default() {
+    let source = resource_content(
+        false,
+        &["type", "definition"],
+        "argument_after_argument_with_default.mamba"
+    );
+    check_all(&[(*parse(&tokenize(&source).unwrap()).unwrap(), None, None)]).unwrap_err();
+}
+
+#[test]
 fn assign_wrong_type() {
     let source = resource_content(false, &["type", "definition"], "assign_wrong_type.mamba");
     check_all(&[(*parse(&tokenize(&source).unwrap()).unwrap(), None, None)]).unwrap_err();


### PR DESCRIPTION
### Summary
- Parse docstrings (without checking if they are in the correct location)
- Remove `retry` keyword from the language
- Allow passing of default arguments to functions
- Identify constructors in AST and desugar function call identifier as a class name if indeed constructor