### PR TITLE
Display only unique error messages

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,7 @@ extern crate log;
 extern crate loggerv;
 
 use clap::App;
+use itertools::Itertools;
 
 use mamba::pipeline::transpile_directory;
 
@@ -37,7 +38,7 @@ pub fn main() -> Result<(), String> {
 
     transpile_directory(&current_dir, in_path, out_path)
         .map_err(|errors| {
-            errors.iter().for_each(|(ty, msg)| eprintln!("[error | {}] {}", ty, msg));
+            errors.iter().unique().for_each(|(ty, msg)| eprintln!("[error | {}] {}", ty, msg));
             match errors.first() {
                 Some((ty, msg)) => format!(
                     "{} {} error occurred: {}",


### PR DESCRIPTION
The type checker has a habit of creating many
duplicate error messages.
This happens due to multiple sets being type
checked, which may have many duplicate errors.

