### PR TITLE
Big Clippy sweep

### DIFF
--- a/src/check/constrain/constraint/expected.rs
+++ b/src/check/constrain/constraint/expected.rs
@@ -8,9 +8,8 @@ use std::ops::Deref;
 use itertools::{EitherOrBoth, Itertools};
 
 use crate::check::constrain::constraint::expected::Expect::*;
-use crate::check::context::{clss, Context};
+use crate::check::context::clss;
 use crate::check::context::clss::{BOOL_PRIMITIVE, FLOAT_PRIMITIVE, INT_PRIMITIVE, NONE, STRING_PRIMITIVE};
-use crate::check::name::{IsNullable, IsSuperSet};
 use crate::check::name::nameunion::NameUnion;
 use crate::check::name::stringname::StringName;
 use crate::check::result::{TypeErr, TypeResult};
@@ -172,21 +171,6 @@ impl Expect {
         match &self {
             Expect::Type { name } => name.is_null(),
             _ => false
-        }
-    }
-
-    pub fn is_nullable(&self) -> bool {
-        match &self {
-            Expect::Type { name } => name.is_nullable(),
-            _ => false
-        }
-    }
-
-    pub fn is_superset_of(&self, other: &Expect, ctx: &Context) -> TypeResult<bool> {
-        match (&self, other) {
-            (Expect::Type { name }, Expect::Type { name: other }) =>
-                name.is_superset_of(other, ctx, &Position::default()),
-            _ => Ok(false)
         }
     }
 }

--- a/src/check/constrain/generate/definition.rs
+++ b/src/check/constrain/generate/definition.rs
@@ -217,7 +217,7 @@ fn identifier_to_tuple(
         Ok(permutations
             .into_iter()
             .map(|elements| {
-                let elements = elements.into_iter().map(|e| e.clone()).collect();
+                let elements = elements.into_iter().cloned().collect();
                 Expected::new(pos, &Expect::Tuple { elements })
             })
             .collect())

--- a/src/check/constrain/generate/env.rs
+++ b/src/check/constrain/generate/env.rs
@@ -1,5 +1,4 @@
 use std::collections::{HashMap, HashSet};
-use std::iter::FromIterator;
 
 use crate::check::constrain::constraint::expected::{Expect, Expected};
 use crate::check::constrain::constraint::expected::Expect::Raises;
@@ -56,7 +55,7 @@ impl Environment {
     /// If the var was previously defined, it is renamed, and the rename mapping is stored.
     /// In future, if we get a variable, if it was renamed, the mapping is returned instead.
     pub fn insert_var(&mut self, mutable: bool, var: &str, expect: &Expected) -> Environment {
-        let expected_set = HashSet::from_iter(vec![(mutable, expect.clone())].into_iter());
+        let expected_set = vec![(mutable, expect.clone())].into_iter().collect::<HashSet<_>>();
         let mut vars = self.vars.clone();
 
         let var = if self.vars.contains_key(var) {
@@ -162,7 +161,7 @@ impl Environment {
             match (self.vars.get(key), other.vars.get(key)) {
                 (Some(l_exp), Some(r_exp)) => {
                     let union = l_exp.union(r_exp);
-                    vars.insert(String::from(key), HashSet::from_iter(union.cloned()));
+                    vars.insert(String::from(key), union.cloned().collect::<HashSet<_>>());
                 }
                 (Some(exp), None) | (None, Some(exp)) => {
                     vars.insert(String::from(key), exp.clone());
@@ -172,7 +171,7 @@ impl Environment {
         }
 
         let to_remove: Vec<String> = self.var_mappings.iter()
-            .filter(|(key, _)| { other.var_mappings.contains_key(key.clone()) })
+            .filter(|(key, _)| { other.var_mappings.contains_key(*key) })
             .map(|(key, _)| key.clone())
             .collect();
 

--- a/src/check/constrain/unify/expression/mod.rs
+++ b/src/check/constrain/unify/expression/mod.rs
@@ -37,10 +37,10 @@ pub fn unify_expression(constraint: &Constraint, constraints: &mut Constraints, 
         (Expression { ast: AST { node: Node::Tuple { elements: ast_elements }, .. } }, Tuple { elements }) => {
             let mut constraints = substitute(&left, &right, constraints, count, total)?;
 
-            for pair in ast_elements.iter().zip_longest(elements.iter()) {
+            for pair in ast_elements.iter().cloned().zip_longest(elements.iter()) {
                 match &pair {
                     Both(ast, exp) => {
-                        let expect = Expect::Expression { ast: ast.clone().clone() };
+                        let expect = Expect::Expression { ast: ast.clone() };
                         let l_ty = Expected::new(&left.pos, &expect);
                         constraints.push("tuple", &l_ty, &exp)
                     }

--- a/src/check/constrain/unify/function.rs
+++ b/src/check/constrain/unify/function.rs
@@ -93,7 +93,7 @@ pub fn unify_function(constraint: &Constraint, constraints: &mut Constraints, ct
 fn field_access(constraints: &mut Constraints,
                 ctx: &Context,
                 entity_name: &NameUnion,
-                name: &String,
+                name: &str,
                 accessed: &Expected,
                 other: &Expected,
                 total: usize) -> Unified {
@@ -108,11 +108,12 @@ fn field_access(constraints: &mut Constraints,
     unify_link(constraints, ctx, total + pushed)
 }
 
+#[allow(clippy::too_many_arguments)]
 fn function_access(constraints: &mut Constraints,
                    ctx: &Context,
                    entity_name: &NameUnion,
                    name: &StringName,
-                   args: &Vec<Expected>,
+                   args: &[Expected],
                    accessed: &Expected,
                    other: &Expected,
                    total: usize) -> Unified {

--- a/src/check/constrain/unify/ty.rs
+++ b/src/check/constrain/unify/ty.rs
@@ -77,10 +77,10 @@ pub fn unify_type(constraint: &Constraint, constraints: &mut Constraints, ctx: &
                             return Err(vec![TypeErr::new(&left.pos, &msg)]);
                         }
 
-                        for pair in names.iter().zip_longest(elements.iter()) {
+                        for pair in names.iter().cloned().zip_longest(elements.iter()) {
                             match &pair {
                                 Both(name, exp) => {
-                                    let expect = Expect::Type { name: name.clone().clone() };
+                                    let expect = Expect::Type { name: name.clone() };
                                     let l_ty = Expected::new(&left.pos, &expect);
                                     constraints.push("tuple", &l_ty, &exp)
                                 }

--- a/src/check/context/field/python.rs
+++ b/src/check/context/field/python.rs
@@ -1,5 +1,4 @@
 use std::collections::HashSet;
-use std::iter::FromIterator;
 
 use python_parser::ast::{Expression, SetItem};
 
@@ -39,47 +38,39 @@ impl From<(&Expression, &Vec<Expression>)> for GenericFields {
 impl From<&Expression> for GenericFields {
     fn from(id: &Expression) -> GenericFields {
         GenericFields {
-            fields: HashSet::from_iter(
-                match id {
-                    Expression::Name(name) => vec![GenericField {
-                        is_py_type: true,
-                        name: name.clone(),
-                        pos: Default::default(),
-                        mutable: false,
-                        in_class: None,
-                        ty: None,
-                    }],
-                    Expression::TupleLiteral(items) => items
-                        .iter()
-                        .filter(|item| if let SetItem::Unique(_) = item { true } else { false })
-                        .filter(|item| match &item {
-                            SetItem::Star(_) => false,
-                            SetItem::Unique(expr) =>
-                                if let Expression::Name(_) = expr {
-                                    true
-                                } else {
-                                    false
-                                },
-                        })
-                        .map(|item| match &item {
-                            SetItem::Star(_) => unreachable!(),
-                            SetItem::Unique(expression) => match expression {
-                                Expression::Name(name) => GenericField {
-                                    is_py_type: true,
-                                    name: name.clone(),
-                                    pos: Default::default(),
-                                    mutable: false,
-                                    in_class: None,
-                                    ty: None,
-                                },
-                                _ => unreachable!()
-                            }
-                        })
-                        .collect(),
-                    _ => vec![]
-                }
-                    .into_iter()
-            )
+            fields: (match id {
+                Expression::Name(name) => vec![GenericField {
+                    is_py_type: true,
+                    name: name.clone(),
+                    pos: Default::default(),
+                    mutable: false,
+                    in_class: None,
+                    ty: None,
+                }],
+                Expression::TupleLiteral(items) => items
+                    .iter()
+                    .filter(|item| matches!(item, SetItem::Unique(_)))
+                    .filter(|item| match &item {
+                        SetItem::Star(_) => false,
+                        SetItem::Unique(expr) => matches!(expr, Expression::Name(_))
+                    })
+                    .map(|item| match &item {
+                        SetItem::Star(_) => unreachable!(),
+                        SetItem::Unique(expression) => match expression {
+                            Expression::Name(name) => GenericField {
+                                is_py_type: true,
+                                name: name.clone(),
+                                pos: Default::default(),
+                                mutable: false,
+                                in_class: None,
+                                ty: None,
+                            },
+                            _ => unreachable!()
+                        }
+                    })
+                    .collect(),
+                _ => vec![]
+            }).iter().cloned().collect::<HashSet<_>>()
         }
     }
 }

--- a/src/check/context/python.rs
+++ b/src/check/context/python.rs
@@ -3,7 +3,6 @@ use std::convert::TryFrom;
 use std::fs;
 use std::fs::File;
 use std::io::Read;
-use std::iter::FromIterator;
 use std::ops::Deref;
 use std::path::PathBuf;
 
@@ -61,8 +60,8 @@ pub fn python_files(
     }
 
     Ok((
-        HashSet::from_iter(types.into_iter()),
-        HashSet::from_iter(fields.into_iter()),
-        HashSet::from_iter(functions.into_iter())
+        types.into_iter().collect::<HashSet<_>>(),
+        fields.into_iter().collect::<HashSet<_>>(),
+        functions.into_iter().collect::<HashSet<_>>()
     ))
 }

--- a/src/check/ident.rs
+++ b/src/check/ident.rs
@@ -29,15 +29,13 @@ impl Identifier {
     pub fn as_mutable(&self, mutable: bool) -> Identifier {
         if let Some((_, id)) = &self.lit {
             Identifier { lit: Some((mutable, id.clone())), names: self.names.clone() }
+        } else if mutable {
+            self.clone()
         } else {
-            if mutable {
-                self.clone()
-            } else {
-                // If not mutable, then make everything immutable
-                Identifier {
-                    lit: self.lit.clone().map(|(_, str)| (false, str)),
-                    names: self.names.iter().map(|name| name.as_mutable(false)).collect(),
-                }
+            // If not mutable, then make everything immutable
+            Identifier {
+                lit: self.lit.clone().map(|(_, str)| (false, str)),
+                names: self.names.iter().map(|name| name.as_mutable(false)).collect(),
             }
         }
     }

--- a/src/check/name/nameunion/generic.rs
+++ b/src/check/name/nameunion/generic.rs
@@ -1,6 +1,5 @@
 use std::collections::HashSet;
 use std::convert::TryFrom;
-use std::iter::FromIterator;
 use std::ops::Deref;
 
 use crate::check::name::nameunion::NameUnion;
@@ -21,7 +20,7 @@ impl TryFrom<&AST> for NameUnion {
         let names = if let Node::TypeUnion { types } = &ast.node {
             types.iter().map(TrueName::try_from).collect::<Result<_, _>>()?
         } else {
-            HashSet::from_iter(vec![TrueName::try_from(ast)?].into_iter())
+            vec![TrueName::try_from(ast)?].into_iter().collect::<HashSet<_>>()
         };
         Ok(NameUnion { names })
     }

--- a/src/check/name/truename/mod.rs
+++ b/src/check/name/truename/mod.rs
@@ -97,10 +97,7 @@ impl TrueName {
     pub fn is_empty(&self) -> bool { self == &TrueName::empty() }
 
     pub fn is_null(&self) -> bool {
-        match &self.variant {
-            NameVariant::Single(StringName { name, .. }) if name.clone() == String::from(NONE) => true,
-            _ => false
-        }
+        matches!(&self.variant, NameVariant::Single(StringName { name, .. }) if name.clone() == *NONE)
     }
 
     pub fn empty() -> TrueName { TrueName::from(&StringName::empty()) }

--- a/src/desugar/class.rs
+++ b/src/desugar/class.rs
@@ -96,10 +96,7 @@ fn extract_class(
             };
 
             let (mut stmts, mut non_variables): (Vec<_>, Vec<_>) =
-                final_definitions.into_iter().partition(|stmt| match stmt {
-                    Core::VarDef { .. } => true,
-                    _ => false
-                });
+                final_definitions.into_iter().partition(|stmt| matches!(stmt, Core::VarDef { .. }));
             stmts.append(&mut non_variables);
             final_definitions = stmts;
 

--- a/src/lex/pass/docstring.rs
+++ b/src/lex/pass/docstring.rs
@@ -17,24 +17,20 @@ impl DocString {
     }
 
     fn get(&mut self) -> Vec<Lex> {
-        match (self.front.clone(), self.middle.clone(), self.back.clone()) {
-            (Some(front), Some(middle), Some(back)) =>
-                match (front.token, middle.token, back.token) {
-                    (Token::Str(f_str, _), Token::Str(doc_str, _), Token::Str(b_str, _)) =>
-                        if f_str.is_empty()
-                            && b_str.is_empty()
-                            && front.pos.end.pos == middle.pos.start.pos
-                            && middle.pos.end.pos == back.pos.start.pos
-                        {
-                            self.front = None;
-                            self.middle = None;
-                            self.back = None;
-                            return vec![Lex::new(&front.pos.start, Token::DocStr(doc_str))];
-                        },
-                    _ => {}
-                },
-            _ => {}
-        };
+        if let (Some(front), Some(middle), Some(back)) = (self.front.clone(), self.middle.clone(), self.back.clone()) {
+            if let (Token::Str(f_str, _), Token::Str(doc_str, _), Token::Str(b_str, _)) = (front.token, middle.token, back.token) {
+                if f_str.is_empty()
+                    && b_str.is_empty()
+                    && front.pos.end.pos == middle.pos.start.pos
+                    && middle.pos.end.pos == back.pos.start.pos
+                {
+                    self.front = None;
+                    self.middle = None;
+                    self.back = None;
+                    return vec![Lex::new(&front.pos.start, Token::DocStr(doc_str))];
+                }
+            }
+        }
 
         if let Some(lex) = &self.front.clone() {
             self.front = None;

--- a/src/parse/ast/node.rs
+++ b/src/parse/ast/node.rs
@@ -437,8 +437,7 @@ impl Node {
     }
 
     fn is_operator(&self) -> bool {
-        match &self {
-            Node::Add { .. }
+        matches!(&self,            Node::Add { .. }
             | Node::AddU { .. }
             | Node::Sub { .. }
             | Node::SubU { .. }
@@ -467,8 +466,6 @@ impl Node {
             | Node::Not { .. }
             | Node::And { .. }
             | Node::Or { .. }
-            | Node::In { .. } => true,
-            _ => false
-        }
+            | Node::In { .. })
     }
 }

--- a/src/parse/block.rs
+++ b/src/parse/block.rs
@@ -22,7 +22,7 @@ pub fn parse_statements(it: &mut LexIterator) -> ParseResult<Vec<AST>> {
                 let node = Node::Comment { comment: comment.clone() };
                 statements.push(AST::new(&lex.pos.union(&end), node));
 
-                let last_pos = &it.last_pos().clone();
+                let last_pos = &it.last_pos();
                 it.eat_if_not_empty(&Token::NL, "block", last_pos)?;
                 Ok(())
             }
@@ -31,7 +31,7 @@ pub fn parse_statements(it: &mut LexIterator) -> ParseResult<Vec<AST>> {
                 let node = Node::DocStr { lit: doc_str.clone() };
                 statements.push(AST::new(&lex.pos.union(&end), node));
 
-                let last_pos = &it.last_pos().clone();
+                let last_pos = &it.last_pos();
                 it.eat_if_not_empty(&Token::NL, "block", last_pos)?;
                 Ok(())
             }

--- a/src/parse/expression.rs
+++ b/src/parse/expression.rs
@@ -143,7 +143,7 @@ fn parse_return(it: &mut LexIterator) -> ParseResult {
 
 /// Excluding unary addition and subtraction
 pub fn is_start_expression_exclude_unary(tp: &Lex) -> bool {
-    match tp.token {
+    matches!(tp.token,
         Token::If
         | Token::Match
         | Token::LRBrack
@@ -159,9 +159,7 @@ pub fn is_start_expression_exclude_unary(tp: &Lex) -> bool {
         | Token::Bool(_)
         | Token::Not
         | Token::Undefined
-        | Token::Id(_) => true,
-        _ => false
-    }
+        | Token::Id(_))
 }
 
 pub fn is_start_expression(tp: &Lex) -> bool {

--- a/src/parse/iterator.rs
+++ b/src/parse/iterator.rs
@@ -42,7 +42,7 @@ impl<'a> LexIterator<'a> {
             } else if peeked_token != token.clone() { break; }
         }
 
-        return last_token == Some(final_token.clone());
+        last_token == Some(final_token.clone())
     }
 
     pub fn eat(&mut self, token: &Token, err_msg: &str) -> ParseResult<Position> {
@@ -80,8 +80,8 @@ impl<'a> LexIterator<'a> {
                             -> ParseResult<Option<Position>> {
         if self.it.peek().is_some() {
             self.eat(token, err_msg)
-                .map(|pos| Some(pos))
-                .map_err(|err| err.clone_with_cause(err_msg, &last_pos.clone().unwrap_or(Position::default())))
+                .map(Some)
+                .map_err(|err| err.clone_with_cause(err_msg, &last_pos.clone().unwrap_or_default()))
         } else {
             Ok(None)
         }

--- a/src/parse/statement.rs
+++ b/src/parse/statement.rs
@@ -82,15 +82,12 @@ pub fn parse_with(it: &mut LexIterator) -> ParseResult {
 }
 
 pub fn is_start_statement(tp: &Token) -> bool {
-    match tp {
-        Token::Def
+    matches!(tp,  Token::Def
         | Token::Fin
         | Token::Print
         | Token::For
         | Token::While
         | Token::Pass
         | Token::Raise
-        | Token::With => true,
-        _ => false
-    }
+        | Token::With)
 }


### PR DESCRIPTION
- Mostly code style items
- Some clones here and there removed where not
  necessary.

This should also mean that clippy behaves at it should in future PR's (See #231),

Supposedly the behavior of the code-base has changed in some areas as we were using references where we should have been using values:
```
for pair in names.iter().cloned().zip_longest(elements.iter()) {
    match &pair {
        Both(name, exp) => {
            let expect = Expect::Type { name: name.clone() };
            let l_ty = Expected::new(&left.pos, &expect);
            constraints.push("tuple", &l_ty, &exp)
        }
}
```
However, no tests have caught this change in behaviour.
