### PR TITLE
Print tokens as their name in parser

### DIFF
--- a/src/parse/operation.rs
+++ b/src/parse/operation.rs
@@ -29,7 +29,7 @@ macro_rules! inner_bin_op {
 pub fn parse_expression(it: &mut LexIterator) -> ParseResult { parse_level_7(it) }
 
 fn parse_level_7(it: &mut LexIterator) -> ParseResult {
-    let start = it.start_pos("operation")?;
+    let start = it.start_pos("operation (7)")?;
     let arithmetic = it.parse(&parse_level_6, "operation", &start)?;
     macro_rules! bin_op {
         ($it:expr, $fun:path, $ast:ident, $arithmetic:expr, $msg:expr) => {{
@@ -49,7 +49,7 @@ fn parse_level_7(it: &mut LexIterator) -> ParseResult {
 }
 
 fn parse_level_6(it: &mut LexIterator) -> ParseResult {
-    let start = it.start_pos("operation")?;
+    let start = it.start_pos("operation (6)")?;
     let arithmetic = it.parse(&parse_level_5, "operation", &start)?;
     macro_rules! bin_op {
         ($it:expr, $fun:path, $ast:ident, $arithmetic:expr, $msg:expr) => {{
@@ -77,7 +77,7 @@ fn parse_level_6(it: &mut LexIterator) -> ParseResult {
 }
 
 fn parse_level_5(it: &mut LexIterator) -> ParseResult {
-    let start = it.start_pos("operation")?;
+    let start = it.start_pos("operation (5)")?;
     let arithmetic = it.parse(&parse_level_4, "operation", &start)?;
     macro_rules! bin_op {
         ($it:expr, $fun:path, $ast:ident, $arithmetic:expr, $msg:expr) => {{
@@ -101,7 +101,7 @@ fn parse_level_5(it: &mut LexIterator) -> ParseResult {
 }
 
 fn parse_level_4(it: &mut LexIterator) -> ParseResult {
-    let start = it.start_pos("operation")?;
+    let start = it.start_pos("operation (4)")?;
     let arithmetic = it.parse(&parse_level_3, "operation", &start)?;
     macro_rules! bin_op {
         ($it:expr, $fun:path, $ast:ident, $arithmetic:expr, $msg:expr) => {{
@@ -120,7 +120,7 @@ fn parse_level_4(it: &mut LexIterator) -> ParseResult {
 }
 
 fn parse_level_3(it: &mut LexIterator) -> ParseResult {
-    let start = it.start_pos("operation")?;
+    let start = it.start_pos("operation (3)")?;
     let arithmetic = it.parse(&parse_level_2, "operation", &start)?;
     macro_rules! bin_op {
         ($it:expr, $fun:path, $ast:ident, $arithmetic:expr, $msg:expr) => {{
@@ -161,7 +161,7 @@ fn parse_level_3(it: &mut LexIterator) -> ParseResult {
 }
 
 fn parse_level_2(it: &mut LexIterator) -> ParseResult {
-    let start = it.start_pos("operation")?;
+    let start = it.start_pos("operation (2)")?;
     macro_rules! un_op {
         ($it:expr, $fun:path, $tok:ident, $ast:ident, $msg:expr) => {{
             let factor = $it.parse(&$fun, $msg, &start)?;
@@ -186,7 +186,7 @@ fn parse_level_2(it: &mut LexIterator) -> ParseResult {
 }
 
 fn parse_level_1(it: &mut LexIterator) -> ParseResult {
-    let start = it.start_pos("operation")?;
+    let start = it.start_pos("operation (1)")?;
     let arithmetic = it.parse(&parse_inner_expression, "operation", &start)?;
     macro_rules! bin_op {
         ($it:expr, $fun:path, $ast:ident, $arithmetic:expr, $msg:expr) => {{

--- a/src/parse/result.rs
+++ b/src/parse/result.rs
@@ -3,6 +3,7 @@ use std::fmt;
 use std::fmt::{Display, Formatter};
 use std::path::PathBuf;
 
+use crate::check::context::clss;
 use crate::common::position::Position;
 use crate::parse::ast::AST;
 use crate::parse::lex::token::Lex;
@@ -79,12 +80,23 @@ pub fn expected_one_of(tokens: &[Token], actual: &Lex, parsing: &str) -> ParseEr
     }
 }
 
+fn token_to_name(token: &Token) -> String {
+    match token {
+        Token::Int(_) => format!("an '{}'", clss::INT_PRIMITIVE),
+        Token::Real(_) => format!("a '{}'", clss::FLOAT_PRIMITIVE),
+        Token::Str(..) => format!("a '{}'", clss::STRING_PRIMITIVE),
+        Token::Bool(_) => format!("a '{}'", clss::BOOL_PRIMITIVE),
+        Token::ENum(..) => format!("an '{}'", clss::ENUM_PRIMITIVE),
+        other => format!("{}", other)
+    }
+}
+
 pub fn expected(expected: &Token, actual: &Lex, parsing: &str) -> ParseErr {
     ParseErr {
         position: actual.pos.clone(),
         msg: format!(
             "Expected {} while parsing {} {}, but found {}",
-            expected,
+            token_to_name(expected),
             an_or_a(parsing),
             parsing,
             actual.token
@@ -114,8 +126,7 @@ pub fn eof_expected_one_of(tokens: &[Token], parsing: &str) -> ParseErr {
                     an_or_a(parsing),
                     parsing)
         } else {
-            format!("Expected '{}' while parsing {} {}",
-                    comma_separated(tokens),
+            format!("Expected a token while parsing {} {}",
                     an_or_a(parsing),
                     parsing)
         },
@@ -126,7 +137,11 @@ pub fn eof_expected_one_of(tokens: &[Token], parsing: &str) -> ParseErr {
 }
 
 fn comma_separated(tokens: &[Token]) -> String {
-    let list = tokens.iter().fold(String::new(), |acc, token| acc + &format!("'{}', ", token));
+    comma_separated_map(tokens, token_to_name)
+}
+
+fn comma_separated_map(tokens: &[Token], map: fn(&Token) -> String) -> String {
+    let list = tokens.iter().fold(String::new(), |acc, token| acc + &format!("'{}', ", map(token)));
     String::from(&list[0..if list.len() >= 2 { list.len() - 2 } else { 0 }])
 }
 


### PR DESCRIPTION
### Relevant issues
Resolves #217 

At least, I think it addresses what that issue said.
It was written a bit vague.

### Summary
- Add some hints for what level of operation
  crashed. This is more to ease development, since
  they won't say much to an end-user.
  Come to think of it, the parser goes on longer
  than it should here so errors aren't that
  helpful.
- If no reference tokens, just say 'a token'.

### Added Tests
None
