### PR TITLE
Add newline after dedent in lexer

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 #![feature(drain_filter)]
+#![feature(termination_trait_lib)]
 
 extern crate ansi_term;
 #[macro_use]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,4 @@
 #![feature(drain_filter)]
-#![feature(termination_trait_lib)]
 
 extern crate ansi_term;
 #[macro_use]

--- a/src/parse/class.rs
+++ b/src/parse/class.rs
@@ -100,7 +100,7 @@ mod test {
     use crate::parse::ast::Node;
     use crate::parse::lex::tokenize;
     use crate::parse::parse;
-    use crate::parse::result::ParseResult;
+    use crate::parse::result::{ParseErr, ParseResult};
     use crate::test_util::resource_content;
 
     #[test]
@@ -219,5 +219,47 @@ mod test {
     fn parse_imports_class() -> ParseResult<()> {
         let source = resource_content(true, &["class"], "import.mamba");
         parse(&tokenize(&source).unwrap()).map(|_| ())
+    }
+
+    #[test]
+    fn single_line_class() {
+        let source = String::from("class MyClass");
+        parse(&tokenize(&source).unwrap()).unwrap();
+    }
+
+    #[test]
+    fn two_classes_no_newline_after() {
+        let source = String::from("class MyClass\nclass MyClass1");
+        parse(&tokenize(&source).unwrap()).unwrap();
+    }
+
+    #[test]
+    fn two_classes_newline_after() {
+        let source = String::from("class MyClass\nclass MyClass1\n");
+        parse(&tokenize(&source).unwrap()).unwrap();
+    }
+
+    #[test]
+    fn class_with_single_line_body_no_newline() -> Result<(), ParseErr> {
+        let source = "class MyClass\n    def var := 10";
+        parse(&tokenize(&source).unwrap())
+            .map_err(|e| e.into_with_source(&Some(String::from(source)), &None))
+            .map(|_| ())
+    }
+
+    #[test]
+    fn class_with_single_line_body_newline() -> Result<(), ParseErr> {
+        let source = "class MyClass\n    def var := 10\n";
+        parse(&tokenize(&source).unwrap())
+            .map_err(|e| e.into_with_source(&Some(String::from(source)), &None))
+            .map(|_| ())
+    }
+
+    #[test]
+    fn class_with_body_class_right_after() -> Result<(), ParseErr> {
+        let source = "class MyClass\n    def var := 10\nclass MyClass1\n";
+        parse(&tokenize(&source).unwrap())
+            .map_err(|e| e.into_with_source(&Some(String::from(source)), &None))
+            .map(|_| ())
     }
 }

--- a/src/parse/control_flow_expr.rs
+++ b/src/parse/control_flow_expr.rs
@@ -30,7 +30,7 @@ fn parse_if(it: &mut LexIterator) -> ParseResult {
     let el = if it.peek_if(&|lex| lex.token == Token::Else) {
         it.parse_if(&Token::Else, &parse_expr_or_stmt, "if else branch", &start)?
     } else if it.peek_if_followed_by(&Token::NL, &Token::Else) {
-        it.eat(&Token::NL, "if else branch");
+        it.eat(&Token::NL, "if else branch")?;
         it.parse_if(&Token::Else, &parse_expr_or_stmt, "if else branch", &start)?
     } else {
         None

--- a/src/parse/control_flow_stmt.rs
+++ b/src/parse/control_flow_stmt.rs
@@ -224,6 +224,6 @@ mod test {
     #[test]
     fn if_stmt() {
         let source = resource_content(true, &["control_flow"], "if.mamba");
-        assert!(parse(&tokenize(&source).unwrap()).is_ok());
+        parse(&tokenize(&source).unwrap()).unwrap();
     }
 }

--- a/src/parse/iterator.rs
+++ b/src/parse/iterator.rs
@@ -163,7 +163,7 @@ impl<'a> LexIterator<'a> {
         }
     }
 
-    #[warn(dead_code)] // Useful method when debugging
+    #[allow(dead_code)] // Useful method when debugging
     pub fn peek_next(&mut self) -> Option<Token> {
         self.it.peek().cloned().cloned().map(|e| e.token)
     }

--- a/src/parse/iterator.rs
+++ b/src/parse/iterator.rs
@@ -163,6 +163,7 @@ impl<'a> LexIterator<'a> {
         }
     }
 
+    #[warn(dead_code)] // Useful method when debugging
     pub fn peek_next(&mut self) -> Option<Token> {
         self.it.peek().cloned().cloned().map(|e| e.token)
     }

--- a/src/parse/iterator.rs
+++ b/src/parse/iterator.rs
@@ -124,23 +124,6 @@ impl<'a> LexIterator<'a> {
         }
     }
 
-    pub fn parse_if_followed_by_both_last(
-        &mut self,
-        token: &Token,
-        final_token: &Token,
-        parse_fun: &dyn Fn(&mut LexIterator) -> ParseResult,
-        err_msg: &str,
-        start: &Position,
-    ) -> ParseResult<Option<Box<AST>>> {
-        if self.peek_if_followed_by(token, final_token) {
-            self.eat(token, err_msg)?;
-            self.eat(final_token, err_msg)?;
-            Ok(Some(self.parse(parse_fun, err_msg, start)?))
-        } else {
-            self.parse_if(final_token, parse_fun, err_msg, start)
-        }
-    }
-
     pub fn parse_vec_if(
         &mut self,
         token: &Token,

--- a/src/parse/lex/state.rs
+++ b/src/parse/lex/state.rs
@@ -40,13 +40,14 @@ impl State {
 
         self.token_this_line = true;
         let mut res = self.newlines.pop().map_or(vec![], |nl| vec![nl]);
-        res.append(&mut if self.line_indent >= self.cur_indent {
+        if self.line_indent >= self.cur_indent {
             let amount = ((self.line_indent - self.cur_indent) / 4) as usize;
-            vec![Lex::new(&self.pos, Token::Indent); amount]
+            res.append(&mut vec![Lex::new(&self.pos, Token::Indent); amount]);
         } else {
             let amount = ((self.cur_indent - self.line_indent) / 4) as usize;
-            vec![Lex::new(&self.pos, Token::Dedent); amount]
-        });
+            res.append(&mut vec![Lex::new(&self.pos, Token::Dedent); amount]);
+            res.push(Lex::new(&self.pos, Token::NL));
+        }
 
         res.append(&mut self.newlines);
         res.push(Lex::new(&self.pos, token.clone()));

--- a/src/parse/lex/tokenize.rs
+++ b/src/parse/lex/tokenize.rs
@@ -266,3 +266,57 @@ fn as_op_or_id(string: String) -> Token {
         _ => Token::Id(string)
     }
 }
+
+#[cfg(test)]
+mod test {
+    use crate::parse::lex::lex_result::LexErr;
+    use crate::parse::lex::token::Token;
+    use crate::parse::lex::tokenize;
+
+    #[test]
+    fn class_with_body_class_right_after() -> Result<(), LexErr> {
+        let source = "class MyClass\n    def var := 10\nclass MyClass1\n";
+        let tokens = tokenize(&source)
+            .map_err(|e| e.into_with_source(&Some(String::from(source)), &None))?;
+
+        assert_eq!(tokens[0].token, Token::Class);
+        assert_eq!(tokens[1].token, Token::Id(String::from("MyClass")));
+        assert_eq!(tokens[2].token, Token::NL);
+        assert_eq!(tokens[3].token, Token::Indent);
+        assert_eq!(tokens[4].token, Token::Def);
+        assert_eq!(tokens[5].token, Token::Id(String::from("var")));
+        assert_eq!(tokens[6].token, Token::Assign);
+        assert_eq!(tokens[7].token, Token::Int(String::from("10")));
+        assert_eq!(tokens[8].token, Token::NL);
+        assert_eq!(tokens[9].token, Token::Dedent);
+        assert_eq!(tokens[10].token, Token::NL);
+        assert_eq!(tokens[11].token, Token::Class);
+        assert_eq!(tokens[12].token, Token::Id(String::from("MyClass1")));
+
+        Ok(())
+    }
+
+
+    #[test]
+    fn if_statement() -> Result<(), LexErr> {
+        let source = "if a then\n    b\nelse\n    c";
+        let tokens = tokenize(&source)
+            .map_err(|e| e.into_with_source(&Some(String::from(source)), &None))?;
+
+        assert_eq!(tokens[0].token, Token::If);
+        assert_eq!(tokens[1].token, Token::Id(String::from("a")));
+        assert_eq!(tokens[2].token, Token::Then);
+        assert_eq!(tokens[3].token, Token::NL);
+        assert_eq!(tokens[4].token, Token::Indent);
+        assert_eq!(tokens[5].token, Token::Id(String::from("b")));
+        assert_eq!(tokens[6].token, Token::NL);
+        assert_eq!(tokens[7].token, Token::Dedent);
+        assert_eq!(tokens[8].token, Token::NL);
+        assert_eq!(tokens[9].token, Token::Else);
+        assert_eq!(tokens[10].token, Token::NL);
+        assert_eq!(tokens[11].token, Token::Indent);
+        assert_eq!(tokens[12].token, Token::Id(String::from("c")));
+
+        Ok(())
+    }
+}

--- a/src/parse/statement.rs
+++ b/src/parse/statement.rs
@@ -82,7 +82,7 @@ pub fn parse_with(it: &mut LexIterator) -> ParseResult {
 }
 
 pub fn is_start_statement(tp: &Token) -> bool {
-    matches!(tp,  Token::Def
+    matches!(tp, Token::Def
         | Token::Fin
         | Token::Print
         | Token::For


### PR DESCRIPTION
### Relevant issues
Resolves #219 

### Summary
Lexer now always adds a newline after a dedent so a block is always followed by a dedent.

Update if else parsing logic to deal with newline after dedent.
Weirdly it seems like this was the only location where the parser had to be updated after this pretty big change.

### Added Tests
- Unit tests for lexer
- Unit tests for parsing if expression and statement
- Unit tests for parsing a few variations of a class
