### PR TITLE
Re-add a tuple test

### DIFF
--- a/tests/system/valid/definition.rs
+++ b/tests/system/valid/definition.rs
@@ -6,7 +6,6 @@ fn long_f_string() -> OutTestRet {
 }
 
 #[test]
-#[ignore]
 fn assign_tuples() -> OutTestRet {
     test_directory(true, &["definition"], &["definition", "target"], "assign_tuples")
 }


### PR DESCRIPTION
This test now properly works, so no need to ignore.

### Added Tests
- Assign to a tuple
