### PR TITLE
Flip function access constraint generation

### DIFF
--- a/src/check/constrain/generate/call.rs
+++ b/src/check/constrain/generate/call.rs
@@ -35,7 +35,7 @@ pub fn gen_call(
                     errors.push(TypeErr::new(&ast.pos, &msg))
                 }
 
-                if let Some((var, expecteds)) = env.get_var(var) {
+                if let Some(expecteds) = env.get_var(var) {
                     if expecteds.iter().any(|(is_mut, _)| !is_mut) {
                         let msg = format!("{} was declared final, cannot reassign", var);
                         errors.push(TypeErr::new(&ast.pos, &msg))
@@ -55,7 +55,7 @@ pub fn gen_call(
             let f_name = StringName::try_from(name)?;
             let (mut constr, env) = gen_vec(args, env, ctx, constr)?;
 
-            if let Some((_, functions)) = env.get_var(&f_name.name) {
+            if let Some(functions) = env.get_var(&f_name.name) {
                 if !f_name.generics.is_empty() {
                     let msg = "Anonymous function call cannot have generics";
                     return Err(vec![TypeErr::new(&name.pos, msg)]);

--- a/src/check/constrain/generate/definition.rs
+++ b/src/check/constrain/generate/definition.rs
@@ -193,7 +193,7 @@ fn identifier_to_tuple(
     if let Some((_, var)) = &iden.lit {
         let expected = env.get_var(var);
 
-        if let Some((_, expected)) = expected {
+        if let Some(expected) = expected {
             Ok(expected.iter().map(|(_, exp)| exp.clone()).collect())
         } else {
             let msg = format!("{} is undefined in this scope", iden);

--- a/src/check/constrain/generate/env.rs
+++ b/src/check/constrain/generate/env.rs
@@ -95,12 +95,12 @@ impl Environment {
     /// This is useful for detecting shadowing.
     ///
     /// Return true variable truename, whether it's mutable and it's expected value
-    pub fn get_var(&self, var: &str) -> Option<(String, HashSet<(bool, Expected)>)> {
+    pub fn get_var(&self, var: &str) -> Option<HashSet<(bool, Expected)>> {
         for (old, new) in &self.var_mappings {
             if old == var { return self.get_var(new); }
         }
 
-        self.vars.get(var).cloned().map(|res| (String::from(var), res))
+        self.vars.get(var).cloned().map(|res| res)
     }
 
     /// Union between two environments

--- a/src/check/constrain/generate/expression.rs
+++ b/src/check/constrain/generate/expression.rs
@@ -21,14 +21,13 @@ pub fn gen_expr(
             let (mut constr, env) = constrain_args(args, env, ctx, constr)?;
             generate(body, &env, ctx, &mut constr)
         }
-        Node::Id { lit } =>
-            if env.is_define_mode {
-                identifier_from_var(ast, &None, &None, false, ctx, constr, env)
-            } else if env.get_var(lit).is_some() {
-                Ok((constr.clone(), env.clone()))
-            } else {
-                Err(vec![TypeErr::new(&ast.pos, &format!("Undefined variable: {}", lit))])
-            },
+        Node::Id { lit } => if env.is_define_mode {
+            identifier_from_var(ast, &None, &None, false, ctx, constr, env)
+        } else if env.get_var(lit).is_some() {
+            Ok((constr.clone(), env.clone()))
+        } else {
+            Err(vec![TypeErr::new(&ast.pos, &format!("Undefined variable: {}", lit))])
+        },
         Node::Question { left, right } => {
             constr.add(
                 "question",
@@ -38,15 +37,14 @@ pub fn gen_expr(
             let (mut constr, env) = generate(left, env, ctx, constr)?;
             generate(right, &env, ctx, &mut constr)
         }
-        Node::Pass =>
-            if let Some(expected_ret_ty) = &env.return_type {
-                if env.last_stmt_in_function {
-                    constr.add("pass", &Expected::new(&ast.pos, &Expect::none()), expected_ret_ty);
-                }
-                Ok((constr.clone(), env.clone()))
-            } else {
-                Ok((constr.clone(), env.clone()))
-            },
+        Node::Pass => if let Some(expected_ret_ty) = &env.return_type {
+            if env.last_stmt_in_function {
+                constr.add("pass", &Expected::new(&ast.pos, &Expect::none()), expected_ret_ty);
+            }
+            Ok((constr.clone(), env.clone()))
+        } else {
+            Ok((constr.clone(), env.clone()))
+        },
 
         _ => Err(vec![TypeErr::new(&ast.pos, "Expected an expression")])
     }

--- a/src/check/constrain/unify/function.rs
+++ b/src/check/constrain/unify/function.rs
@@ -123,7 +123,7 @@ fn function_access(constraints: &mut Constraints,
     let mut pushed = 0;
     for function in &function_union.union {
         let fun_ty_exp = Expected::new(&accessed.pos, &Type { name: function.ret_ty.clone() });
-        constraints.push("function access", &fun_ty_exp, other);
+        constraints.push("function access", other, &fun_ty_exp);
         pushed += 1;
     }
 

--- a/tests/system/valid/function.rs
+++ b/tests/system/valid/function.rs
@@ -12,7 +12,6 @@ fn definition_ast_verify() -> OutTestRet {
 }
 
 #[test]
-#[ignore]  // Problem with access, presumably
 fn function_with_defaults_ast_verify() -> OutTestRet {
     test_directory(true, &["function"], &["function", "target"], "function_with_defaults")
 }


### PR DESCRIPTION
### Relevant issues
Resolves #228 

### Summary
Now, the thing the function return type is being compared to must be the super.
This makes sense, as a function may return a subset of the type its value is being assigned to,
but not the other way around.

- Streamline env.get_var method. Doesn't make
  sense to have function argument in return.

### Added Tests
- Unify access of a tuple arguments when tuple class attribute
- Tuple does not have type annotation when variable definition
