### PR TITLE
Add extra test for unify access

### DIFF
--- a/src/check/constrain/generate/env.rs
+++ b/src/check/constrain/generate/env.rs
@@ -99,8 +99,7 @@ impl Environment {
         for (old, new) in &self.var_mappings {
             if old == var { return self.get_var(new); }
         }
-
-        self.vars.get(var).cloned().map(|res| res)
+        self.vars.get(var).cloned()
     }
 
     /// Union between two environments

--- a/src/check/constrain/generate/expression.rs
+++ b/src/check/constrain/generate/expression.rs
@@ -21,13 +21,11 @@ pub fn gen_expr(
             let (mut constr, env) = constrain_args(args, env, ctx, constr)?;
             generate(body, &env, ctx, &mut constr)
         }
-        Node::Id { lit } => if env.is_define_mode {
-            identifier_from_var(ast, &None, &None, false, ctx, constr, env)
-        } else if env.get_var(lit).is_some() {
-            Ok((constr.clone(), env.clone()))
-        } else {
-            Err(vec![TypeErr::new(&ast.pos, &format!("Undefined variable: {}", lit))])
-        },
+
+        Node::Id { .. }  if env.is_define_mode => identifier_from_var(ast, &None, &None, false, ctx, constr, env),
+        Node::Id { lit } if env.get_var(lit).is_some() => Ok((constr.clone(), env.clone())),
+        Node::Id { lit } => Err(vec![TypeErr::new(&ast.pos, &format!("Undefined variable: {}", lit))]),
+
         Node::Question { left, right } => {
             constr.add(
                 "question",

--- a/src/core/construct.rs
+++ b/src/core/construct.rs
@@ -297,3 +297,12 @@ pub enum Core {
         expr: Box<Core>,
     },
 }
+
+impl Core {
+    pub fn is_tuple(&self) -> bool {
+        match self {
+            Core::Tuple { .. } => true,
+            _ => false
+        }
+    }
+}

--- a/src/core/construct.rs
+++ b/src/core/construct.rs
@@ -297,12 +297,3 @@ pub enum Core {
         expr: Box<Core>,
     },
 }
-
-impl Core {
-    pub fn is_tuple(&self) -> bool {
-        match self {
-            Core::Tuple { .. } => true,
-            _ => false
-        }
-    }
-}

--- a/src/desugar/definition.rs
+++ b/src/desugar/definition.rs
@@ -35,8 +35,8 @@ pub fn desugar_definition(ast: &AST, imp: &mut Imports, state: &State) -> Desuga
                 Core::VarDef {
                     var: Box::from(var.clone()),
                     ty: match ty {
-                        Some(ty) => Some(Box::from(desugar_node(ty, imp, &state)?)),
-                        None => None
+                        Some(ty) if !var.is_tuple() => Some(Box::from(desugar_node(ty, imp, &state)?)),
+                        _ => None
                     },
                     expr: match (var, expression) {
                         (_, Some(expr)) => Some(Box::from(desugar_node(expr, imp, &state)?)),

--- a/src/desugar/definition.rs
+++ b/src/desugar/definition.rs
@@ -35,7 +35,7 @@ pub fn desugar_definition(ast: &AST, imp: &mut Imports, state: &State) -> Desuga
                 Core::VarDef {
                     var: Box::from(var.clone()),
                     ty: match ty {
-                        Some(ty) if !var.is_tuple() => Some(Box::from(desugar_node(ty, imp, &state)?)),
+                        Some(ty) if !matches!(var, Core::Tuple{ .. }) => Some(Box::from(desugar_node(ty, imp, &state)?)),
                         _ => None
                     },
                     expr: match (var, expression) {

--- a/tests/resource/valid/function/call_simple_function_class.mamba
+++ b/tests/resource/valid/function/call_simple_function_class.mamba
@@ -1,0 +1,7 @@
+class A
+    def (a, b): (Int, Int) := (10, 100)
+
+
+def a := A()
+print(a.a)
+print(a.b)

--- a/tests/resource/valid/function/call_simple_function_class_check.py
+++ b/tests/resource/valid/function/call_simple_function_class_check.py
@@ -1,0 +1,7 @@
+class A:
+    (a, b) = (10, 100)
+
+
+a = A()
+print(a.a)
+print(a.b)

--- a/tests/system/valid/function.rs
+++ b/tests/system/valid/function.rs
@@ -15,3 +15,8 @@ fn definition_ast_verify() -> OutTestRet {
 fn function_with_defaults_ast_verify() -> OutTestRet {
     test_directory(true, &["function"], &["function", "target"], "function_with_defaults")
 }
+
+#[test]
+fn call_simple_function_class() -> OutTestRet {
+    test_directory(true, &["function"], &["function", "target"], "call_simple_function_class")
+}


### PR DESCRIPTION
### Relevant issues

Resolves https://github.com/JSAbrahams/mamba/issues/228

### Summary

Now, the thing the function return type is being compared to must be the super.
This makes sense, as a function may return a subset of the type its value is being assigned to, but not the other way around.

Modify desugar stage so that tuples do not have type annotations, which Python does not allow.

### Added Tests

-  Unify access of a tuple arguments when tuple class attribute
-  Tuple does not have type annotation when variable definition