### PR TITLE
Verify some Name functionality

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [ master ]
   pull_request:
-    branches: [ master, develop ]
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [ master ]
   pull_request:
-    branches: [ master, develop ]
 
 env:
   CARGO_TERM_COLOR: always

--- a/src/check/constrain/constraint/builder.rs
+++ b/src/check/constrain/constraint/builder.rs
@@ -43,8 +43,8 @@ impl ConstrBuilder {
             .1
             .clone()
             .drain_filter(|con| {
-                !con.left.expect.structurally_eq(&expected.expect)
-                    && !con.right.expect.structurally_eq(&expected.expect)
+                !con.left.expect.same_value(&expected.expect)
+                    && !con.right.expect.same_value(&expected.expect)
             })
             .collect()
     }

--- a/src/check/constrain/constraint/expected.rs
+++ b/src/check/constrain/constraint/expected.rs
@@ -124,9 +124,9 @@ impl Display for Expect {
 }
 
 impl Expect {
-    pub fn structurally_eq(&self, other: &Self) -> bool {
+    pub fn same_value(&self, other: &Self) -> bool {
         match (self, other) {
-            (Collection { ty: l }, Collection { ty: r }) => l.expect.structurally_eq(&r.expect),
+            (Collection { ty: l }, Collection { ty: r }) => l.expect.same_value(&r.expect),
             (Field { name: l }, Field { name: r }) => l == r,
             (Raises { name: l }, Raises { name: r }) | (Type { name: l }, Type { name: r }) =>
                 l == r,
@@ -136,13 +136,13 @@ impl Expect {
                 l == r
                     && la.iter().zip_longest(ra.iter()).all(|pair| {
                     if let EitherOrBoth::Both(left, right) = pair {
-                        left.expect.structurally_eq(&right.expect)
+                        left.expect.same_value(&right.expect)
                     } else {
                         false
                     }
                 }),
 
-            (Expression { ast: l }, Expression { ast: r }) => l.equal_structure(r),
+            (Expression { ast: l }, Expression { ast: r }) => l.same_value(r),
 
             (ExpressionAny, ExpressionAny) => true,
 

--- a/src/check/constrain/unify/expression/substitute.rs
+++ b/src/check/constrain/unify/expression/substitute.rs
@@ -116,7 +116,7 @@ fn substitute_vec(side: &str, old: &Expected, new: &Expected, elements: &[Expect
 
 fn is_expr_and_structurally_eq(inspected: &Expect, old: &Expect) -> bool {
     match inspected {
-        Expect::Expression { .. } => inspected.structurally_eq(old),
+        Expect::Expression { .. } => inspected.same_value(old),
         _ => false
     }
 }

--- a/src/check/ident.rs
+++ b/src/check/ident.rs
@@ -79,7 +79,6 @@ impl From<&Vec<Identifier>> for Identifier {
 
 impl From<(bool, &str)> for Identifier {
     fn from((mutable, name): (bool, &str)) -> Self {
-        // TODO use mutable field from identifier
         Identifier { lit: Some((mutable, String::from(name))), names: vec![] }
     }
 }

--- a/src/check/ident.rs
+++ b/src/check/ident.rs
@@ -7,7 +7,7 @@ use crate::check::result::{TypeErr, TypeResult};
 use crate::common::delimit::comma_delm;
 use crate::parse::ast::{AST, Node};
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Identifier {
     pub lit: Option<(bool, String)>,
     pub names: Vec<Identifier>,
@@ -80,5 +80,89 @@ impl From<&Vec<Identifier>> for Identifier {
 impl From<(bool, &str)> for Identifier {
     fn from((mutable, name): (bool, &str)) -> Self {
         Identifier { lit: Some((mutable, String::from(name))), names: vec![] }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::convert::TryFrom;
+
+    use crate::check::ident::Identifier;
+    use crate::check::result::TypeResult;
+    use crate::common::position::Position;
+    use crate::parse::ast::{AST, Node};
+
+    #[test]
+    fn from_id() -> TypeResult<()> {
+        let ast = AST::new(&Position::default(), Node::Id { lit: String::from("r") });
+        let iden = Identifier::try_from(&ast)?;
+        assert_eq!(iden, Identifier::from((true, "r")));
+        Ok(())
+    }
+
+    #[test]
+    fn from_expression_type() -> TypeResult<()> {
+        let ast = AST::new(&Position::default(), Node::ExpressionType {
+            expr: Box::new(AST::new(&Position::default(), Node::Id { lit: String::from("h") })),
+            mutable: false,
+            ty: None,
+        });
+        let iden = Identifier::try_from(&ast)?;
+
+        assert_eq!(iden, Identifier::from((false, "h")));
+        Ok(())
+    }
+
+    #[test]
+    fn from_expression_type_as_mutable() -> TypeResult<()> {
+        let ast = AST::new(&Position::default(), Node::ExpressionType {
+            expr: Box::new(AST::new(&Position::default(), Node::Id { lit: String::from("h") })),
+            mutable: false,
+            ty: None,
+        });
+        let iden = Identifier::try_from(&ast)?.as_mutable(true);
+
+        assert_eq!(iden, Identifier::from((true, "h")));
+        Ok(())
+    }
+
+    #[test]
+    fn from_int_error() {
+        let ast = AST::new(&Position::default(), Node::Int { lit: String::from("r") });
+        let res = Identifier::try_from(&ast);
+        assert!(res.is_err())
+    }
+
+    #[test]
+    fn from_tuple() -> TypeResult<()> {
+        let node = Node::Tuple {
+            elements: vec![
+                AST::new(&Position::default(), Node::Id { lit: String::from("a") }),
+                AST::new(&Position::default(), Node::Id { lit: String::from("b") }),
+            ]
+        };
+        let ast = AST::new(&Position::default(), node);
+        let iden = Identifier::try_from(&ast)?;
+
+        assert!(iden.lit.is_none());
+        let idens = iden.names;
+        assert_eq!(idens.len(), 2);
+        assert_eq!(idens[0], Identifier::from((true, "a")));
+        assert_eq!(idens[1], Identifier::from((true, "b")));
+
+        Ok(())
+    }
+
+    #[test]
+    fn from_tuple_with_int_err() {
+        let node = Node::Tuple {
+            elements: vec![
+                AST::new(&Position::default(), Node::Int { lit: String::from("a") }),
+                AST::new(&Position::default(), Node::Id { lit: String::from("b") }),
+            ]
+        };
+        let ast = AST::new(&Position::default(), node);
+        let iden = Identifier::try_from(&ast);
+        assert!(iden.is_err());
     }
 }

--- a/src/check/name/mod.rs
+++ b/src/check/name/mod.rs
@@ -387,4 +387,78 @@ mod tests {
 
         Ok(())
     }
+
+    #[test]
+    fn test_match_name_err_iden_is_tuple() {
+        let iden = Identifier::from((false, "abc"));
+        let iden2 = Identifier::from((false, "abc2"));
+        let iden3 = Identifier::from(&vec![iden, iden2]);
+
+        let name = Name::from("MyType3");
+        let err = match_name(&iden3, &name, &Position::default());
+
+        assert!(err.is_err())
+    }
+
+
+    #[test]
+    fn test_match_name_type_is_tuple() -> TypeResult<()> {
+        let iden = Identifier::from((false, "abc"));
+        let name = Name::from(&NameVariant::Tuple(vec![Name::from("A2"), Name::from("A1")]));
+        let matchings = match_name(&iden, &name, &Position::default())?;
+
+        assert_eq!(matchings.len(), 1);
+        let (mutable, matching) = matchings["abc"].clone();
+        assert!(!mutable);
+        assert_eq!(matching, name);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_match_name_iden_and_type_is_tuple() -> TypeResult<()> {
+        let iden = Identifier::from((false, "abc"));
+        let iden2 = Identifier::from((false, "abc2"));
+        let iden3 = Identifier::from(&vec![iden, iden2]);
+
+        let name = Name::from(&NameVariant::Tuple(vec![Name::from("A2"), Name::from("A1")]));
+
+        let matchings = match_name(&iden3, &name, &Position::default())?;
+
+        assert_eq!(matchings.len(), 2);
+        let (mutable1, matching1) = matchings["abc"].clone();
+        let (mutable2, matching2) = matchings["abc2"].clone();
+
+        assert!(!mutable1);
+        assert!(!mutable2);
+        assert_eq!(matching1, Name::from("A2"));
+        assert_eq!(matching2, Name::from("A1"));
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_match_name_iden_wrong_size_and_type() {
+        let iden = Identifier::from((false, "abc"));
+        let iden2 = Identifier::from((false, "abc2"));
+        let iden3 = Identifier::from((false, "abc2"));
+        let iden4 = Identifier::from(&vec![iden, iden2, iden3]);
+
+        let name = Name::from(&NameVariant::Tuple(vec![Name::from("A2"), Name::from("A1")]));
+
+        let matchings = match_name(&iden4, &name, &Position::default());
+        assert!(matchings.is_err());
+    }
+
+    #[test]
+    fn test_match_name_iden_and_type_wrong_size() {
+        let iden = Identifier::from((false, "abc"));
+        let iden2 = Identifier::from((false, "abc2"));
+        let iden3 = Identifier::from(&vec![iden, iden2]);
+
+        let name = Name::from(&NameVariant::Tuple(vec![Name::from("A2"), Name::from("A1"), Name::from("A0")]));
+
+        let matchings = match_name(&iden3, &name, &Position::default());
+        assert!(matchings.is_err());
+    }
 }

--- a/src/parse/ast/mod.rs
+++ b/src/parse/ast/mod.rs
@@ -449,6 +449,47 @@ mod test {
     }
 
     #[test]
+    fn tuple_equal_structure() {
+        let pos = Position::default();
+        let node1 = Node::Tuple {
+            elements: vec![
+                AST::new(&pos, Node::Id { lit: String::from("aa") }),
+                AST::new(&pos, Node::Id { lit: String::from("ba") }),
+                AST::new(&pos, Node::Id { lit: String::from("ca") })]
+        };
+        let node2 = Node::Tuple {
+            elements: vec![
+                AST::new(&pos, Node::Id { lit: String::from("aa") }),
+                AST::new(&pos, Node::Id { lit: String::from("ba") }),
+                AST::new(&pos, Node::Id { lit: String::from("ca") })]
+        };
+
+        let (ast, ast2) = two_ast!(node1, node2);
+        assert!(ast.same_value(&ast2));
+    }
+
+    #[test]
+    fn tuple_not_equal_structure() {
+        let pos = Position::default();
+        let node1 = Node::Tuple {
+            elements: vec![
+                AST::new(&pos, Node::Id { lit: String::from("aa") }),
+                AST::new(&pos, Node::Id { lit: String::from("ba") }),
+                AST::new(&pos, Node::Id { lit: String::from("ca") })]
+        };
+        let node2 = Node::Tuple {
+            elements: vec![
+                AST::new(&pos, Node::Id { lit: String::from("aa") }),
+                AST::new(&pos, Node::Id { lit: String::from("ba") }),
+                AST::new(&pos, Node::Id { lit: String::from("ca") }),
+                AST::new(&pos, Node::Id { lit: String::from("ca") })]
+        };
+
+        let (ast, ast2) = two_ast!(node1, node2);
+        assert!(!ast.same_value(&ast2));
+    }
+
+    #[test]
     fn break_equal_structure() {
         let (ast, ast2) = two_ast!(Node::Break, Node::Break);
         assert!(ast.same_value(&ast2));

--- a/src/parse/ast/node.rs
+++ b/src/parse/ast/node.rs
@@ -7,7 +7,7 @@ use crate::parse::lex::token::Token;
 
 fn equal_optional(this: &Option<Box<AST>>, that: &Option<Box<AST>>) -> bool {
     if let (Some(this), Some(that)) = (this, that) {
-        this.equal_structure(that)
+        this.same_value(that)
     } else {
         true
     }
@@ -18,7 +18,7 @@ fn equal_vec(this: &[AST], other: &[AST]) -> bool {
         false
     } else {
         for (left, right) in this.iter().zip(other) {
-            if !left.equal_structure(right) {
+            if !left.same_value(right) {
                 return false;
             }
         }
@@ -148,22 +148,21 @@ impl Node {
             (
                 Node::FromImport { id: lid, import: li },
                 Node::FromImport { id: rid, import: ri }
-            ) => lid.equal_structure(rid) && li.equal_structure(ri),
+            ) => lid.same_value(rid) && li.same_value(ri),
             (
                 Node::Class { ty: lt, args: la, parents: lp, body: lb },
                 Node::Class { ty: rt, args: ra, parents: rp, body: rb }
             ) =>
-                lt.equal_structure(rt)
+                lt.same_value(rt)
                     && equal_vec(la, ra)
                     && equal_vec(lp, rp)
                     && equal_optional(lb, rb),
             (Node::Generic { id: li, isa: lisa }, Node::Generic { id: ri, isa: risa }) =>
-                li.equal_structure(ri) && equal_optional(lisa, risa),
+                li.same_value(ri) && equal_optional(lisa, risa),
             (Node::Parent { ty: l_ty, args: la }, Node::Parent { ty: r_ty, args: ra }) =>
-                l_ty.equal_structure(r_ty) && equal_vec(la, ra),
-            (Node::Init, Node::Init) => true,
+                l_ty.same_value(r_ty) && equal_vec(la, ra),
             (Node::Reassign { left: ll, right: lr }, Node::Reassign { left: rl, right: rr }) =>
-                ll.equal_structure(rl) && lr.equal_structure(rr),
+                ll.same_value(rl) && lr.same_value(rr),
             (
                 Node::VariableDef {
                     mutable: lm,
@@ -180,7 +179,7 @@ impl Node {
                     forward: rf
                 }
             ) => lm == rm
-                && lv.equal_structure(rv)
+                && lv.same_value(rv)
                 && equal_optional(lt, rt)
                 && equal_optional(le, re)
                 && equal_vec(lf, rf),
@@ -203,93 +202,81 @@ impl Node {
                 }
             ) =>
                 lpu == rpu
-                    && li.equal_structure(ri)
+                    && li.same_value(ri)
                     && equal_vec(la, ra)
                     && equal_optional(lret, rret)
                     && equal_vec(lraise, rraise)
                     && equal_optional(lb, rb),
             (Node::AnonFun { args: la, body: lb }, Node::AnonFun { args: ra, body: rb }) =>
-                equal_vec(la, ra) && lb.equal_structure(rb),
+                equal_vec(la, ra) && lb.same_value(rb),
             (
                 Node::Raises { expr_or_stmt: les, errors: le },
                 Node::Raises { expr_or_stmt: res, errors: re }
-            ) => les.equal_structure(res) && equal_vec(le, re),
-            (Node::Raise { error: le }, Node::Raise { error: re }) => le.equal_structure(re),
+            ) => les.same_value(res) && equal_vec(le, re),
+            (Node::Raise { error: le }, Node::Raise { error: re }) => le.same_value(re),
             (
                 Node::Handle { expr_or_stmt: les, cases: lc },
                 Node::Handle { expr_or_stmt: res, cases: rc }
-            ) => les.equal_structure(res) && equal_vec(lc, rc),
+            ) => les.same_value(res) && equal_vec(lc, rc),
             (
                 Node::With { resource: lr, alias: Some((la, lmut, lty)), expr: le },
                 Node::With { resource: rr, alias: Some((ra, rmut, rty)), expr: re }
             ) =>
-                lr.equal_structure(rr)
-                    && la.equal_structure(ra)
+                lr.same_value(rr)
+                    && la.same_value(ra)
                     && lmut == rmut
                     && equal_optional(lty, rty)
-                    && le.equal_structure(re),
+                    && le.same_value(re),
             (
                 Node::With { resource: lr, alias: None, expr: le },
                 Node::With { resource: rr, alias: None, expr: re }
-            ) => lr.equal_structure(rr) && le.equal_structure(re),
+            ) => lr.same_value(rr) && le.same_value(re),
             (
                 Node::FunctionCall { name: ln, args: la },
                 Node::FunctionCall { name: rn, args: ra }
-            ) => ln.equal_structure(rn) && equal_vec(la, ra),
+            ) => ln.same_value(rn) && equal_vec(la, ra),
             (
                 Node::PropertyCall { instance: li, property: lp },
                 Node::PropertyCall { instance: ri, property: rp }
-            ) => li.equal_structure(ri) && lp.equal_structure(rp),
+            ) => li.same_value(ri) && lp.same_value(rp),
             (Node::Id { lit: l }, Node::Id { lit: r }) => l == r,
             (
                 Node::ExpressionType { expr: le, mutable: lm, ty: lt },
                 Node::ExpressionType { expr: re, mutable: rm, ty: rt }
-            ) => le.equal_structure(re) && lm == rm && equal_optional(lt, rt),
+            ) => le.same_value(re) && lm == rm && equal_optional(lt, rt),
             (
                 Node::TypeDef { ty: lt, isa: li, body: lb },
                 Node::TypeDef { ty: rt, isa: ri, body: rb }
-            ) => lt.equal_structure(rt) && equal_optional(li, ri) && equal_optional(lb, rb),
+            ) => lt.same_value(rt) && equal_optional(li, ri) && equal_optional(lb, rb),
             (
                 Node::TypeAlias { ty: lt, isa: li, conditions: lc },
                 Node::TypeAlias { ty: rt, isa: ri, conditions: rc }
-            ) => lt.equal_structure(rt) && li.equal_structure(ri) && equal_vec(lc, rc),
+            ) => lt.same_value(rt) && li.same_value(ri) && equal_vec(lc, rc),
             (Node::TypeTup { types: l }, Node::TypeTup { types: r }) => equal_vec(l, r),
             (Node::TypeUnion { types: l }, Node::TypeUnion { types: r }) => equal_vec(l, r),
             (Node::Type { id: li, generics: lg }, Node::Type { id: ri, generics: rg }) =>
-                li.equal_structure(ri) && equal_vec(lg, rg),
+                li.same_value(ri) && equal_vec(lg, rg),
             (Node::TypeFun { args: la, ret_ty: lr }, Node::TypeFun { args: ra, ret_ty: rr }) =>
-                equal_vec(la, ra) && lr.equal_structure(rr),
+                equal_vec(la, ra) && lr.same_value(rr),
             (Node::Condition { cond: lc, el: le }, Node::Condition { cond: rc, el: re }) =>
-                lc.equal_structure(rc) && equal_optional(le, re),
+                lc.same_value(rc) && equal_optional(le, re),
             (
                 Node::FunArg { vararg: lv, mutable: lm, var: lvar, ty: lt, default: ld },
                 Node::FunArg { vararg: rv, mutable: rm, var: rvar, ty: rt, default: rd }
             ) =>
                 lv == rv
                     && lm == rm
-                    && lvar.equal_structure(rvar)
+                    && lvar.same_value(rvar)
                     && equal_optional(lt, rt)
                     && equal_optional(ld, rd),
-            (Node::_Self, Node::_Self) => true,
-            (Node::AddOp, Node::AddOp) => true,
-            (Node::SubOp, Node::SubOp) => true,
-            (Node::SqrtOp, Node::SqrtOp) => true,
-            (Node::MulOp, Node::MulOp) => true,
-            (Node::FDivOp, Node::FDivOp) => true,
-            (Node::DivOp, Node::DivOp) => true,
-            (Node::PowOp, Node::PowOp) => true,
-            (Node::ModOp, Node::ModOp) => true,
-            (Node::EqOp, Node::EqOp) => true,
-            (Node::LeOp, Node::LeOp) => true,
-            (Node::GeOp, Node::GeOp) => true,
             (
                 Node::SetBuilder { item: li, conditions: lc },
                 Node::SetBuilder { item: ri, conditions: rc }
-            ) => li.equal_structure(ri) && equal_vec(lc, rc),
+            ) => li.same_value(ri) && equal_vec(lc, rc),
             (
                 Node::ListBuilder { item: li, conditions: lc },
                 Node::ListBuilder { item: ri, conditions: rc }
-            ) => li.equal_structure(ri) && equal_vec(lc, rc),
+            ) => li.same_value(ri) && equal_vec(lc, rc),
             (Node::Set { elements: l }, Node::Set { elements: r }) => equal_vec(l, r),
             (Node::List { elements: l }, Node::List { elements: r }) => equal_vec(l, r),
             (Node::Tuple { elements: l }, Node::Tuple { elements: r }) => equal_vec(l, r),
@@ -297,8 +284,8 @@ impl Node {
                 Node::Range { from: lf, to: lt, inclusive: li, step: ls },
                 Node::Range { from: rf, to: rt, inclusive: ri, step: rs }
             ) =>
-                lf.equal_structure(rf)
-                    && lt.equal_structure(rt)
+                lf.same_value(rf)
+                    && lt.same_value(rt)
                     && li == ri
                     && equal_optional(ls, rs),
             (Node::Block { statements: l }, Node::Block { statements: r }) => equal_vec(l, r),
@@ -310,91 +297,87 @@ impl Node {
                 l == r && equal_vec(le, re),
             (Node::DocStr { lit: l }, Node::DocStr { lit: r }) => l == r,
             (Node::Bool { lit: l }, Node::Bool { lit: r }) => l == r,
-            (Node::AddU { expr: l }, Node::AddU { expr: r }) => l.equal_structure(r),
-            (Node::SubU { expr: l }, Node::SubU { expr: r }) => l.equal_structure(r),
+            (Node::AddU { expr: l }, Node::AddU { expr: r }) => l.same_value(r),
+            (Node::SubU { expr: l }, Node::SubU { expr: r }) => l.same_value(r),
             (Node::Add { left: ll, right: lr }, Node::Add { left: rl, right: rr }) =>
-                ll.equal_structure(rl) && lr.equal_structure(rr),
+                ll.same_value(rl) && lr.same_value(rr),
             (Node::Sub { left: ll, right: lr }, Node::Sub { left: rl, right: rr }) =>
-                ll.equal_structure(rl) && lr.equal_structure(rr),
+                ll.same_value(rl) && lr.same_value(rr),
             (Node::Mul { left: ll, right: lr }, Node::Mul { left: rl, right: rr }) =>
-                ll.equal_structure(rl) && lr.equal_structure(rr),
+                ll.same_value(rl) && lr.same_value(rr),
             (Node::Div { left: ll, right: lr }, Node::Div { left: rl, right: rr }) =>
-                ll.equal_structure(rl) && lr.equal_structure(rr),
+                ll.same_value(rl) && lr.same_value(rr),
             (Node::BOr { left: ll, right: lr }, Node::BOr { left: rl, right: rr }) =>
-                ll.equal_structure(rl) && lr.equal_structure(rr),
+                ll.same_value(rl) && lr.same_value(rr),
             (Node::Mod { left: ll, right: lr }, Node::Mod { left: rl, right: rr }) =>
-                ll.equal_structure(rl) && lr.equal_structure(rr),
+                ll.same_value(rl) && lr.same_value(rr),
             (Node::Pow { left: ll, right: lr }, Node::Pow { left: rl, right: rr }) =>
-                ll.equal_structure(rl) && lr.equal_structure(rr),
-            (Node::Sqrt { expr: l }, Node::Sqrt { expr: r }) => l.equal_structure(r),
+                ll.same_value(rl) && lr.same_value(rr),
+            (Node::Sqrt { expr: l }, Node::Sqrt { expr: r }) => l.same_value(r),
             (Node::FDiv { left: ll, right: lr }, Node::FDiv { left: rl, right: rr }) =>
-                ll.equal_structure(rl) && lr.equal_structure(rr),
+                ll.same_value(rl) && lr.same_value(rr),
             (Node::BAnd { left: ll, right: lr }, Node::BAnd { left: rl, right: rr }) =>
-                ll.equal_structure(rl) && lr.equal_structure(rr),
+                ll.same_value(rl) && lr.same_value(rr),
             (Node::BXOr { left: ll, right: lr }, Node::BXOr { left: rl, right: rr }) =>
-                ll.equal_structure(rl) && lr.equal_structure(rr),
-            (Node::BOneCmpl { expr: l }, Node::BOneCmpl { expr: r }) => l.equal_structure(r),
+                ll.same_value(rl) && lr.same_value(rr),
+            (Node::BOneCmpl { expr: l }, Node::BOneCmpl { expr: r }) => l.same_value(r),
             (Node::BLShift { left: ll, right: lr }, Node::BLShift { left: rl, right: rr }) =>
-                ll.equal_structure(rl) && lr.equal_structure(rr),
+                ll.same_value(rl) && lr.same_value(rr),
             (Node::BRShift { left: ll, right: lr }, Node::BRShift { left: rl, right: rr }) =>
-                ll.equal_structure(rl) && lr.equal_structure(rr),
+                ll.same_value(rl) && lr.same_value(rr),
             (Node::Leq { left: ll, right: lr }, Node::Leq { left: rl, right: rr }) =>
-                ll.equal_structure(rl) && lr.equal_structure(rr),
+                ll.same_value(rl) && lr.same_value(rr),
             (Node::Geq { left: ll, right: lr }, Node::Geq { left: rl, right: rr }) =>
-                ll.equal_structure(rl) && lr.equal_structure(rr),
+                ll.same_value(rl) && lr.same_value(rr),
             (Node::IsN { left: ll, right: lr }, Node::IsN { left: rl, right: rr }) =>
-                ll.equal_structure(rl) && lr.equal_structure(rr),
+                ll.same_value(rl) && lr.same_value(rr),
             (Node::Neq { left: ll, right: lr }, Node::Neq { left: rl, right: rr }) =>
-                ll.equal_structure(rl) && lr.equal_structure(rr),
+                ll.same_value(rl) && lr.same_value(rr),
             (Node::IsA { left: ll, right: lr }, Node::IsA { left: rl, right: rr }) =>
-                ll.equal_structure(rl) && lr.equal_structure(rr),
+                ll.same_value(rl) && lr.same_value(rr),
             (Node::Le { left: ll, right: lr }, Node::Le { left: rl, right: rr }) =>
-                ll.equal_structure(rl) && lr.equal_structure(rr),
+                ll.same_value(rl) && lr.same_value(rr),
             (Node::Ge { left: ll, right: lr }, Node::Ge { left: rl, right: rr }) =>
-                ll.equal_structure(rl) && lr.equal_structure(rr),
+                ll.same_value(rl) && lr.same_value(rr),
             (Node::Is { left: ll, right: lr }, Node::Is { left: rl, right: rr }) =>
-                ll.equal_structure(rl) && lr.equal_structure(rr),
+                ll.same_value(rl) && lr.same_value(rr),
             (Node::Eq { left: ll, right: lr }, Node::Eq { left: rl, right: rr }) =>
-                ll.equal_structure(rl) && lr.equal_structure(rr),
+                ll.same_value(rl) && lr.same_value(rr),
             (Node::IsNA { left: ll, right: lr }, Node::IsNA { left: rl, right: rr }) =>
-                ll.equal_structure(rl) && lr.equal_structure(rr),
-            (Node::Not { expr: l }, Node::Not { expr: r }) => l.equal_structure(r),
+                ll.same_value(rl) && lr.same_value(rr),
+            (Node::Not { expr: l }, Node::Not { expr: r }) => l.same_value(r),
             (Node::And { left: ll, right: lr }, Node::And { left: rl, right: rr }) =>
-                ll.equal_structure(rl) && lr.equal_structure(rr),
+                ll.same_value(rl) && lr.same_value(rr),
             (Node::Or { left: ll, right: lr }, Node::Or { left: rl, right: rr }) =>
-                ll.equal_structure(rl) && lr.equal_structure(rr),
+                ll.same_value(rl) && lr.same_value(rr),
             (
                 Node::IfElse { cond: lc, then: lt, el: le },
                 Node::IfElse { cond: rc, then: rt, el: re }
-            ) => lc.equal_structure(rc) && lt.equal_structure(rt) && equal_optional(le, re),
+            ) => lc.same_value(rc) && lt.same_value(rt) && equal_optional(le, re),
             (Node::Match { cond: lco, cases: lc }, Node::Match { cond: rco, cases: rc }) =>
-                lco.equal_structure(rco) && equal_vec(lc, rc),
+                lco.same_value(rco) && equal_vec(lc, rc),
             (Node::Case { cond: lc, body: lb }, Node::Case { cond: rc, body: rb }) =>
-                lc.equal_structure(rc) && lb.equal_structure(rb),
+                lc.same_value(rc) && lb.same_value(rb),
             (
                 Node::For { expr: le, col: lc, body: lb },
                 Node::For { expr: re, col: rc, body: rb }
-            ) => le.equal_structure(re) && lc.equal_structure(rc) && lb.equal_structure(rb),
+            ) => le.same_value(re) && lc.same_value(rc) && lb.same_value(rb),
             (Node::In { left: ll, right: lr }, Node::In { left: rl, right: rr }) =>
-                ll.equal_structure(rl) && lr.equal_structure(rr),
-            (Node::Step { amount: la }, Node::Step { amount: ra }) => la.equal_structure(ra),
+                ll.same_value(rl) && lr.same_value(rr),
+            (Node::Step { amount: la }, Node::Step { amount: ra }) => la.same_value(ra),
             (Node::While { cond: lc, body: lb }, Node::While { cond: rc, body: rb }) =>
-                lc.equal_structure(rc) && lb.equal_structure(rb),
-            (Node::Break, Node::Break) => true,
-            (Node::Continue, Node::Continue) => true,
+                lc.same_value(rc) && lb.same_value(rb),
             (Node::Return { expr: left }, Node::Return { expr: right }) =>
-                left.equal_structure(right),
-            (Node::ReturnEmpty, Node::ReturnEmpty) => true,
-            (Node::Underscore, Node::Underscore) => true,
-            (Node::Undefined, Node::Undefined) => true,
-            (Node::Pass, Node::Pass) => true,
+                left.same_value(right),
             (Node::Question { left: ll, right: lr }, Node::Question { left: rl, right: rr }) =>
-                ll.equal_structure(rl) && lr.equal_structure(rr),
+                ll.same_value(rl) && lr.same_value(rr),
             (Node::QuestionOp { expr: left }, Node::QuestionOp { expr: right }) =>
-                left.equal_structure(right),
+                left.same_value(right),
             (Node::Print { expr: left }, Node::Print { expr: right }) =>
-                left.equal_structure(right),
+                left.same_value(right),
             (Node::Comment { .. }, Node::Comment { .. }) => true,
+
+            (left, right) if **left == **right => true,
             _ => false
         }
     }
@@ -437,7 +420,7 @@ impl Node {
     }
 
     fn is_operator(&self) -> bool {
-        matches!(&self,            Node::Add { .. }
+        matches!(&self, Node::Add { .. }
             | Node::AddU { .. }
             | Node::Sub { .. }
             | Node::SubU { .. }


### PR DESCRIPTION
### Summary
Add extra tests to test low hanging fruit of Name and AST.
A lot of the type checker builds on these so best to test some extra edge cases which are not covered in any of the end-to-end tests we have currently.
A lot of these end-to-end tests cover only basic language functionality, but not a lot of type unions etc.

### Added Tests
- Identifier from id, expression type, and tuple
- Matching tuple identifier with type
- Matching identifier with tuple type
- Equality of tuples for AST Node
