### PR TITLE
Treat alias in with resource as def

### DIFF
--- a/src/check/constrain/generate/resources.rs
+++ b/src/check/constrain/generate/resources.rs
@@ -50,7 +50,7 @@ pub fn gen_resources(
                 *mutable,
                 ctx,
                 &mut constr,
-                &env,
+                &env.define_mode(true),
             )?;
             let (mut constr, env) = generate(expr, &env, ctx, &mut constr)?;
             constr.exit_set(&ast.pos)?;

--- a/tests/system/valid/error.rs
+++ b/tests/system/valid/error.rs
@@ -16,7 +16,6 @@ fn raise_ast_verify() -> OutTestRet {
 }
 
 #[test]
-#[ignore] // Type aliases
 fn with_ast_verify() -> OutTestRet {
     test_directory(true, &["error"], &["error", "target"], "with")
 }


### PR DESCRIPTION
### Relevant issues

Closes #264 

### Summary

A type alias is now treated as a variable declaration.
It is added to the environment as opposed to checking  that the environment contains said variable.

### Added Tests

- `with_ast_verify`: Check that with type alias works


