### PR TITLE
Treat Range as List[Int]

### DIFF
--- a/src/check/constrain/generate/call.rs
+++ b/src/check/constrain/generate/call.rs
@@ -125,7 +125,7 @@ pub fn gen_call(
                 &Expected::try_from((ast, &env.var_mappings))?,
             );
 
-            let mut constr = constr_col(item, &env, &mut constr, Some(name.clone()))?;
+            let mut constr = constr_col(item, &env, &mut constr, Some(name))?;
             generate(item, &env, ctx, &mut constr)
         }
 

--- a/src/check/constrain/generate/env.rs
+++ b/src/check/constrain/generate/env.rs
@@ -102,7 +102,7 @@ impl Environment {
             if old == var { return self.get_var(new); }
         }
 
-        self.vars.get(var).cloned().map(|res| res)
+        self.vars.get(var).cloned()
     }
 
     /// Union between two environments

--- a/src/check/constrain/generate/operation.rs
+++ b/src/check/constrain/generate/operation.rs
@@ -30,7 +30,14 @@ pub fn gen_op(
             let (mut constr, env) = generate(right, &env, ctx, &mut constr)?;
             generate(left, &env, ctx, &mut constr)
         }
-        Node::Range { .. } => constr_range(ast, env, ctx, constr, "range", true),
+        Node::Range { .. } => {
+            constr.add(
+                "range",
+                &Expected::new(&ast.pos, &Expect::Type { name: Name::from(clss::RANGE) }),
+                &Expected::try_from((ast, &env.var_mappings))?,
+            );
+            constr_range(ast, env, ctx, constr, "range", true)
+        },
         Node::Slice { .. } => {
             constr.add(
                 "slice",

--- a/src/check/constrain/unify/ty.rs
+++ b/src/check/constrain/unify/ty.rs
@@ -163,7 +163,7 @@ pub fn unify_type(
         (l_exp, r_exp) => match (l_exp, r_exp) {
             (Collection { ty }, Type { name }) | (Type { name }, Collection { ty }) => {
                 if let Some(col_ty) = name.collection_type(ctx)? {
-                    let expect = Expect::Type { name: col_ty.clone() };
+                    let expect = Expect::Type { name: col_ty };
                     constraints.push("collection type", ty, &Expected::new(&left.pos, &expect));
                     unify_link(constraints, ctx, total + 1)
                 } else {

--- a/src/check/constrain/unify/ty.rs
+++ b/src/check/constrain/unify/ty.rs
@@ -162,7 +162,7 @@ pub fn unify_type(
 
         (l_exp, r_exp) => match (l_exp, r_exp) {
             (Collection { ty }, Type { name }) | (Type { name }, Collection { ty }) => {
-                if let Some(col_ty) = name.collection_type(ctx) {
+                if let Some(col_ty) = name.collection_type(ctx)? {
                     let expect = Expect::Type { name: col_ty.clone() };
                     constraints.push("collection type", ty, &Expected::new(&left.pos, &expect));
                     unify_link(constraints, ctx, total + 1)

--- a/src/check/context/arg/mod.rs
+++ b/src/check/context/arg/mod.rs
@@ -5,7 +5,6 @@ use std::fmt::{Display, Formatter};
 
 use crate::check::context::arg::generic::GenericFunctionArg;
 use crate::check::name::Name;
-use crate::check::name::truename::TrueName;
 use crate::check::result::TypeErr;
 use crate::common::position::Position;
 
@@ -39,11 +38,11 @@ impl Display for FunctionArg {
     }
 }
 
-impl TryFrom<(&GenericFunctionArg, &HashMap<String, TrueName>, &Position)> for FunctionArg {
+impl TryFrom<(&GenericFunctionArg, &HashMap<Name, Name>, &Position)> for FunctionArg {
     type Error = Vec<TypeErr>;
 
     fn try_from(
-        (fun_arg, generics, pos): (&GenericFunctionArg, &HashMap<String, TrueName>, &Position)
+        (fun_arg, generics, pos): (&GenericFunctionArg, &HashMap<Name, Name>, &Position)
     ) -> Result<Self, Self::Error> {
         Ok(FunctionArg {
             is_py_type: fun_arg.is_py_type,

--- a/src/check/context/clss/mod.rs
+++ b/src/check/context/clss/mod.rs
@@ -25,6 +25,7 @@ pub const BOOL_PRIMITIVE: &str = "Bool";
 pub const ENUM_PRIMITIVE: &str = "Enum";
 pub const COMPLEX_PRIMITIVE: &str = "Complex";
 
+pub const COLLECTION: &str = "Collection";
 pub const RANGE: &str = "Range";
 pub const SLICE: &str = "Slice";
 pub const SET: &str = "Set";
@@ -221,6 +222,7 @@ pub fn concrete_to_python(name: &str) -> String {
         ENUM_PRIMITIVE => String::from(python::ENUM_PRIMITIVE),
         COMPLEX_PRIMITIVE => String::from(python::COMPLEX_PRIMITIVE),
 
+        COLLECTION => String::from(python::COLLECTION),
         RANGE => String::from(python::RANGE),
         SLICE => String::from(python::SLICE),
         SET => String::from(python::SET),

--- a/src/check/context/clss/mod.rs
+++ b/src/check/context/clss/mod.rs
@@ -77,7 +77,9 @@ impl HasParent<&TrueName> for Class {
     fn has_parent(&self, name: &TrueName, ctx: &Context, pos: &Position) -> TypeResult<bool> {
         Ok(&self.name == name || self.parents
             .iter()
-            .map(|p| ctx.class(p, pos)?.has_parent(name, ctx, pos))
+            .map(|p| ctx.class(p, pos)?.has_parent(name, ctx, pos).map(|res| {
+                res || p == name
+            }))
             .collect::<Result<Vec<bool>, _>>()?
             .iter()
             .any(|b| *b))
@@ -110,11 +112,11 @@ impl Display for Class {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result { write!(f, "{}", self.name) }
 }
 
-impl TryFrom<(&GenericClass, &HashMap<String, TrueName>, &Position)> for Class {
+impl TryFrom<(&GenericClass, &HashMap<Name, Name>, &Position)> for Class {
     type Error = Vec<TypeErr>;
 
     fn try_from(
-        (generic, generics, pos): (&GenericClass, &HashMap<String, TrueName>, &Position)
+        (generic, generics, pos): (&GenericClass, &HashMap<Name, Name>, &Position)
     ) -> Result<Self, Self::Error> {
         let try_arg = |a: &GenericFunctionArg| FunctionArg::try_from((a, generics, pos));
         let try_field = |field: &GenericField| Field::try_from((field, generics, pos));

--- a/src/check/context/clss/python.rs
+++ b/src/check/context/clss/python.rs
@@ -23,6 +23,7 @@ pub const BOOL_PRIMITIVE: &str = "bool";
 pub const ENUM_PRIMITIVE: &str = "enum";
 pub const COMPLEX_PRIMITIVE: &str = "complex";
 
+pub const COLLECTION: &str = "collection";
 pub const RANGE: &str = "range";
 pub const SLICE: &str = "slice";
 pub const SET: &str = "set";

--- a/src/check/context/field/mod.rs
+++ b/src/check/context/field/mod.rs
@@ -6,7 +6,6 @@ use std::fmt;
 use crate::check::context::field::generic::GenericField;
 use crate::check::name::Name;
 use crate::check::name::stringname::StringName;
-use crate::check::name::truename::TrueName;
 use crate::check::result::TypeErr;
 use crate::common::position::Position;
 
@@ -32,11 +31,11 @@ impl Display for Field {
     }
 }
 
-impl TryFrom<(&GenericField, &HashMap<String, TrueName>, &Position)> for Field {
+impl TryFrom<(&GenericField, &HashMap<Name, Name>, &Position)> for Field {
     type Error = Vec<TypeErr>;
 
     fn try_from(
-        (field, generics, pos): (&GenericField, &HashMap<String, TrueName>, &Position)
+        (field, generics, pos): (&GenericField, &HashMap<Name, Name>, &Position)
     ) -> Result<Self, Self::Error> {
         Ok(Field {
             is_py_type: field.is_py_type,

--- a/src/check/context/function/mod.rs
+++ b/src/check/context/function/mod.rs
@@ -12,7 +12,6 @@ use crate::check::context::function::generic::GenericFunction;
 use crate::check::name::IsSuperSet;
 use crate::check::name::Name;
 use crate::check::name::stringname::StringName;
-use crate::check::name::truename::TrueName;
 use crate::check::result::{TypeErr, TypeResult};
 use crate::common::delimit::comma_delm;
 use crate::common::position::Position;
@@ -85,11 +84,11 @@ impl Display for Function {
     }
 }
 
-impl TryFrom<(&GenericFunction, &HashMap<String, TrueName>, &Position)> for Function {
+impl TryFrom<(&GenericFunction, &HashMap<Name, Name>, &Position)> for Function {
     type Error = Vec<TypeErr>;
 
     fn try_from(
-        (fun, generics, pos): (&GenericFunction, &HashMap<String, TrueName>, &Position)
+        (fun, generics, pos): (&GenericFunction, &HashMap<Name, Name>, &Position)
     ) -> Result<Self, Self::Error> {
         let arguments: Vec<FunctionArg> = fun
             .arguments

--- a/src/check/context/resource.rs
+++ b/src/check/context/resource.rs
@@ -21,9 +21,9 @@ impl Context {
         let python_dir = resource("std");
         let (py_types, py_fields, py_functions) = python_files(&python_dir)?;
 
-        let classes = classes.union(&py_types).cloned().collect();
-        let functions = functions.union(&py_functions).cloned().collect();
-        let fields = fields.union(&py_fields).cloned().collect();
+        let classes: HashSet<GenericClass> = classes.union(&py_types).cloned().collect();
+        let functions: HashSet<GenericFunction> = functions.union(&py_functions).cloned().collect();
+        let fields: HashSet<GenericField> = fields.union(&py_fields).cloned().collect();
 
         Ok(Context { classes, functions, fields })
     }

--- a/src/check/name/namevariant.rs
+++ b/src/check/name/namevariant.rs
@@ -27,11 +27,11 @@ impl Display for NameVariant {
 }
 
 impl CollectionType for NameVariant {
-    fn collection_type(&self, ctx: &Context) -> Option<Name> {
+    fn collection_type(&self, ctx: &Context) -> TypeResult<Option<Name>> {
         if let NameVariant::Single(string_name) = self {
             string_name.collection_type(ctx)
         } else {
-            None
+            Ok(None)
         }
     }
 }

--- a/src/check/name/namevariant.rs
+++ b/src/check/name/namevariant.rs
@@ -2,7 +2,7 @@ use std::fmt::{Display, Error, Formatter};
 use std::hash::Hash;
 
 use crate::check::context::Context;
-use crate::check::name::IsSuperSet;
+use crate::check::name::{CollectionType, IsSuperSet};
 use crate::check::name::Name;
 use crate::check::name::stringname::StringName;
 use crate::check::result::TypeResult;
@@ -22,6 +22,16 @@ impl Display for NameVariant {
             NameVariant::Single(direct_name) => write!(f, "{}", direct_name),
             NameVariant::Tuple(names) => write!(f, "({})", comma_delm(names)),
             NameVariant::Fun(args, ret) => write!(f, "({}) -> {}", comma_delm(args), ret)
+        }
+    }
+}
+
+impl CollectionType for NameVariant {
+    fn collection_type(&self, ctx: &Context) -> Option<Name> {
+        if let NameVariant::Single(string_name) = self {
+            string_name.collection_type(ctx)
+        } else {
+            None
         }
     }
 }

--- a/src/check/name/stringname/mod.rs
+++ b/src/check/name/stringname/mod.rs
@@ -34,9 +34,9 @@ impl Display for StringName {
 }
 
 impl CollectionType for StringName {
+    /// Checks if this type has a List\[Int\] as parent, and returns Int if it does.
     fn collection_type(&self, ctx: &Context) -> TypeResult<Option<Name>> {
         if let Ok(clss) = ctx.class(self, &Position::default()) {
-            // Must either return type as generic for matching, or check type (as here).
             let generics = &[Name::from(clss::INT_PRIMITIVE)];
             let col_string_name = StringName::new(clss::LIST, generics);
 
@@ -92,8 +92,14 @@ impl StringName {
     ) -> TypeResult<StringName> {
         if let Some(name) = generics.get(&Name::from(self)) {
             let msg = format!("{} is not a DirectName", name);
-            for string_name in name.as_direct(&msg, pos)? {
-                return Ok(string_name);
+            let string_names = name.as_direct(&msg, pos)?;
+            if string_names.len() > 1 {
+                let msg = format!("Cannot substitute type union {}", name);
+                return Err(vec![TypeErr::new(pos, &msg)])
+            }
+
+            if let Some(string_name) = string_names.iter().next() {
+                return Ok(string_name.clone());
             }
 
             let msg = format!("{} incorrect DirectName", name);

--- a/src/check/name/stringname/mod.rs
+++ b/src/check/name/stringname/mod.rs
@@ -2,12 +2,10 @@ use std::collections::HashMap;
 use std::fmt::{Display, Error, Formatter};
 use std::hash::Hash;
 
-use crate::check::context::{Context, LookupClass};
+use crate::check::context::{clss, Context, LookupClass};
 use crate::check::context::clss::HasParent;
-use crate::check::name::IsSuperSet;
+use crate::check::name::{CollectionType, IsSuperSet};
 use crate::check::name::Name;
-use crate::check::name::namevariant::NameVariant;
-use crate::check::name::TrueName;
 use crate::check::result::{TypeErr, TypeResult};
 use crate::common::delimit::comma_delm;
 use crate::common::position::Position;
@@ -35,8 +33,26 @@ impl Display for StringName {
     }
 }
 
+impl CollectionType for StringName {
+    fn collection_type(&self, ctx: &Context) -> Option<Name> {
+        if let Ok(clss) = ctx.class(self, &Position::default()) {
+            // Must either return type as generic for matching, or check type (as here).
+            let generics = &[Name::from(clss::INT_PRIMITIVE)];
+            let col_string_name = StringName::new(clss::LIST, generics);
+
+            let col_name = Name::from(&col_string_name);
+            if let Ok(parent) = clss.has_parent(&col_name, ctx, &Position::default()) {
+                return if parent { Some(Name::from(clss::INT_PRIMITIVE)) } else { None };
+            }
+        }
+        None
+    }
+}
+
 impl From<&str> for StringName {
-    fn from(name: &str) -> Self { StringName { name: String::from(name), generics: vec![] } }
+    fn from(name: &str) -> Self {
+        StringName { name: String::from(name), generics: vec![] }
+    }
 }
 
 impl IsSuperSet<StringName> for StringName {
@@ -62,22 +78,23 @@ impl StringName {
         StringName { name: String::from(lit), generics: Vec::from(generics) }
     }
 
-    pub fn empty() -> StringName { StringName::new("()", &[]) }
+    pub fn empty() -> StringName {
+        StringName::new("()", &[])
+    }
 
     pub fn substitute(
         &self,
-        generics: &HashMap<String, TrueName>,
+        generics: &HashMap<Name, Name>,
         pos: &Position,
     ) -> TypeResult<StringName> {
-        if let Some(name) = generics.get(&self.name) {
-            match &name.variant {
-                NameVariant::Single(direct_name) if direct_name.generics.is_empty() =>
-                    Ok(direct_name.clone()),
-                _ => {
-                    let msg = format!("Cannot substitute '{}' with `{}`", name.variant, name);
-                    Err(vec![TypeErr::new(pos, &msg)])
-                }
+        if let Some(name) = generics.get(&Name::from(self)) {
+            let msg = format!("{} is not a DirectName", name);
+            for string_name in name.as_direct(&msg, pos)? {
+                return Ok(string_name)
             }
+
+            let msg = format!("{} incorrect DirectName", name);
+            Err(vec![TypeErr::new(pos, &msg)])
         } else {
             Ok(StringName {
                 name: self.name.clone(),

--- a/src/check/name/stringname/mod.rs
+++ b/src/check/name/stringname/mod.rs
@@ -34,18 +34,21 @@ impl Display for StringName {
 }
 
 impl CollectionType for StringName {
-    fn collection_type(&self, ctx: &Context) -> Option<Name> {
+    fn collection_type(&self, ctx: &Context) -> TypeResult<Option<Name>> {
         if let Ok(clss) = ctx.class(self, &Position::default()) {
             // Must either return type as generic for matching, or check type (as here).
             let generics = &[Name::from(clss::INT_PRIMITIVE)];
             let col_string_name = StringName::new(clss::LIST, generics);
 
             let col_name = Name::from(&col_string_name);
-            if let Ok(parent) = clss.has_parent(&col_name, ctx, &Position::default()) {
-                return if parent { Some(Name::from(clss::INT_PRIMITIVE)) } else { None };
-            }
+            let parent = clss.has_parent(&col_name, ctx, &Position::default())?;
+            return if parent {
+                Ok(Some(Name::from(clss::INT_PRIMITIVE)))
+            } else {
+                Ok(None)
+            };
         }
-        None
+        Ok(None)
     }
 }
 
@@ -90,7 +93,7 @@ impl StringName {
         if let Some(name) = generics.get(&Name::from(self)) {
             let msg = format!("{} is not a DirectName", name);
             for string_name in name.as_direct(&msg, pos)? {
-                return Ok(string_name)
+                return Ok(string_name);
             }
 
             let msg = format!("{} incorrect DirectName", name);

--- a/src/check/name/truename/mod.rs
+++ b/src/check/name/truename/mod.rs
@@ -4,7 +4,7 @@ use std::hash::Hash;
 
 use crate::check::context::clss::NONE;
 use crate::check::context::Context;
-use crate::check::name::{AsMutable, AsNullable, IsNullable, IsSuperSet};
+use crate::check::name::{AsMutable, AsNullable, CollectionType, IsNullable, IsSuperSet};
 use crate::check::name::Name;
 use crate::check::name::namevariant::NameVariant;
 use crate::check::name::stringname::StringName;
@@ -29,6 +29,12 @@ impl AsMutable for TrueName {
 impl From<&NameVariant> for TrueName {
     fn from(variant: &NameVariant) -> Self {
         TrueName { is_mutable: false, is_nullable: false, variant: variant.clone() }
+    }
+}
+
+impl CollectionType for TrueName {
+    fn collection_type(&self, ctx: &Context) -> Option<Name> {
+        self.variant.collection_type(ctx)
     }
 }
 
@@ -119,7 +125,7 @@ impl TrueName {
         }
     }
 
-    pub fn substitute(&self, generics: &HashMap<String, TrueName>, pos: &Position) -> TypeResult<TrueName> {
+    pub fn substitute(&self, generics: &HashMap<Name, Name>, pos: &Position) -> TypeResult<TrueName> {
         let variant = match &self.variant {
             NameVariant::Single(direct_name) =>
                 NameVariant::Single(direct_name.substitute(generics, pos)?),

--- a/src/check/name/truename/mod.rs
+++ b/src/check/name/truename/mod.rs
@@ -33,7 +33,7 @@ impl From<&NameVariant> for TrueName {
 }
 
 impl CollectionType for TrueName {
-    fn collection_type(&self, ctx: &Context) -> Option<Name> {
+    fn collection_type(&self, ctx: &Context) -> TypeResult<Option<Name>> {
         self.variant.collection_type(ctx)
     }
 }

--- a/src/check/resource/std/collection.py
+++ b/src/check/resource/std/collection.py
@@ -8,7 +8,7 @@ class collection_iter(Generic[T]):
     def __init__(self): pass
     def __next__(self) -> T: pass
 
-class set(Generic[T], collection):
+class set(Generic[T], collection[T]):
     def __init__(self): pass
     def __iter__(self) -> set_iterator[T]: pass
 
@@ -19,7 +19,7 @@ class set_iterator(Generic[T]):
     def __init__(self): pass
     def __next__(self) -> T: pass
 
-class list(Generic[T], collection):
+class list(Generic[T], collection[T]):
     def __init__(self): pass
     def __iter__(self) -> list_iterator[T]: pass
 

--- a/src/check/resource/std/collection.py
+++ b/src/check/resource/std/collection.py
@@ -1,6 +1,14 @@
 from typing import TypeVar, Generic, Union
 
-class set(Generic[T]):
+class collection(Generic[T]):
+    def __init__(self): pass
+    def __iter__(self) -> collection_iter[T]: pass
+
+class collection_iter(Generic[T]):
+    def __init__(self): pass
+    def __next__(self) -> T: pass
+
+class set(Generic[T], collection):
     def __init__(self): pass
     def __iter__(self) -> set_iterator[T]: pass
 
@@ -11,7 +19,7 @@ class set_iterator(Generic[T]):
     def __init__(self): pass
     def __next__(self) -> T: pass
 
-class list(Generic[T]):
+class list(Generic[T], collection):
     def __init__(self): pass
     def __iter__(self) -> list_iterator[T]: pass
 

--- a/src/check/resource/std/range.py
+++ b/src/check/resource/std/range.py
@@ -1,4 +1,6 @@
-class range:
+from typing import List
+
+class range(list[int]):
     start: int = 0
     stop: int = 0
     step: int = 0

--- a/src/check/resource/std/range.py
+++ b/src/check/resource/std/range.py
@@ -17,3 +17,5 @@ class slice:
     start: int = 0
     stop: int = 0
     step: int = 0
+
+    def __str__(self) -> str: pass

--- a/tests/resource/invalid/type/control_flow/if_not_boolean.mamba
+++ b/tests/resource/invalid/type/control_flow/if_not_boolean.mamba
@@ -1,1 +1,1 @@
-if 0..10 then print "hello world"
+if 0::10 then print "hello world"

--- a/tests/resource/valid/control_flow/.tmpTnm001/for_over_range_from_func.py
+++ b/tests/resource/valid/control_flow/.tmpTnm001/for_over_range_from_func.py
@@ -1,0 +1,5 @@
+def f() -> range:
+    range(0, 2, 1)
+
+for x in f():
+    print(x)

--- a/tests/resource/valid/control_flow/for_over_range_from_func_check.py
+++ b/tests/resource/valid/control_flow/for_over_range_from_func_check.py
@@ -1,4 +1,4 @@
-def f(): range:
+def f() -> range:
     range(0,2,1)
 
 for x in f():

--- a/tests/system/valid/control_flow.rs
+++ b/tests/system/valid/control_flow.rs
@@ -11,7 +11,7 @@ fn for_over_collection_of_tuple() -> OutTestRet {
 }
 
 #[test]
-fn fot_over_range_from_func() -> OutTestRet {
+fn for_over_range_from_func() -> OutTestRet {
     test_directory(true, &["control_flow"], &["control_flow", "target"], "for_over_range_from_func")
 }
 

--- a/tests/system/valid/control_flow.rs
+++ b/tests/system/valid/control_flow.rs
@@ -11,7 +11,6 @@ fn for_over_collection_of_tuple() -> OutTestRet {
 }
 
 #[test]
-#[ignore] // Fix range from function
 fn fot_over_range_from_func() -> OutTestRet {
     test_directory(true, &["control_flow"], &["control_flow", "target"], "for_over_range_from_func")
 }


### PR DESCRIPTION
### Relevant issues

Closes #260

### Summary

Insert a `Range(List[Int])` class in built-in Python resources.
The type checker should detect that this is a type of collection, and then match the `List[Int]` with `List[Int]` when matching a `Collection { exp }` with `Type { .. }`.

Expand generics so that to make use of the fact that, for instance, Range is a type of List[Int] which is a type of Collection[Int].

### Added Tests

