### PR TITLE
Remove range and slice from core language

### DIFF
--- a/src/generate/ast/mod.rs
+++ b/src/generate/ast/mod.rs
@@ -271,18 +271,6 @@ fn to_py(core: &Core, ind: usize) -> String {
             newline_if_body(body, ind)
         ),
         Core::In { left, right } => format! {"{} in {}", to_py(left, ind), to_py(right, ind)},
-        Core::Range { from, to, step } => format!(
-            "range({}, {}, {})",
-            to_py(from.as_ref(), ind),
-            to_py(to.as_ref(), ind),
-            to_py(step.as_ref(), ind),
-        ),
-        Core::Slice { from, to, step } => format!(
-            "slice({}, {}, {})",
-            to_py(from.as_ref(), ind),
-            to_py(to.as_ref(), ind),
-            to_py(step.as_ref(), ind),
-        ),
         Core::Index { item, range } => format!("{}[{}]", to_py(item, ind), to_py(range, ind)),
         Core::If { cond, then } => {
             format!("if {}:{}", to_py(cond.as_ref(), ind), newline_if_body(then, ind))

--- a/src/generate/ast/node.rs
+++ b/src/generate/ast/node.rs
@@ -26,8 +26,6 @@ pub enum Core {
     TupleLiteral { elements: Vec<Core> },
     Set { elements: Vec<Core> },
     List { elements: Vec<Core> },
-    Range { from: Box<Core>, to: Box<Core>, step: Box<Core> },
-    Slice { from: Box<Core>, to: Box<Core>, step: Box<Core> },
     Index { item: Box<Core>, range: Box<Core> },
     GeOp,
     Ge { left: Box<Core>, right: Box<Core> },

--- a/src/generate/convert/control_flow.rs
+++ b/src/generate/convert/control_flow.rs
@@ -167,13 +167,16 @@ mod tests {
         let range = to_pos!(Node::Range { from, to, inclusive: false, step: None });
 
         let (from, to, step) = match gen(&range) {
-            Ok(Core::Range { from, to, step }) => (from, to, step),
+            Ok(Core::FunctionCall { function, args }) => {
+                assert_eq!(*function, Core::Id { lit: String::from("range") });
+                (args[0].clone(), args[1].clone(), args[2].clone())
+            }
             other => panic!("Expected range but was {:?}", other),
         };
 
-        assert_eq!(*from, Core::Id { lit: String::from("a") });
-        assert_eq!(*to, Core::Id { lit: String::from("b") });
-        assert_eq!(*step, Core::Int { int: String::from("1") });
+        assert_eq!(from, Core::Id { lit: String::from("a") });
+        assert_eq!(to, Core::Id { lit: String::from("b") });
+        assert_eq!(step, Core::Int { int: String::from("1") });
     }
 
     #[test]
@@ -183,19 +186,22 @@ mod tests {
         let range = to_pos!(Node::Range { from, to, inclusive: true, step: None });
 
         let (from, to, step) = match gen(&range) {
-            Ok(Core::Range { from, to, step }) => (from, to, step),
+            Ok(Core::FunctionCall { function, args }) => {
+                assert_eq!(*function, Core::Id { lit: String::from("range") });
+                (args[0].clone(), args[1].clone(), args[2].clone())
+            }
             other => panic!("Expected range but was {:?}", other),
         };
 
-        assert_eq!(*from, Core::Id { lit: String::from("a") });
+        assert_eq!(from, Core::Id { lit: String::from("a") });
         assert_eq!(
-            *to,
+            to,
             Core::Add {
                 left: Box::from(Core::Id { lit: String::from("b") }),
                 right: Box::from(Core::Int { int: String::from("1") }),
             }
         );
-        assert_eq!(*step, Core::Int { int: String::from("1") });
+        assert_eq!(step, Core::Int { int: String::from("1") });
     }
 
     #[test]
@@ -206,12 +212,15 @@ mod tests {
         let range = to_pos!(Node::Range { from, to, inclusive: false, step });
 
         let (from, to, step) = match gen(&range) {
-            Ok(Core::Range { from, to, step }) => (from, to, step),
+            Ok(Core::FunctionCall { function, args }) => {
+                assert_eq!(*function, Core::Id { lit: String::from("range") });
+                (args[0].clone(), args[1].clone(), args[2].clone())
+            }
             other => panic!("Expected range but was {:?}", other),
         };
 
-        assert_eq!(*from, Core::Id { lit: String::from("a") });
-        assert_eq!(*to, Core::Id { lit: String::from("b") });
-        assert_eq!(*step, Core::Id { lit: String::from("c") });
+        assert_eq!(from, Core::Id { lit: String::from("a") });
+        assert_eq!(to, Core::Id { lit: String::from("b") });
+        assert_eq!(step, Core::Id { lit: String::from("c") });
     }
 }


### PR DESCRIPTION
These are just function calls, no need to have separate language constructs.

I do distinctly remember removing this, not sure how this didn't make it into develop.


