### PR TITLE
Remove Print Token and Node

### DIFF
--- a/spec/keyword.md
+++ b/spec/keyword.md
@@ -91,7 +91,6 @@ Keyword | Use
 
 Keyword | Use
 ---|---
-`print`   | Print value of an expression
 `return`  | Return from a function or method
 `pass`    | Empty placeholder statement
 

--- a/src/check/constrain/generate/mod.rs
+++ b/src/check/constrain/generate/mod.rs
@@ -110,7 +110,6 @@ pub fn generate(
         Break | Continue => gen_flow(ast, env, ctx, constr),
 
         Return { .. } | ReturnEmpty => gen_stmt(ast, env, ctx, constr),
-        Print { .. } => gen_stmt(ast, env, ctx, constr),
         Raise { .. } => gen_stmt(ast, env, ctx, constr),
 
         Import { .. } |

--- a/src/check/constrain/generate/statement.rs
+++ b/src/check/constrain/generate/statement.rs
@@ -1,7 +1,6 @@
 use std::convert::TryFrom;
 
 use crate::check::constrain::constraint::builder::ConstrBuilder;
-use crate::check::constrain::constraint::Constraint;
 use crate::check::constrain::constraint::expected::Expected;
 use crate::check::constrain::generate::{Constrained, generate};
 use crate::check::constrain::generate::env::Environment;
@@ -30,11 +29,6 @@ pub fn gen_stmt(
             } else {
                 Err(vec![TypeErr::new(&ast.pos, "Return outside function with return type")])
             },
-        Node::Print { expr } => {
-            let con = Constraint::stringy("print", &Expected::try_from((expr, &env.var_mappings))?);
-            constr.add_constr(&con);
-            generate(expr, env, ctx, constr)
-        }
         _ => Err(vec![TypeErr::new(&ast.pos, "Expected statement")])
     }
 }

--- a/src/check/context/function/mod.rs
+++ b/src/check/context/function/mod.rs
@@ -17,6 +17,7 @@ use crate::common::delimit::comma_delm;
 use crate::common::position::Position;
 
 pub const INIT: &str = "init";
+pub const PRINT: &str = "print";
 
 pub const ADD: &str = "+";
 pub const DIV: &str = "/";

--- a/src/generate/convert/mod.rs
+++ b/src/generate/convert/mod.rs
@@ -106,10 +106,6 @@ pub fn convert_node(ast: &AST, imp: &mut Imports, state: &State) -> GenResult {
 
         Node::ReturnEmpty => Core::Return { expr: Box::from(Core::None) },
         Node::Return { expr } => Core::Return { expr: Box::from(convert_node(expr, imp, state)?) },
-        Node::Print { expr } => Core::FunctionCall {
-            function: Box::from(Core::Id { lit: String::from("print") }),
-            args: vec![convert_node(expr, imp, state)?],
-        },
 
         Node::IfElse { .. }
         | Node::While { .. }
@@ -372,19 +368,6 @@ mod tests {
     fn pass_verify() {
         let pass = to_pos!(Node::Pass);
         assert_eq!(gen(&pass).unwrap(), Core::Pass);
-    }
-
-    #[test]
-    fn print_verify() {
-        let expr = to_pos!(Node::Str { lit: String::from("a"), expressions: vec![] });
-        let print_stmt = to_pos!(Node::Print { expr });
-        assert_eq!(
-            gen(&print_stmt).unwrap(),
-            Core::FunctionCall {
-                function: Box::from(Core::Id { lit: String::from("print") }),
-                args: vec![Core::Str { string: String::from("a") }],
-            }
-        );
     }
 
     #[test]

--- a/src/parse/ast/mod.rs
+++ b/src/parse/ast/mod.rs
@@ -120,7 +120,6 @@ pub enum Node {
     Pass,
     Question { left: Box<AST>, right: Box<AST> },
     QuestionOp { expr: Box<AST> },
-    Print { expr: Box<AST> },
     Comment { comment: String },
 }
 

--- a/src/parse/ast/node.rs
+++ b/src/parse/ast/node.rs
@@ -132,7 +132,6 @@ impl Display for Node {
             Node::Pass => format!("{}", Token::Pass),
             Node::Question { .. } => String::from("ternary operator"),
             Node::QuestionOp { .. } => String::from("unsafe operator"),
-            Node::Print { .. } => format!("{}", Token::Print),
             Node::Comment { .. } => String::from("comment"),
         };
 
@@ -420,7 +419,6 @@ impl Node {
                 right: Box::from(right.map(mapping)),
             },
             Node::QuestionOp { expr } => Node::QuestionOp { expr: Box::from(expr.map(mapping)) },
-            Node::Print { expr } => Node::Print { expr: Box::from(expr.map(mapping)) },
 
             other => mapping(&other)
         }
@@ -674,7 +672,6 @@ impl Node {
             (Node::QuestionOp { expr: left }, Node::QuestionOp { expr: right }) => {
                 left.same_value(right)
             }
-            (Node::Print { expr: left }, Node::Print { expr: right }) => left.same_value(right),
             (Node::Comment { .. }, Node::Comment { .. }) => true,
 
             (left, right) if **left == **right => true,
@@ -1211,11 +1208,6 @@ mod test {
     #[test]
     fn return_equal_value() {
         two_ast!(Node::Return { expr: Box::from(AST::new(&Position::default(), Node::Continue)) });
-    }
-
-    #[test]
-    fn print_equal_value() {
-        two_ast!(Node::Print { expr: Box::from(AST::new(&Position::default(), Node::Continue)) });
     }
 
     #[test]

--- a/src/parse/expr_or_stmt.rs
+++ b/src/parse/expr_or_stmt.rs
@@ -149,19 +149,6 @@ mod test {
     }
 
     #[test]
-    fn print_verify() {
-        let source = String::from("print some_value");
-        let statements = parse_direct(&source).unwrap();
-
-        let expr = match &statements.first().expect("script empty.").node {
-            Node::Print { expr } => expr.clone(),
-            _ => panic!("first element script was not reassign.")
-        };
-
-        assert_eq!(expr.node, Node::Id { lit: String::from("some_value") });
-    }
-
-    #[test]
     fn return_verify() {
         let source = String::from("return some_value");
         let statements = parse_direct(&source).unwrap();
@@ -260,12 +247,6 @@ mod test {
         assert_eq!(_as.len(), 2);
         assert_eq!(_as[0].node, Node::Id { lit: String::from("c") });
         assert_eq!(_as[1].node, Node::Id { lit: String::from("d") });
-    }
-
-    #[test]
-    fn print_missing_arg() {
-        let source = String::from("print");
-        parse(&source).unwrap_err();
     }
 
     #[test]

--- a/src/parse/lex/token.rs
+++ b/src/parse/lex/token.rs
@@ -134,8 +134,6 @@ pub enum Token {
     Question,
     Handle,
 
-    Print,
-
     Pass,
     Undefined,
     Comment(String),
@@ -285,7 +283,6 @@ impl fmt::Display for Token {
             Token::When => String::from("when"),
 
             Token::Pass => String::from("pass"),
-            Token::Print => String::from("print"),
             Token::Undefined => String::from("None"),
             Token::Comment(string) => format!("{} (comment)", string)
         })

--- a/src/parse/lex/tokenize.rs
+++ b/src/parse/lex/tokenize.rs
@@ -294,7 +294,6 @@ fn as_op_or_id(string: String) -> Token {
 
         "True" => Token::Bool(true),
         "False" => Token::Bool(false),
-        "print" => Token::Print,
 
         "None" => Token::Undefined,
         "pass" => Token::Pass,

--- a/src/parse/statement.rs
+++ b/src/parse/statement.rs
@@ -14,12 +14,6 @@ use crate::parse::ty::parse_expression_type;
 pub fn parse_statement(it: &mut LexIterator) -> ParseResult {
     it.peek_or_err(
         &|it, lex| match lex.token {
-            Token::Print => {
-                it.eat(&Token::Print, "statement")?;
-                let expr = it.parse(&parse_expression, "statement", &lex.pos)?;
-                let node = Node::Print { expr: expr.clone() };
-                Ok(Box::from(AST::new(&lex.pos.union(&expr.pos), node)))
-            }
             Token::Pass => {
                 let end = it.eat(&Token::Pass, "statement")?;
                 Ok(Box::from(AST::new(&end, Node::Pass)))
@@ -35,7 +29,6 @@ pub fn parse_statement(it: &mut LexIterator) -> ParseResult {
             Token::For | Token::While => parse_cntrl_flow_stmt(it),
             _ => Err(expected_one_of(
                 &[
-                    Token::Print,
                     Token::Pass,
                     Token::Raise,
                     Token::Def,
@@ -48,7 +41,6 @@ pub fn parse_statement(it: &mut LexIterator) -> ParseResult {
             )),
         },
         &[
-            Token::Print,
             Token::Pass,
             Token::Raise,
             Token::Def,
@@ -123,7 +115,6 @@ pub fn is_start_statement(tp: &Token) -> bool {
         tp,
         Token::Def
             | Token::Fin
-            | Token::Print
             | Token::For
             | Token::While
             | Token::Pass

--- a/tests/resource/invalid/type/control_flow/for_non_iterable.mamba
+++ b/tests/resource/invalid/type/control_flow/for_non_iterable.mamba
@@ -1,2 +1,2 @@
 for i in 10 do
-    print i
+    print(i)

--- a/tests/resource/invalid/type/control_flow/if_not_bool_union.mamba
+++ b/tests/resource/invalid/type/control_flow/if_not_bool_union.mamba
@@ -1,3 +1,3 @@
 def x: {Slice, Range} := 0::1
 
-if x then print "hello world"
+if x then print("hello world")

--- a/tests/resource/invalid/type/control_flow/if_not_boolean.mamba
+++ b/tests/resource/invalid/type/control_flow/if_not_boolean.mamba
@@ -1,1 +1,1 @@
-if 0::10 then print "hello world"
+if 0::10 then print("hello world")

--- a/tests/resource/invalid/type/definition/undefined_variable.mamba
+++ b/tests/resource/invalid/type/definition/undefined_variable.mamba
@@ -1,1 +1,1 @@
-print a
+print(a)

--- a/tests/resource/invalid/type/error/using_old_resource_in_with.mamba
+++ b/tests/resource/invalid/type/error/using_old_resource_in_with.mamba
@@ -1,4 +1,4 @@
 def old := 10
 
 with old as new do
-    print old + 10
+    print(old + 10)

--- a/tests/resource/invalid/type/error/with_not_expression.mamba
+++ b/tests/resource/invalid/type/error/with_not_expression.mamba
@@ -1,4 +1,4 @@
-def not_an_expression() => print "not an expression"
+def not_an_expression() => print("not an expression")
 
 with not_an_expression() as my_expression do
-    print "not an expression!"
+    print("not an expression!")

--- a/tests/resource/invalid/type/error/with_wrong_type.mamba
+++ b/tests/resource/invalid/type/error/with_wrong_type.mamba
@@ -1,4 +1,4 @@
 def my_string := "my string"
 
 with my_string as my_int: Int do
-    print "error"
+    print("error")

--- a/tests/resource/invalid/type/function/as_statement.mamba
+++ b/tests/resource/invalid/type/function/as_statement.mamba
@@ -1,4 +1,4 @@
 def f(x: Int) => x
 
 # f is a statement because it has no return type
-print f(10)
+print(f(10))

--- a/tests/resource/invalid/type/function/statement_as_param.mamba
+++ b/tests/resource/invalid/type/function/statement_as_param.mamba
@@ -1,4 +1,4 @@
 def f(x: Int) -> Int => x
-def g() => print "statement"
+def g() => print("statement")
 
 f(g())

--- a/tests/resource/invalid/type/function/unmentioned_exception.mamba
+++ b/tests/resource/invalid/type/function/unmentioned_exception.mamba
@@ -1,4 +1,4 @@
 class MyErr: Exception
 
-def f(x: Int) raise [MyErr] => print "nothing"
+def f(x: Int) raise [MyErr] => print("nothing")
 def g(x: Int) => f(x)

--- a/tests/resource/valid/class/types.mamba
+++ b/tests/resource/valid/class/types.mamba
@@ -20,7 +20,7 @@ class MyClass(def my_field: Int, other_field: String := "Hello"): MyType(other_f
     def private_field: Int := 20
 
     def fun_a(self: SomeState) => self.some_field := "my field is {self.required_field}"
-    def fun_b(self) => print "this function is private: {self.private_field}!"
+    def fun_b(self) => print("this function is private: {self.private_field}!")
 
     def some_higher_order(self, fun: Int -> Int) -> Int => return fun(self.my_field)
     def higher_order(self) -> Int => return self.some_higher_order(\x: Int => x * 2)

--- a/tests/resource/valid/control_flow/for_over_collection_of_tuple.mamba
+++ b/tests/resource/valid/control_flow/for_over_collection_of_tuple.mamba
@@ -1,2 +1,2 @@
 def b := {(1, 4), (2, 5)}
-for (first, second) in b do print first + second
+for (first, second) in b do print(first + second)

--- a/tests/resource/valid/control_flow/for_statements.mamba
+++ b/tests/resource/valid/control_flow/for_statements.mamba
@@ -1,31 +1,31 @@
 def b := {1, 2}
 for b in b do
-    print b + 5
+    print(b + 5)
     def new := b + 1
     new := 30
-    print new
+    print(new)
 
 def e := {1, 2, 3, 4, 5, 6, 7, 8, 9, 10}
 for d in e do
-    print d
-    print d - 1
+    print(d)
+    print(d - 1)
 
-    print d + 1
+    print(d + 1)
 
 for i in 0 .. 34 do
-    print i
+    print(i)
 
 for i in 0 ..= 345 do
-    print i
+    print(i)
 
 def a := 1
 def b := 112
 for i in a.. b .. 1 do
-    print "hello"
+    print("hello")
 
 def c := 2451
 for i in a ..= c .. 20 do
-    print "world"
+    print("world")
 
 # for i in ([1, 2], {3, 4}) do
-#    print i
+#    print(i)

--- a/tests/resource/valid/control_flow/for_statements_check.py
+++ b/tests/resource/valid/control_flow/for_statements_check.py
@@ -28,4 +28,4 @@ for i in range(a, c + 1, 20):
     print("world")
 
 # for i in ([1, 2], {3, 4}) do
-#    print i
+#    print(i)

--- a/tests/resource/valid/control_flow/if.mamba
+++ b/tests/resource/valid/control_flow/if.mamba
@@ -1,6 +1,6 @@
 def b := 40
 
-if True then print "hello world"
+if True then print("hello world")
 if False then "hello" else "world"
 
 def cond := True and False
@@ -8,7 +8,7 @@ cond := True or False
 
 if cond then
     "asdf"
-    print "hello \"world\""
+    print("hello \"world\"")
 
     if cond or True then
         "bbb"
@@ -21,11 +21,11 @@ if cond then
     else iii
 else
     "other"
-    print "hello \"world\""
+    print("hello \"world\"")
 
     if cond or True then
         "bbb"
     else
         "ccc"
 
-if "as" = "as" then print "hi" else print "asdf"
+if "as" = "as" then print("hi") else print("asdf")

--- a/tests/resource/valid/control_flow/while.mamba
+++ b/tests/resource/valid/control_flow/while.mamba
@@ -1,11 +1,11 @@
 def b := False
 def e := "Hello world"
-while b do print b
+while b do print(b)
 
 def d := True
 while d do
-    print d and False
+    print(d and False)
 
-    print d and True
+    print(d and True)
 
-print "hello"
+print("hello")

--- a/tests/resource/valid/error/handle.mamba
+++ b/tests/resource/valid/error/handle.mamba
@@ -12,8 +12,8 @@ def f(x: Int) -> Int raise [MyErr1, MyErr2] =>
 
 def a := f(10) handle
     err: MyErr1 =>
-        print "Something went wrong"
+        print("Something went wrong")
         -1
     err: MyErr2 =>
-        print "Something else went wrong"
+        print("Something else went wrong")
         -2

--- a/tests/resource/valid/function/allowed_exception.mamba
+++ b/tests/resource/valid/function/allowed_exception.mamba
@@ -1,4 +1,4 @@
 class MyErr: Exception
 
-def f(x: Int) raise [MyErr] => print "nothing"
+def f(x: Int) raise [MyErr] => print("nothing")
 def g(x: Int) raise [MyErr] => f(x)

--- a/tests/resource/valid/function/calls.mamba
+++ b/tests/resource/valid/function/calls.mamba
@@ -1,5 +1,5 @@
-def fun_a() => print "hello world"
-def fun_b(x: Int) => print "hello {x}"
+def fun_a() => print("hello world")
+def fun_b(x: Int) => print("hello {x}")
 
 fun_a()
 fun_b(123)

--- a/tests/resource/valid/function/definition.mamba
+++ b/tests/resource/valid/function/definition.mamba
@@ -1,14 +1,14 @@
 def fun_a() -> Int? =>
-    print 11
-    if True and True then print "hello"
-    if False or True then print "world"
+    print(11)
+    if True and True then print("hello")
+    if False or True then print("world")
 
     def a := None ? 11
     if True then return 10 else return None
 
-def fun_b(b: Int) => print b
+def fun_b(b: Int) => print(b)
 
-def fun_c(d: (String, Int)) => print d
+def fun_c(d: (String, Int)) => print(d)
 def fun_d(h: (String, String) -> Int) -> Int? => return h("hello", "world")
 
 def fun_e(m: Int, o: (String, String), r: (Int, (String, String)) -> Int) -> Int => return r(m, o)


### PR DESCRIPTION
### Summary

No need for this application logic.
Leftover remnant from a very early version of the langauge where we wanted to be able to use postfix notation for the print funciton.
However, singling out the print function felt weird.
Python v3 also removed this notation, for many reasions (I could link the blog post here but it's a quick google search really).

In future, we should be able to actually add the print function to the context.
However, we need to be able to specify that the input should implement `__str__`.
