### PR TITLE
Streamline interfaces

### DIFF
--- a/src/check/ast.rs
+++ b/src/check/ast.rs
@@ -1,0 +1,30 @@
+use std::ops::Deref;
+
+use crate::check::name::Name;
+use crate::common::position::Position;
+use crate::parse::ast::{AST, Node};
+
+#[derive(PartialEq, Eq, Hash, Clone, Debug)]
+pub struct ASTTy {
+    pub pos: Position,
+    pub node: Node,
+    pub ty: Option<Name>,
+}
+
+impl From<&AST> for ASTTy {
+    fn from(ast: &AST) -> Self {
+        ASTTy { pos: ast.pos.clone(), node: ast.node.clone(), ty: None }
+    }
+}
+
+impl From<&Box<AST>> for ASTTy {
+    fn from(ast: &Box<AST>) -> Self {
+        ASTTy::from(ast.deref())
+    }
+}
+
+impl ASTTy {
+    pub fn to_ty(self, ty: &Name) -> ASTTy {
+        ASTTy { ty: Some(ty.clone()), ..self }
+    }
+}

--- a/src/check/ast.rs
+++ b/src/check/ast.rs
@@ -28,3 +28,34 @@ impl ASTTy {
         ASTTy { ty: Some(ty.clone()), ..self }
     }
 }
+
+#[cfg(test)]
+mod test {
+    use crate::{AST, ASTTy};
+    use crate::check::name::Name;
+    use crate::common::position::{CaretPos, Position};
+    use crate::parse::ast::Node;
+
+    #[test]
+    fn from_ast() {
+        let node = Node::Pass;
+        let pos = Position::from(&CaretPos::new(4, 8));
+        let ast = AST::new(&pos, node.clone());
+
+        let ast_ty = ASTTy::from(&ast);
+        let ast_ty2 = ASTTy::from(&Box::from(ast));
+
+        assert_eq!(ast_ty, ast_ty2);
+        assert_eq!(ast_ty.node, node);
+        assert_eq!(ast_ty.pos, pos);
+    }
+
+    #[test]
+    fn to_ty() {
+        let node = Node::Pass;
+        let ast = AST::new(&Position::default(), node.clone());
+        let ast_ty = ASTTy::from(&ast).to_ty(&Name::from("Dummy"));
+
+        assert_eq!(ast_ty.ty, Some(Name::from("Dummy")));
+    }
+}

--- a/src/check/context/generic.rs
+++ b/src/check/context/generic.rs
@@ -20,16 +20,13 @@ pub fn generics(
                 for module in modules {
                     match &module.node {
                         Node::Class { .. } | Node::TypeDef { .. } | Node::TypeAlias { .. } => {
-                            let generic_type = GenericClass::try_from(module)?;
-                            types.insert(generic_type);
+                            types.insert(GenericClass::try_from(module)?);
                         }
                         Node::FunDef { .. } => {
-                            let generic_type = GenericFunction::try_from(module)?;
-                            functions.insert(generic_type);
+                            functions.insert(GenericFunction::try_from(module)?);
                         }
                         Node::VariableDef { .. } => {
-                            let generic_type = GenericFields::try_from(module)?;
-                            generic_type.fields.iter().for_each(|ty| {
+                            GenericFields::try_from(module)?.fields.iter().for_each(|ty| {
                                 fields.insert(ty.clone());
                             });
                         }

--- a/src/check/context/generic.rs
+++ b/src/check/context/generic.rs
@@ -1,50 +1,34 @@
 use std::collections::HashSet;
 use std::convert::TryFrom;
 
-use crate::check::CheckInput;
 use crate::check::context::clss::generic::GenericClass;
 use crate::check::context::field::generic::{GenericField, GenericFields};
 use crate::check::context::function::generic::GenericFunction;
 use crate::check::result::{TypeErr, TypeResult};
-use crate::parse::ast::Node;
+use crate::parse::ast::{AST, Node};
 
 pub fn generics(
-    files: &[CheckInput],
+    files: &[AST],
 ) -> TypeResult<(HashSet<GenericClass>, HashSet<GenericField>, HashSet<GenericFunction>)> {
     let mut types = HashSet::new();
     let mut fields = HashSet::new();
     let mut functions = HashSet::new();
 
-    for (file, source, path) in files {
+    for file in files {
         match &file.node {
             Node::File { statements: modules, .. } => {
                 for module in modules {
                     match &module.node {
                         Node::Class { .. } | Node::TypeDef { .. } | Node::TypeAlias { .. } => {
-                            let generic_type: Result<_, Vec<TypeErr>> =
-                                GenericClass::try_from(module).map_err(|errs| {
-                                    errs.into_iter()
-                                        .map(|e| e.into_with_source(source, path))
-                                        .collect()
-                                });
-                            types.insert(generic_type?);
+                            let generic_type = GenericClass::try_from(module)?;
+                            types.insert(generic_type);
                         }
                         Node::FunDef { .. } => {
-                            let generic_type: Result<_, Vec<TypeErr>> =
-                                GenericFunction::try_from(module).map_err(|errs| {
-                                    errs.into_iter()
-                                        .map(|e| e.into_with_source(source, path))
-                                        .collect()
-                                });
-                            functions.insert(generic_type?);
+                            let generic_type = GenericFunction::try_from(module)?;
+                            functions.insert(generic_type);
                         }
                         Node::VariableDef { .. } => {
-                            let generic_type = GenericFields::try_from(module).map_err(|errs| {
-                                errs.into_iter()
-                                    .map(|e| e.into_with_source(source, path))
-                                    .collect::<Vec<TypeErr>>()
-                            })?;
-
+                            let generic_type = GenericFields::try_from(module)?;
                             generic_type.fields.iter().for_each(|ty| {
                                 fields.insert(ty.clone());
                             });

--- a/src/check/context/mod.rs
+++ b/src/check/context/mod.rs
@@ -6,7 +6,6 @@ use std::hash::{Hash, Hasher};
 
 use itertools::{EitherOrBoth, Itertools};
 
-use crate::check::CheckInput;
 use crate::check::context::arg::FunctionArg;
 use crate::check::context::clss::{Class, HasParent};
 use crate::check::context::clss::generic::GenericClass;
@@ -22,6 +21,7 @@ use crate::check::name::truename::TrueName;
 use crate::check::result::{TypeErr, TypeResult};
 use crate::common::delimit::comma_delm;
 use crate::common::position::Position;
+use crate::parse::ast::AST;
 
 pub mod arg;
 pub mod clss;
@@ -61,12 +61,12 @@ impl Context {
     }
 }
 
-impl TryFrom<&[CheckInput]> for Context {
+impl TryFrom<&[AST]> for Context {
     type Error = Vec<TypeErr>;
 
-    fn try_from(files: &[CheckInput]) -> Result<Self, Self::Error> {
+    fn try_from(files: &[AST]) -> Result<Self, Self::Error> {
         let (classes, fields, functions) = generics(files)?;
-        Ok(Context { classes, functions, fields })
+        Context { classes, functions, fields }.into_with_primitives()?.into_with_std_lib()
     }
 }
 
@@ -406,7 +406,6 @@ pub struct FieldUnion {
 mod tests {
     use std::convert::TryFrom;
 
-    use crate::check::CheckInput;
     use crate::check::context::{Context, LookupClass};
     use crate::check::name::Name;
     use crate::check::name::stringname::StringName;
@@ -427,7 +426,7 @@ mod tests {
 
     #[test]
     pub fn primitives_present() {
-        let files: Vec<CheckInput> = vec![];
+        let files = vec![];
         let context = Context::try_from(files.as_slice()).unwrap();
         let context = context.into_with_primitives().unwrap();
 
@@ -440,7 +439,7 @@ mod tests {
 
     #[test]
     pub fn std_lib_present() {
-        let files: Vec<CheckInput> = vec![];
+        let files = vec![];
         let context = Context::try_from(files.as_slice()).unwrap();
         let context = context.into_with_std_lib().unwrap();
 

--- a/src/check/mod.rs
+++ b/src/check/mod.rs
@@ -1,43 +1,54 @@
 use std::convert::TryFrom;
-use std::path::PathBuf;
 
+use crate::check::ast::ASTTy;
 use crate::check::constrain::constraints;
 use crate::check::context::Context;
-use crate::check::result::{TypeErr, TypeResults};
+use crate::check::result::TypeResult;
 use crate::parse::ast::AST;
+use crate::TypeErr;
 
 mod constrain;
 mod ident;
 
+pub mod ast;
 pub mod context;
-pub mod result;
 pub mod name;
-
-pub type CheckInput = (AST, Option<String>, Option<PathBuf>);
+pub mod result;
 
 /// Checks whether a given [AST](mamba::parser::ast::AST) is well
 /// typed according to the specification of the language.
 ///
-/// Should never panic.
-///
 /// # Failures
 ///
-/// Any ill-typed [AST](mamba::parser::ast::AST) results in a
-/// failure.
-pub fn check_all(inputs: &[CheckInput]) -> TypeResults {
-    let context = Context::try_from(inputs)?.into_with_primitives()?.into_with_std_lib()?;
+/// Any ill-typed [AST](mamba::parser::ast::AST) results in a failure.
+pub fn check(ast: &AST, ctx: &Context) -> TypeResult {
     trace!(
         "Constructed context with\n - {} classes\n - {} functions\n - {} fields",
-        context.class_count(),
-        context.function_count(),
-        context.field_count()
+        ctx.class_count(),
+        ctx.function_count(),
+        ctx.field_count()
     );
 
-    for (ast, source, path) in inputs {
-        constraints(ast, &context).map_err(|err| {
-            err.into_iter().map(|err| err.into_with_source(source, path)).collect::<Vec<TypeErr>>()
-        })?;
-    }
+    constraints(ast, ctx).map(|_| ASTTy::from(ast))
+}
 
-    Ok(Vec::from(inputs))
+pub fn check_all(asts: &[AST]) -> TypeResult<Vec<ASTTy>> {
+    let ctx = Context::try_from(asts);
+
+    match ctx {
+        Ok(ctx) => {
+            let (typed_ast, type_errs): (Vec<_>, Vec<_>) = asts
+                .iter()
+                .map(|ast| check(ast, &ctx))
+                .partition(Result::is_ok);
+
+            let type_errs: Vec<Vec<TypeErr>> = type_errs.into_iter().map(Result::unwrap_err).collect();
+            if !type_errs.is_empty() {
+                Err(type_errs.into_iter().flatten().collect())
+            } else {
+                Ok(typed_ast.into_iter().map(Result::unwrap).collect())
+            }
+        }
+        Err(errs) => Err(errs),
+    }
 }

--- a/src/check/result.rs
+++ b/src/check/result.rs
@@ -3,11 +3,11 @@ use std::fmt::{Display, Formatter};
 use std::hash::{Hash, Hasher};
 use std::path::PathBuf;
 
-use crate::check::CheckInput;
+use crate::check::ast::ASTTy;
 use crate::common::position::Position;
+use crate::common::result::IntoWithSource;
 
-pub type TypeResult<T> = std::result::Result<T, Vec<TypeErr>>;
-pub type TypeResults = std::result::Result<Vec<CheckInput>, Vec<TypeErr>>;
+pub type TypeResult<T = ASTTy> = std::result::Result<T, Vec<TypeErr>>;
 
 #[derive(Debug, Clone, Eq)]
 pub struct TypeErr {
@@ -59,9 +59,10 @@ impl TypeErr {
             source_line: None,
         }
     }
+}
 
-    #[must_use]
-    pub fn into_with_source(self, source: &Option<String>, path: &Option<PathBuf>) -> TypeErr {
+impl IntoWithSource for TypeErr {
+    fn into_with_source(self, source: &Option<String>, path: &Option<PathBuf>) -> TypeErr {
         let (source_before, source_line, source_after) = if let Some(position) = &self.position {
             if let Some(source) = source {
                 (
@@ -96,7 +97,6 @@ impl TypeErr {
 }
 
 impl Display for TypeErr {
-    // TODO deal with Positions that cover multiple lines
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         let path = self.path.clone().map_or(String::from("<unknown>"), |p| p.display().to_string());
         let msg = {

--- a/src/check/result.rs
+++ b/src/check/result.rs
@@ -5,7 +5,7 @@ use std::path::PathBuf;
 
 use crate::check::ast::ASTTy;
 use crate::common::position::Position;
-use crate::common::result::IntoWithSource;
+use crate::common::result::WithSource;
 
 pub type TypeResult<T = ASTTy> = std::result::Result<T, Vec<TypeErr>>;
 
@@ -61,8 +61,8 @@ impl TypeErr {
     }
 }
 
-impl IntoWithSource for TypeErr {
-    fn into_with_source(self, source: &Option<String>, path: &Option<PathBuf>) -> TypeErr {
+impl WithSource for TypeErr {
+    fn with_source(self, source: &Option<String>, path: &Option<PathBuf>) -> TypeErr {
         let (source_before, source_line, source_after) = if let Some(position) = &self.position {
             if let Some(source) = source {
                 (

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -1,2 +1,3 @@
 pub mod delimit;
 pub mod position;
+pub mod result;

--- a/src/common/result.rs
+++ b/src/common/result.rs
@@ -1,0 +1,5 @@
+use std::path::PathBuf;
+
+pub trait IntoWithSource {
+    fn into_with_source(self, source: &Option<String>, path: &Option<PathBuf>) -> Self;
+}

--- a/src/common/result.rs
+++ b/src/common/result.rs
@@ -1,5 +1,5 @@
 use std::path::PathBuf;
 
-pub trait IntoWithSource {
-    fn into_with_source(self, source: &Option<String>, path: &Option<PathBuf>) -> Self;
+pub trait WithSource {
+    fn with_source(self, source: &Option<String>, path: &Option<PathBuf>) -> Self;
 }

--- a/src/generate/convert/class.rs
+++ b/src/generate/convert/class.rs
@@ -195,6 +195,7 @@ fn extract_class(
 mod tests {
     use std::ops::Deref;
 
+    use crate::check::ast::ASTTy;
     use crate::check::context::function;
     use crate::common::position::Position;
     use crate::generate::ast::node::Core;
@@ -223,7 +224,7 @@ mod tests {
         let aliases = vec![];
         let import = to_pos!(Node::Import { import, aliases });
 
-        let core_import = match gen(&import) {
+        let core_import = match gen(&ASTTy::from(&*import)) {
             Ok(Core::Import { imports }) => imports,
             other => panic!("Expected tuple but got {:?}", other),
         };
@@ -242,7 +243,7 @@ mod tests {
         let aliases = vec![to_pos_unboxed!(Node::Real { lit: String::from("0.5") })];
         let import = to_pos!(Node::Import { import, aliases });
 
-        let (core_import, core_as) = match gen(&import) {
+        let (core_import, core_as) = match gen(&ASTTy::from(&import)) {
             Ok(Core::ImportAs { imports, aliases }) => (imports, aliases),
             other => panic!("Expected import but got {:?}", other),
         };
@@ -266,7 +267,7 @@ mod tests {
             import: to_pos!(Node::Import { import, aliases: vec![] })
         });
 
-        let (from, import) = match gen(&import) {
+        let (from, import) = match gen(&ASTTy::from(&import)) {
             Ok(Core::FromImport { from, import }) => match &import.deref() {
                 Core::Import { imports } => (from.clone(), imports.clone()),
                 other => panic!("Expected import but got {:?}", other),
@@ -285,7 +286,7 @@ mod tests {
         let cond = to_pos!(Node::Bool { lit: true });
         let condition = to_pos!(Node::Condition { cond, el: None });
 
-        let result = gen(&condition);
+        let result = gen(&ASTTy::from(&condition));
         assert!(result.is_err());
     }
 
@@ -310,7 +311,7 @@ mod tests {
             body: None
         });
 
-        let (var, ty, expr) = match gen(&alias) {
+        let (var, ty, expr) = match gen(&ASTTy::from(&alias)) {
             Ok(Core::VarDef { var, ty, expr }) => (*var.clone(), ty.clone(), expr.clone()),
             other => panic!("Expected type alias but got {:?}", other),
         };
@@ -355,7 +356,7 @@ mod tests {
             body: None
         });
 
-        let (name, parent_names, body) = match gen(&alias) {
+        let (name, parent_names, body) = match gen(&ASTTy::from(&alias)) {
             Ok(Core::ClassDef { name, parent_names, body }) => (*name, parent_names, *body),
             other => panic!("Expected class def but got {:?}", other),
         };

--- a/src/generate/convert/control_flow.rs
+++ b/src/generate/convert/control_flow.rs
@@ -52,6 +52,7 @@ pub fn convert_cntrl_flow(ast: &AST, imp: &mut Imports, state: &State) -> GenRes
 
 #[cfg(test)]
 mod tests {
+    use crate::ASTTy;
     use crate::common::position::Position;
     use crate::generate::ast::node::Core;
     use crate::generate::gen;
@@ -76,7 +77,7 @@ mod tests {
         let then = to_pos!(Node::Id { lit: String::from("then") });
         let if_stmt = to_pos!(Node::IfElse { cond, then, el: None });
 
-        let (core_cond, core_then) = match gen(&if_stmt) {
+        let (core_cond, core_then) = match gen(&ASTTy::from(&if_stmt)) {
             Ok(Core::If { cond, then }) => (cond, then),
             other => panic!("Expected reassign but was {:?}", other),
         };
@@ -92,7 +93,7 @@ mod tests {
         let el = to_pos!(Node::Id { lit: String::from("else") });
         let if_stmt = to_pos!(Node::IfElse { cond, then, el: Some(el) });
 
-        let (core_cond, core_then, core_else) = match gen(&if_stmt) {
+        let (core_cond, core_then, core_else) = match gen(&ASTTy::from(&if_stmt)) {
             Ok(Core::IfElse { cond, then, el }) => (cond, then, el),
             other => panic!("Expected reassign but was {:?}", other),
         };
@@ -108,7 +109,7 @@ mod tests {
         let body = to_pos!(Node::ENum { num: String::from("num"), exp: String::from("") });
         let while_stmt = to_pos!(Node::While { cond, body });
 
-        let (core_cond, core_body) = match gen(&while_stmt) {
+        let (core_cond, core_body) = match gen(&ASTTy::from(&while_stmt)) {
             Ok(Core::While { cond, body }) => (cond, body),
             other => panic!("Expected reassign but was {:?}", other),
         };
@@ -124,7 +125,7 @@ mod tests {
         let body = to_pos!(Node::Id { lit: String::from("body") });
         let for_stmt = to_pos!(Node::For { expr, col, body });
 
-        let (core_expr, core_col, core_body) = match gen(&for_stmt) {
+        let (core_expr, core_col, core_body) = match gen(&ASTTy::from(&for_stmt)) {
             Ok(Core::For { expr, col, body }) => (expr, col, body),
             other => panic!("Expected for but was {:?}", other),
         };
@@ -140,7 +141,7 @@ mod tests {
         let to = to_pos!(Node::Id { lit: String::from("b") });
         let range = to_pos!(Node::Range { from, to, inclusive: false, step: None });
 
-        let (from, to, step) = match gen(&range) {
+        let (from, to, step) = match gen(&ASTTy::from(&range)) {
             Ok(Core::FunctionCall { function, args }) => {
                 assert_eq!(*function, Core::Id { lit: String::from("range") });
                 (args[0].clone(), args[1].clone(), args[2].clone())
@@ -159,7 +160,7 @@ mod tests {
         let to = to_pos!(Node::Id { lit: String::from("b") });
         let range = to_pos!(Node::Range { from, to, inclusive: true, step: None });
 
-        let (from, to, step) = match gen(&range) {
+        let (from, to, step) = match gen(&ASTTy::from(&range)) {
             Ok(Core::FunctionCall { function, args }) => {
                 assert_eq!(*function, Core::Id { lit: String::from("range") });
                 (args[0].clone(), args[1].clone(), args[2].clone())
@@ -185,7 +186,7 @@ mod tests {
         let step = Some(to_pos!(Node::Id { lit: String::from("c") }));
         let range = to_pos!(Node::Range { from, to, inclusive: false, step });
 
-        let (from, to, step) = match gen(&range) {
+        let (from, to, step) = match gen(&ASTTy::from(&range)) {
             Ok(Core::FunctionCall { function, args }) => {
                 assert_eq!(*function, Core::Id { lit: String::from("range") });
                 (args[0].clone(), args[1].clone(), args[2].clone())

--- a/src/generate/convert/definition.rs
+++ b/src/generate/convert/definition.rs
@@ -98,6 +98,7 @@ pub fn convert_def(ast: &AST, imp: &mut Imports, state: &State) -> GenResult {
 
 #[cfg(test)]
 mod test {
+    use crate::ASTTy;
     use crate::common::position::Position;
     use crate::generate::ast::node::{Core, CoreOp};
     use crate::generate::gen;
@@ -123,7 +124,7 @@ mod test {
         let right = to_pos!(Node::Id { lit: String::from("other") });
         let reassign = to_pos!(Node::Reassign { left, right, op: NodeOp::Assign });
 
-        let (left, right, op) = match gen(&reassign) {
+        let (left, right, op) = match gen(&ASTTy::from(&reassign)) {
             Ok(Core::Assign { left, right, op }) => (left, right, op),
             other => panic!("Expected reassign but was {:?}", other),
         };
@@ -143,7 +144,7 @@ mod test {
             forward: vec![]
         });
 
-        let (var, ty, expr) = match gen(&definition) {
+        let (var, ty, expr) = match gen(&ASTTy::from(&definition)) {
             Ok(Core::VarDef { var, ty, expr }) => (var, ty, expr),
             other => panic!("Expected var def but got: {:?}.", other),
         };
@@ -163,7 +164,7 @@ mod test {
             forward: vec![]
         });
 
-        let (var, ty, expr) = match gen(&definition) {
+        let (var, ty, expr) = match gen(&ASTTy::from(&definition)) {
             Ok(Core::VarDef { var, ty, expr }) => (var, ty, expr),
             other => panic!("Expected var def but got: {:?}.", other),
         };
@@ -191,7 +192,7 @@ mod test {
             forward: vec![]
         });
 
-        let (var, ty, expr) = match gen(&definition) {
+        let (var, ty, expr) = match gen(&ASTTy::from(&definition)) {
             Ok(Core::VarDef { var, ty, expr }) => (var, ty, expr),
             other => panic!("Expected var def but got: {:?}.", other),
         };
@@ -215,7 +216,7 @@ mod test {
             forward: vec![]
         });
 
-        let (var, ty, expr) = match gen(&definition) {
+        let (var, ty, expr) = match gen(&ASTTy::from(&definition)) {
             Ok(Core::VarDef { var, ty, expr }) => (var, ty, expr),
             other => panic!("Expected var def but got: {:?}.", other),
         };
@@ -239,7 +240,7 @@ mod test {
             forward: vec![]
         });
 
-        let (var, ty, expr) = match gen(&definition) {
+        let (var, ty, expr) = match gen(&ASTTy::from(&definition)) {
             Ok(Core::VarDef { var, ty, expr }) => (var, ty, expr),
             other => panic!("Expected var def but got: {:?}.", other),
         };
@@ -277,7 +278,7 @@ mod test {
             body: None
         });
 
-        let (id, args, body) = match gen(&definition) {
+        let (id, args, body) = match gen(&ASTTy::from(&definition)) {
             Ok(Core::FunDef { id, arg, body, .. }) => (id, arg, body),
             other => panic!("Expected fun def but got: {:?}.", other),
         };
@@ -326,7 +327,7 @@ mod test {
             body: None
         });
 
-        let (id, args, body) = match gen(&definition) {
+        let (id, args, body) = match gen(&ASTTy::from(&definition)) {
             Ok(Core::FunDef { id, arg, body, .. }) => (id, arg, body),
             other => panic!("Expected fun def but got: {:?}.", other),
         };
@@ -360,7 +361,7 @@ mod test {
             body: Some(to_pos!(Node::Real { lit: String::from("2.4") }))
         });
 
-        let (id, args, body) = match gen(&definition) {
+        let (id, args, body) = match gen(&ASTTy::from(&definition)) {
             Ok(Core::FunDef { id, arg, body, .. }) => (id, arg, body),
             other => panic!("Expected fun def but got: {:?}.", other),
         };
@@ -383,7 +384,7 @@ mod test {
             body: to_pos!(Node::Str { lit: String::from("this_string"), expressions: vec![] })
         });
 
-        let (args, body) = match gen(&anon_fun) {
+        let (args, body) = match gen(&ASTTy::from(&anon_fun)) {
             Ok(Core::AnonFun { args, body }) => (args, body),
             other => panic!("Expected anon fun but got: {:?}.", other),
         };

--- a/src/generate/convert/mod.rs
+++ b/src/generate/convert/mod.rs
@@ -334,6 +334,7 @@ pub fn convert_node(ast: &AST, imp: &mut Imports, state: &State) -> GenResult {
 
 #[cfg(test)]
 mod tests {
+    use crate::ASTTy;
     use crate::common::position::Position;
     use crate::generate::ast::node::Core;
     use crate::generate::gen;
@@ -355,19 +356,19 @@ mod tests {
     #[test]
     fn break_verify() {
         let _break = to_pos!(Node::Break);
-        assert_eq!(gen(&_break).unwrap(), Core::Break);
+        assert_eq!(gen(&ASTTy::from(&_break)).unwrap(), Core::Break);
     }
 
     #[test]
     fn continue_verify() {
         let _continue = to_pos!(Node::Continue);
-        assert_eq!(gen(&_continue).unwrap(), Core::Continue);
+        assert_eq!(gen(&ASTTy::from(&_continue)).unwrap(), Core::Continue);
     }
 
     #[test]
     fn pass_verify() {
         let pass = to_pos!(Node::Pass);
-        assert_eq!(gen(&pass).unwrap(), Core::Pass);
+        assert_eq!(gen(&ASTTy::from(&pass)).unwrap(), Core::Pass);
     }
 
     #[test]
@@ -376,7 +377,7 @@ mod tests {
         let print_stmt = to_pos!(Node::Return { expr });
 
         assert_eq!(
-            gen(&print_stmt).unwrap(),
+            gen(&ASTTy::from(&print_stmt)).unwrap(),
             Core::Return { expr: Box::from(Core::Str { string: String::from("a") }) }
         );
     }
@@ -384,7 +385,7 @@ mod tests {
     #[test]
     fn return_empty_verify() {
         let print_stmt = to_pos!(Node::ReturnEmpty);
-        assert_eq!(gen(&print_stmt).unwrap(), Core::Return { expr: Box::from(Core::None) });
+        assert_eq!(gen(&ASTTy::from(&print_stmt)).unwrap(), Core::Return { expr: Box::from(Core::None) });
     }
 
     #[test]
@@ -395,7 +396,7 @@ mod tests {
         });
 
         assert_eq!(
-            gen(&_break).unwrap(),
+            gen(&ASTTy::from(&_break)).unwrap(),
             Core::ImportAs {
                 imports: vec![Core::Id { lit: String::from("a") }],
                 aliases: vec![Core::Id { lit: String::from("b") }],
@@ -414,7 +415,7 @@ mod tests {
         });
 
         assert_eq!(
-            gen(&_break).unwrap(),
+            gen(&ASTTy::from(&_break)).unwrap(),
             Core::FromImport {
                 from: Box::from(Core::Id { lit: String::from("f") }),
                 import: Box::from(Core::ImportAs {
@@ -431,7 +432,7 @@ mod tests {
             expr_or_stmt: Box::from(to_pos!(Node::Id { lit: String::from("a") })),
             errors: vec![]
         });
-        assert_eq!(gen(&type_def).unwrap(), Core::Id { lit: String::from("a") });
+        assert_eq!(gen(&ASTTy::from(&type_def)).unwrap(), Core::Id { lit: String::from("a") });
     }
 
     macro_rules! verify {
@@ -440,7 +441,7 @@ mod tests {
             let right = Node::Id { lit: String::from("right") };
             let add_node = to_pos!(Node::$ast { left: to_pos!(left), right: to_pos!(right) });
 
-            let (left, right) = match gen(&add_node) {
+            let (left, right) = match gen(&ASTTy::from(&add_node)) {
                 Ok(Core::$ast { left, right }) => (left, right),
                 other => panic!("Expected binary operation but was {:?}", other),
             };
@@ -455,7 +456,7 @@ mod tests {
             let expr = to_pos!(Node::Id { lit: String::from("expression") });
             let add_node = to_pos!(Node::$ast { expr });
 
-            let expr_des = match gen(&add_node) {
+            let expr_des = match gen(&ASTTy::from(&add_node)) {
                 Ok(Core::$ast { expr }) => expr,
                 other => panic!("Expected unary operation but was {:?}", other),
             };
@@ -561,7 +562,7 @@ mod tests {
             to_pos_unboxed!(Node::Real { lit: String::from("3000.5") }),
         ];
         let tuple = to_pos!(Node::Tuple { elements });
-        let core = gen(&tuple);
+        let core = gen(&ASTTy::from(&tuple));
 
         let core_elements = match core {
             Ok(Core::Tuple { elements }) => elements,
@@ -582,7 +583,7 @@ mod tests {
             to_pos_unboxed!(Node::Bool { lit: true }),
         ];
         let set = to_pos!(Node::Set { elements });
-        let core = gen(&set);
+        let core = gen(&ASTTy::from(&set));
 
         let core_elements = match core {
             Ok(Core::Set { elements }) => elements,
@@ -600,7 +601,7 @@ mod tests {
             to_pos_unboxed!(Node::Real { lit: String::from("3000.5") }),
         ];
         let tuple = to_pos!(Node::List { elements });
-        let core = gen(&tuple);
+        let core = gen(&ASTTy::from(&tuple));
 
         let core_elements = match core {
             Ok(Core::List { elements }) => elements,
@@ -620,7 +621,7 @@ mod tests {
         let conditions = vec![];
         let list_builder = to_pos!(Node::SetBuilder { item, conditions });
 
-        let desugar_result = gen(&list_builder);
+        let desugar_result = gen(&ASTTy::from(&list_builder));
         assert!(desugar_result.is_err());
     }
 
@@ -630,7 +631,7 @@ mod tests {
         let conditions = vec![];
         let list_builder = to_pos!(Node::ListBuilder { item, conditions });
 
-        let desugar_result = gen(&list_builder);
+        let desugar_result = gen(&ASTTy::from(&list_builder));
         assert!(desugar_result.is_err());
     }
 
@@ -641,7 +642,7 @@ mod tests {
         let expr = to_pos!(Node::Int { lit: String::from("9") });
         let with = to_pos!(Node::With { resource, alias, expr });
 
-        let (resource, alias, expr) = match gen(&with) {
+        let (resource, alias, expr) = match gen(&ASTTy::from(&with)) {
             Ok(Core::WithAs { resource, alias, expr }) => (resource, alias, expr),
             other => panic!("Expected with as but was {:?}", other),
         };
@@ -657,7 +658,7 @@ mod tests {
         let expr = to_pos!(Node::Int { lit: String::from("2341") });
         let with = to_pos!(Node::With { resource, alias: None, expr });
 
-        let (resource, expr) = match gen(&with) {
+        let (resource, expr) = match gen(&ASTTy::from(&with)) {
             Ok(Core::With { resource, expr }) => (resource, expr),
             other => panic!("Expected with but was {:?}", other),
         };
@@ -671,7 +672,7 @@ mod tests {
         let expr_or_stmt = to_pos!(Node::Id { lit: String::from("my_fun") });
         let handle = to_pos!(Node::Handle { expr_or_stmt, cases: vec![] });
 
-        let (setup, _try, except) = match gen(&handle) {
+        let (setup, _try, except) = match gen(&ASTTy::from(&handle)) {
             Ok(Core::TryExcept { setup, attempt, except }) => {
                 (setup.clone(), attempt.clone(), except.clone())
             }
@@ -698,7 +699,7 @@ mod tests {
         let case = to_pos_unboxed!(Node::Case { cond, body });
         let handle = to_pos!(Node::Handle { expr_or_stmt, cases: vec![case] });
 
-        let (setup, _try, except) = match gen(&handle) {
+        let (setup, _try, except) = match gen(&ASTTy::from(&handle)) {
             Ok(Core::TryExcept { setup, attempt, except }) => {
                 (setup.clone(), attempt.clone(), except.clone())
             }

--- a/src/generate/mod.rs
+++ b/src/generate/mod.rs
@@ -1,17 +1,14 @@
-use std::path::PathBuf;
-
+use crate::AST;
+use crate::check::ast::ASTTy;
 use crate::generate::convert::convert_node;
 use crate::generate::convert::state::{Imports, State};
-use crate::generate::result::{GenResult, GenResults};
-use crate::parse::ast::AST;
+use crate::generate::result::GenResult;
 
 mod convert;
 
 pub mod ast;
 
 pub mod result;
-
-pub type DesugarInput = (AST, Option<String>, Option<PathBuf>);
 
 /// Consumes the given [AST](mamba::parser::ast::AST) and produces
 /// a [Core](mamba::generate.ast::construct::Core) node.
@@ -24,6 +21,7 @@ pub type DesugarInput = (AST, Option<String>, Option<PathBuf>);
 /// # Examples
 ///
 /// ```
+/// # use mamba::check::ast::ASTTy;
 /// # use mamba::parse::ast::Node;
 /// # use mamba::parse::ast::AST;
 /// # use mamba::generate::ast::node::Core;
@@ -31,7 +29,8 @@ pub type DesugarInput = (AST, Option<String>, Option<PathBuf>);
 /// # use mamba::generate::gen;
 /// let node = Node::ReturnEmpty;
 /// let ast = AST::new(&Position::new(&CaretPos::new(1, 1), &CaretPos::new(1, 5)), node);
-/// let core_result = gen(&ast).unwrap();
+/// let ast_ty = ASTTy::from(&ast);
+/// let core_result = gen(&ast_ty).unwrap();
 ///
 /// assert_eq!(core_result, Core::Return { expr: Box::from(Core::None) });
 /// ```
@@ -41,6 +40,7 @@ pub type DesugarInput = (AST, Option<String>, Option<PathBuf>);
 /// Fails if converting a construct which has not been implemented yet.
 ///
 /// ```rust
+/// # use mamba::check::ast::ASTTy;
 /// # use mamba::parse::ast::Node;
 /// # use mamba::parse::ast::AST;
 /// # use mamba::generate::ast::node::Core;
@@ -50,7 +50,8 @@ pub type DesugarInput = (AST, Option<String>, Option<PathBuf>);
 /// let cond_pos = AST::new(&Position::new(&CaretPos::new(0, 0), &CaretPos::new(0, 5)), cond_node);
 /// let node = Node::Condition { cond: Box::from(cond_pos), el: None };
 /// let ast = AST::new(&Position::new(&CaretPos::new(0, 0), &CaretPos::new(0, 5)), node);
-/// let core_result = gen(&ast);
+/// let ast_ty = ASTTy::from(&ast);
+/// let core_result = gen(&ast_ty);
 ///
 /// assert!(core_result.is_err());
 /// ```
@@ -59,26 +60,7 @@ pub type DesugarInput = (AST, Option<String>, Option<PathBuf>);
 ///
 /// A malformed [AST](crate::parser::ast::AST) causes this stage
 /// to panic.
-pub fn gen(input: &AST) -> GenResult {
-    convert_node(input, &mut Imports::new(), &State::new())
-}
-
-pub fn gen_all(inputs: &[DesugarInput]) -> GenResults {
-    let inputs: Vec<_> = inputs
-        .iter()
-        .map(|(ast, source, path)| (gen(ast), source, path))
-        .map(|(result, source, path)| {
-            (result.map_err(|err| err.into_with_source(source, path)), source.clone(), path.clone())
-        })
-        .collect();
-
-    let (oks, errs): (Vec<_>, Vec<_>) = inputs.iter().partition(|(res, ..)| res.is_ok());
-    if errs.is_empty() {
-        Ok(oks
-            .iter()
-            .map(|(res, src, path)| (res.as_ref().unwrap().clone(), src.clone(), path.clone()))
-            .collect())
-    } else {
-        Err(errs.iter().map(|(res, ..)| res.as_ref().unwrap_err().clone()).collect())
-    }
+pub fn gen(input: &ASTTy) -> GenResult {
+    let ast = AST::new(&input.pos, input.node.clone());
+    convert_node(&ast, &mut Imports::new(), &State::new())
 }

--- a/src/generate/result.rs
+++ b/src/generate/result.rs
@@ -3,7 +3,7 @@ use std::fmt::{Display, Formatter};
 use std::path::PathBuf;
 
 use crate::common::position::Position;
-use crate::common::result::IntoWithSource;
+use crate::common::result::WithSource;
 use crate::generate::ast::node::Core;
 use crate::parse::ast::AST;
 
@@ -33,8 +33,8 @@ impl UnimplementedErr {
     }
 }
 
-impl IntoWithSource for UnimplementedErr {
-    fn into_with_source(
+impl WithSource for UnimplementedErr {
+    fn with_source(
         self,
         source: &Option<String>,
         path: &Option<PathBuf>,

--- a/src/generate/result.rs
+++ b/src/generate/result.rs
@@ -3,11 +3,11 @@ use std::fmt::{Display, Formatter};
 use std::path::PathBuf;
 
 use crate::common::position::Position;
+use crate::common::result::IntoWithSource;
 use crate::generate::ast::node::Core;
 use crate::parse::ast::AST;
 
 pub type GenResult<T = Core> = Result<T, UnimplementedErr>;
-pub type GenResults = Result<Vec<(Core, Option<String>, Option<PathBuf>)>, Vec<UnimplementedErr>>;
 
 const VERSION: &str = env!("CARGO_PKG_VERSION");
 
@@ -31,9 +31,10 @@ impl UnimplementedErr {
             path: None,
         }
     }
+}
 
-    #[must_use]
-    pub fn into_with_source(
+impl IntoWithSource for UnimplementedErr {
+    fn into_with_source(
         self,
         source: &Option<String>,
         path: &Option<PathBuf>,
@@ -53,7 +54,6 @@ impl UnimplementedErr {
 }
 
 impl Display for UnimplementedErr {
-    // TODO handle multi-line errors
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         write!(
             f,

--- a/src/io.rs
+++ b/src/io.rs
@@ -8,26 +8,22 @@ use std::path::Path;
 use glob::glob;
 use pathdiff::diff_paths;
 
-pub fn read_source(source_path: &Path) -> Result<String, (String, String)> {
+pub fn read_source(source_path: &Path) -> Result<String, String> {
     let mut source = String::new();
     OpenOptions::new()
         .read(true)
         .open(source_path)
-        .map_err(|e| (String::from("input"), format!("{}: {}", e, source_path.display())))?
+        .map_err(|e| format!("{}: {}", e, source_path.display()))?
         .read_to_string(&mut source)
-        .map_err(|e| (String::from("input"), format!("{}: {}", e, source_path.display())))?;
+        .map_err(|e| format!("{}: {}", e, source_path.display()))?;
     Ok(source)
 }
 
-pub fn write_source(source: &str, out_path: &Path) -> Result<usize, (String, String)> {
+pub fn write_source(source: &str, out_path: &Path) -> Result<usize, String> {
     match out_path.parent() {
         Some(parent) => fs::create_dir_all(parent)
-            .map_err(|e| (String::from("output"), format!("{}: {}", e, parent.display())))?,
-        None =>
-            return Err((
-                String::from("output"),
-                format!("No parent directory: {}", out_path.display())
-            )),
+            .map_err(|e| format!("{}: {}", e, parent.display()))?,
+        None => return Err(format!("No parent directory: {}", out_path.display()))
     };
 
     // LF instead of CRLF line endings
@@ -36,16 +32,16 @@ pub fn write_source(source: &str, out_path: &Path) -> Result<usize, (String, Str
         .write(true)
         .create(true)
         .open(out_path)
-        .map_err(|e| (String::from("output"), format!("{}: {}", e, out_path.display())))?
+        .map_err(|e| format!("{}: {}", e, out_path.display()))?
         .write(source.as_ref())
-        .map_err(|e| (String::from("output"), format!("{}: {}", e, out_path.display())))
+        .map_err(|e| format!("{}: {}", e, out_path.display()))
 }
 
 /// Get all `*.mamba` files paths relative to given path.
 ///
 /// If path is file, return file name.
 /// If directory, return all `*.mamba` files as relative paths to given path.
-pub fn relative_files(in_path: &Path) -> Result<Vec<OsString>, (String, String)> {
+pub fn relative_files(in_path: &Path) -> Result<Vec<OsString>, String> {
     if in_path.is_file() {
         let in_file_name = in_path.file_name().unwrap_or_else(|| unreachable!());
         return Ok(vec![in_file_name.to_os_string()]);
@@ -54,13 +50,13 @@ pub fn relative_files(in_path: &Path) -> Result<Vec<OsString>, (String, String)>
     let pattern_path = in_path.to_owned().join("**").join("*.mamba");
     let pattern = pattern_path.as_os_str().to_string_lossy();
     let glob = glob(pattern.as_ref())
-        .map_err(|e| (String::from("file"), format!("Unable to recursively find files: {}", e)))?;
+        .map_err(|e| format!("Unable to recursively find files: {}", e))?;
 
     let mut relative_paths = vec![];
     for absolute_result in glob {
-        let absolute_path = absolute_result.map_err(|e| (String::from("file"), e.to_string()))?;
+        let absolute_path = absolute_result.map_err(|e| (e.to_string()))?;
         let relative_path = diff_paths(absolute_path.as_path(), in_path)
-            .ok_or((String::from("file"), String::from("Unable to create relative path")))?;
+            .ok_or_else(|| String::from("Unable to create relative path"))?;
         relative_paths.push(relative_path.into_os_string());
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,12 +6,19 @@ extern crate core;
 extern crate log;
 extern crate loggerv;
 
+use std::convert::TryFrom;
 use std::fs::create_dir;
+use std::ops::Deref;
 use std::path::{Path, PathBuf};
 
-use crate::check::check_all;
-use crate::generate::gen_all;
-use crate::parse::{parse_all, ParseInput};
+use crate::check::ast::ASTTy;
+use crate::check::check;
+use crate::check::context::Context;
+use crate::check::result::TypeErr;
+use crate::common::result::IntoWithSource;
+use crate::generate::gen;
+use crate::parse::ast::AST;
+use crate::parse::parse;
 
 pub mod common;
 
@@ -43,23 +50,24 @@ mod test_util {
 /// Output directory structure reflects input directory structure.
 /// If no output given, target directory created in current directory and output
 /// stored here.
-pub fn transpile_directory(
-    current_dir: &Path,
-    source: Option<&str>,
+pub fn transpile_dir(
+    dir: &Path,
+    src: Option<&str>,
     target: Option<&str>,
-) -> Result<PathBuf, Vec<(String, String)>> {
-    let src_path = source.map_or(current_dir.join(SOURCE), |p| current_dir.join(p));
+) -> Result<PathBuf, Vec<String>> {
+    let src_path = src.map_or(dir.join(SOURCE), |p| dir.join(p));
     if !src_path.is_file() && !src_path.is_dir() {
-        let msg = format!("Source directory does not exist: {}", src_path.as_os_str().to_str().unwrap());
-        return Err(vec![(String::from("pathfinding"), msg)]);
+        let msg =
+            format!("Source directory does not exist: {}", src_path.as_os_str().to_str().unwrap());
+        return Err(vec![msg]);
     } else if src_path.is_file() && !src_path.exists() {
         let msg = format!("Source file does not exist: {}", src_path.as_os_str().to_str().unwrap());
-        return Err(vec![(String::from("pathfinding"), msg)]);
+        return Err(vec![msg]);
     }
 
-    let out_dir = current_dir.join(target.unwrap_or(TARGET));
+    let out_dir = dir.join(target.unwrap_or(TARGET));
     if !out_dir.exists() {
-        create_dir(&out_dir).map_err(|e| vec![(String::from("io"), e.to_string())])?;
+        create_dir(&out_dir).map_err(|e| vec![e.to_string()])?;
     }
     info!("Input is '{}'", src_path.display());
     info!("Output will be stored in '{}'", out_dir.display());
@@ -105,7 +113,7 @@ pub fn transpile_directory(
 pub fn mamba_to_python(
     source: &[(String, Option<PathBuf>)],
     source_dir: &PathBuf,
-) -> Result<Vec<String>, Vec<(String, String)>> {
+) -> Result<Vec<String>, Vec<String>> {
     // Strip until source
     let strip_prefix = |p: PathBuf| {
         p.strip_prefix(source_dir)
@@ -114,29 +122,70 @@ pub fn mamba_to_python(
             })
             .unwrap_or(p)
     };
-    let source: Vec<ParseInput> =
-        source.iter().map(|(src, path)| (src.clone(), path.clone().map(strip_prefix))).collect();
+    let source: Vec<(String, Option<PathBuf>)> =
+        source.iter().map(|(src, dir)| (src.clone(), dir.clone().map(strip_prefix))).collect();
 
-    let asts = parse_all(&source).map_err(|errs| {
-        errs.iter()
-            .map(|err| (String::from("syntax"), format!("{}", err)))
-            .collect::<Vec<(String, String)>>()
-    })?;
+    let (asts, parse_errs): (Vec<_>, Vec<_>) = source
+        .iter()
+        .map(|(src, path)| {
+            parse(src)
+                .map_err(|err| err.into_with_source(&Some(src.clone()), &path.clone()))
+                .map(|ok| ok.deref().clone())
+        })
+        .partition(Result::is_ok);
+
+    let parse_errs: Vec<_> = parse_errs.into_iter().map(Result::unwrap_err).collect();
+    if !parse_errs.is_empty() {
+        return Err(parse_errs.iter().map(|err| format!("{}", err)).collect());
+    }
+
+    let asts: Vec<AST> = asts.into_iter().map(Result::unwrap).collect();
     trace!("Parsed {} files", asts.len());
 
-    let modified_trees = check_all(asts.as_slice()).map_err(|errs| {
-        errs.iter()
-            .map(|err| (String::from("type"), format!("{}", err)))
-            .collect::<Vec<(String, String)>>()
-    })?;
-    trace!("Checked {} files", modified_trees.len());
+    let ctx = Context::try_from(asts.as_ref());
+    let typed_ast: Vec<ASTTy> = match ctx {
+        Ok(ctx) => {
+            let (typed_ast, type_errs): (Vec<_>, Vec<_>) = asts
+                .iter()
+                .zip(&source)
+                .map(|(ast, (src, path))| {
+                    check(ast, &ctx).map_err(|errs| {
+                        errs.iter()
+                            .map(|err| err.clone().into_with_source(&Some(src.clone()), &path.clone()))
+                            .collect()
+                    })
+                })
+                .partition(Result::is_ok);
 
-    let core_tree = gen_all(modified_trees.as_slice()).map_err(|errs| {
-        errs.iter()
-            .map(|err| (String::from("unimplemented"), format!("{}", err)))
-            .collect::<Vec<(String, String)>>()
-    })?;
-    trace!("Converted {} checked files to Python", core_tree.len());
+            let type_errs: Vec<Vec<TypeErr>> = type_errs.into_iter().map(Result::unwrap_err).collect();
+            if !type_errs.is_empty() {
+                return Err(type_errs.iter().flatten().map(|err| format!("{}", err)).collect());
+            } else {
+                typed_ast.into_iter().map(Result::unwrap).collect()
+            }
+        }
+        Err(errs) => return Err(errs.iter().map(|e| format!("{}", e)).collect()),
+    };
 
-    Ok(core_tree.iter().map(|(core, ..)| core.to_source()).collect())
+    trace!("Checked {} files", typed_ast.len());
+
+    let (py_sources, gen_errs): (Vec<_>, Vec<_>) = typed_ast
+        .iter()
+        .zip(&source)
+        .map(|(ast_ty, (src, path))| {
+            gen(ast_ty)
+                .map_err(|err| err.into_with_source(&Some(src.clone()), &path.clone()))
+                .map(|core| core.to_source())
+        })
+        .partition(Result::is_ok);
+
+    let gen_errs: Vec<_> = gen_errs.into_iter().map(Result::unwrap_err).collect();
+    if !gen_errs.is_empty() {
+        return Err(gen_errs.iter().map(|err| format!("{}", err)).collect());
+    }
+
+    let py_sources: Vec<String> = py_sources.into_iter().map(Result::unwrap).collect();
+    trace!("Converted {} files to Python source", py_sources.len());
+
+    Ok(py_sources)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,7 @@ use crate::check::ast::ASTTy;
 use crate::check::check;
 use crate::check::context::Context;
 use crate::check::result::TypeErr;
-use crate::common::result::IntoWithSource;
+use crate::common::result::WithSource;
 use crate::generate::gen;
 use crate::parse::ast::AST;
 use crate::parse::parse;
@@ -129,7 +129,7 @@ pub fn mamba_to_python(
         .iter()
         .map(|(src, path)| {
             parse(src)
-                .map_err(|err| err.into_with_source(&Some(src.clone()), &path.clone()))
+                .map_err(|err| err.with_source(&Some(src.clone()), &path.clone()))
                 .map(|ok| ok.deref().clone())
         })
         .partition(Result::is_ok);
@@ -151,7 +151,7 @@ pub fn mamba_to_python(
                 .map(|(ast, (src, path))| {
                     check(ast, &ctx).map_err(|errs| {
                         errs.iter()
-                            .map(|err| err.clone().into_with_source(&Some(src.clone()), &path.clone()))
+                            .map(|err| err.clone().with_source(&Some(src.clone()), &path.clone()))
                             .collect()
                     })
                 })
@@ -174,7 +174,7 @@ pub fn mamba_to_python(
         .zip(&source)
         .map(|(ast_ty, (src, path))| {
             gen(ast_ty)
-                .map_err(|err| err.into_with_source(&Some(src.clone()), &path.clone()))
+                .map_err(|err| err.with_source(&Some(src.clone()), &path.clone()))
                 .map(|core| core.to_source())
         })
         .partition(Result::is_ok);

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,7 +9,7 @@ extern crate loggerv;
 use clap::App;
 use itertools::Itertools;
 
-use mamba::transpile_directory;
+use mamba::transpile_dir;
 
 const VERSION: &str = env!("CARGO_PKG_VERSION");
 
@@ -37,20 +37,11 @@ pub fn main() -> Result<(), String> {
         format!("Error while finding current directory: {}", err)
     })?;
 
-    transpile_directory(&current_dir, in_path, out_path)
+    transpile_dir(&current_dir, in_path, out_path)
         .map_err(|errors| {
-            errors.iter().unique().for_each(|(ty, msg)| eprintln!("[error | {}] {}", ty, msg));
+            errors.iter().unique().for_each(|msg| eprintln!("error: {}", msg));
             match errors.first() {
-                Some((ty, msg)) => format!(
-                    "{} {} error occurred: {}",
-                    match ty.chars().next() {
-                        Some(c) if ['a', 'e', 'i', 'o', 'u'].contains(&c.to_ascii_lowercase()) =>
-                            "An",
-                        _ => "A"
-                    },
-                    ty,
-                    msg
-                ),
+                Some(msg) => format!("error: {}", msg),
                 None => String::new()
             }
         })

--- a/src/parse/class.rs
+++ b/src/parse/class.rs
@@ -97,6 +97,7 @@ pub fn parse_parent(it: &mut LexIterator) -> ParseResult {
 
 #[cfg(test)]
 mod test {
+    use crate::common::result::IntoWithSource;
     use crate::parse::ast::Node;
     use crate::parse::parse;
     use crate::parse::result::{ParseErr, ParseResult};

--- a/src/parse/class.rs
+++ b/src/parse/class.rs
@@ -97,7 +97,7 @@ pub fn parse_parent(it: &mut LexIterator) -> ParseResult {
 
 #[cfg(test)]
 mod test {
-    use crate::common::result::IntoWithSource;
+    use crate::common::result::WithSource;
     use crate::parse::ast::Node;
     use crate::parse::parse;
     use crate::parse::result::{ParseErr, ParseResult};
@@ -243,7 +243,7 @@ mod test {
     fn class_with_single_line_body_no_newline() -> Result<(), ParseErr> {
         let source = "class MyClass\n    def var := 10";
         parse(&source)
-            .map_err(|e| e.into_with_source(&Some(String::from(source)), &None))
+            .map_err(|e| e.with_source(&Some(String::from(source)), &None))
             .map(|_| ())
     }
 
@@ -251,7 +251,7 @@ mod test {
     fn class_with_single_line_body_newline() -> Result<(), ParseErr> {
         let source = "class MyClass\n    def var := 10\n";
         parse(&source)
-            .map_err(|e| e.into_with_source(&Some(String::from(source)), &None))
+            .map_err(|e| e.with_source(&Some(String::from(source)), &None))
             .map(|_| ())
     }
 
@@ -259,7 +259,7 @@ mod test {
     fn class_with_body_class_right_after() -> Result<(), ParseErr> {
         let source = "class MyClass\n    def var := 10\nclass MyClass1\n";
         parse(&source)
-            .map_err(|e| e.into_with_source(&Some(String::from(source)), &None))
+            .map_err(|e| e.with_source(&Some(String::from(source)), &None))
             .map(|_| ())
     }
 

--- a/src/parse/mod.rs
+++ b/src/parse/mod.rs
@@ -1,10 +1,8 @@
-use std::path::PathBuf;
-
 #[cfg(test)]
 use crate::parse::ast::{AST, Node};
 use crate::parse::iterator::LexIterator;
 use crate::parse::lex::tokenize;
-use crate::parse::result::{ParseErr, ParseResult, ParseResults};
+use crate::parse::result::{ParseErr, ParseResult};
 
 pub mod ast;
 
@@ -27,33 +25,10 @@ mod operation;
 mod statement;
 mod ty;
 
-pub type ParseInput = (String, Option<PathBuf>);
-
 /// Parse input, which is a string.
 pub fn parse(input: &str) -> ParseResult {
     let tokens = tokenize(input).map_err(ParseErr::from)?;
     file::parse_file(&mut LexIterator::new(tokens.iter().peekable()))
-}
-
-pub fn parse_all(inputs: &[ParseInput]) -> ParseResults {
-    let results: Vec<(ParseResult, Option<String>, Option<PathBuf>)> = inputs
-        .iter()
-        .map(|(source, path)| (parse(source), source, path))
-        .map(|(result, source, path)| {
-            let result = result.map_err(|err| err.into_with_source(&Some(source.clone()), path));
-            (result, Some(source.clone()), path.clone())
-        })
-        .collect();
-
-    let (oks, errs): (Vec<_>, Vec<_>) = results.iter().partition(|(res, ..)| res.is_ok());
-    if errs.is_empty() {
-        Ok(oks
-            .iter()
-            .map(|(res, src, path)| (*res.as_ref().unwrap().clone(), src.clone(), path.clone()))
-            .collect())
-    } else {
-        Err(errs.iter().map(|(res, ..)| res.as_ref().unwrap_err().clone()).collect())
-    }
 }
 
 #[cfg(test)]

--- a/src/parse/result.rs
+++ b/src/parse/result.rs
@@ -5,7 +5,7 @@ use std::path::PathBuf;
 
 use crate::check::context::clss;
 use crate::common::position::Position;
-use crate::common::result::IntoWithSource;
+use crate::common::result::WithSource;
 use crate::parse::ast::AST;
 use crate::parse::lex::result::LexErr;
 use crate::parse::lex::token::Lex;
@@ -53,8 +53,8 @@ impl ParseErr {
     }
 }
 
-impl IntoWithSource for ParseErr {
-    fn into_with_source(self, source: &Option<String>, path: &Option<PathBuf>) -> ParseErr {
+impl WithSource for ParseErr {
+    fn with_source(self, source: &Option<String>, path: &Option<PathBuf>) -> ParseErr {
         ParseErr {
             position: self.position,
             msg: self.msg,

--- a/src/parse/result.rs
+++ b/src/parse/result.rs
@@ -5,6 +5,7 @@ use std::path::PathBuf;
 
 use crate::check::context::clss;
 use crate::common::position::Position;
+use crate::common::result::IntoWithSource;
 use crate::parse::ast::AST;
 use crate::parse::lex::result::LexErr;
 use crate::parse::lex::token::Lex;
@@ -13,7 +14,6 @@ use crate::parse::lex::token::Token;
 const SYNTAX_ERR_MAX_DEPTH: usize = 1;
 
 pub type ParseResult<T = Box<AST>> = Result<T, ParseErr>;
-pub type ParseResults = Result<Vec<(AST, Option<String>, Option<PathBuf>)>, Vec<ParseErr>>;
 
 #[derive(Debug, Clone)]
 pub struct ParseErr {
@@ -51,9 +51,10 @@ impl ParseErr {
             path: self.path.clone(),
         }
     }
+}
 
-    #[must_use]
-    pub fn into_with_source(self, source: &Option<String>, path: &Option<PathBuf>) -> ParseErr {
+impl IntoWithSource for ParseErr {
+    fn into_with_source(self, source: &Option<String>, path: &Option<PathBuf>) -> ParseErr {
         ParseErr {
             position: self.position,
             msg: self.msg,

--- a/tests/check/invalid/access.rs
+++ b/tests/check/invalid/access.rs
@@ -6,36 +6,36 @@ use crate::common::resource_content;
 #[test]
 fn access_list_with_string() {
     let source = resource_content(false, &["type", "access"], "access_list_with_string.mamba");
-    check_all(&[(*parse(&source).unwrap(), None, None)]).unwrap_err();
+    check_all(&[*parse(&source).unwrap()]).unwrap_err();
 }
 
 #[test]
 #[ignore] // Cannot parse dictionaries yet
 fn access_string_dict_with_int() {
     let source = resource_content(false, &["type", "access"], "access_string_dict_with_int.mamba");
-    check_all(&[(*parse(&source).unwrap(), None, None)]).unwrap_err();
+    check_all(&[*parse(&source).unwrap()]).unwrap_err();
 }
 
 #[test]
 fn slice_begin_wrong_type() {
     let source = resource_content(false, &["type", "access"], "slice_begin_wrong_type.mamba");
-    check_all(&[(*parse(&source).unwrap(), None, None)]).unwrap_err();
+    check_all(&[*parse(&source).unwrap()]).unwrap_err();
 }
 
 #[test]
 fn slice_end_wrong_type() {
     let source = resource_content(false, &["type", "access"], "slice_end_wrong_type.mamba");
-    check_all(&[(*parse(&source).unwrap(), None, None)]).unwrap_err();
+    check_all(&[*parse(&source).unwrap()]).unwrap_err();
 }
 
 #[test]
 fn slice_step_wrong_type() {
     let source = resource_content(false, &["type", "access"], "slice_step_wrong_type.mamba");
-    check_all(&[(*parse(&source).unwrap(), None, None)]).unwrap_err();
+    check_all(&[*parse(&source).unwrap()]).unwrap_err();
 }
 
 #[test]
 fn access_int() {
     let source = resource_content(false, &["type", "access"], "access_int.mamba");
-    check_all(&[(*parse(&source).unwrap(), None, None)]).unwrap_err();
+    check_all(&[*parse(&source).unwrap()]).unwrap_err();
 }

--- a/tests/check/invalid/class.rs
+++ b/tests/check/invalid/class.rs
@@ -1,112 +1,113 @@
-use mamba::{check::check_all, parse::parse};
+use mamba::check::check_all;
+use mamba::parse::parse;
 
 use crate::common::resource_content;
 
 #[test]
 fn reassign_non_existent() {
     let source = resource_content(false, &["type", "class"], "reassign_non_existent.mamba");
-    check_all(&[(*parse(&source).unwrap(), None, None)]).unwrap_err();
+    check_all(&[*parse(&source).unwrap()]).unwrap_err();
 }
 
 #[test]
 fn assign_to_non_existent_self() {
     let source = resource_content(false, &["type", "class"], "assign_to_non_existent_self.mamba");
-    check_all(&[(*parse(&source).unwrap(), None, None)]).unwrap_err();
+    check_all(&[*parse(&source).unwrap()]).unwrap_err();
 }
 
 #[test]
 fn access_unassigned_field() {
     let source = resource_content(false, &["type", "class"], "access_unassigned_field.mamba");
-    check_all(&[(*parse(&source).unwrap(), None, None)]).unwrap_err();
+    check_all(&[*parse(&source).unwrap()]).unwrap_err();
 }
 
 #[test]
 fn reassign_wrong_type() {
     let source = resource_content(false, &["type", "class"], "reassign_wrong_type.mamba");
-    check_all(&[(*parse(&source).unwrap(), None, None)]).unwrap_err();
+    check_all(&[*parse(&source).unwrap()]).unwrap_err();
 }
 
 #[test]
 fn reassign_function() {
     let source = resource_content(false, &["type", "class"], "reassign_function.mamba");
-    check_all(&[(*parse(&source).unwrap(), None, None)]).unwrap_err();
+    check_all(&[*parse(&source).unwrap()]).unwrap_err();
 }
 
 #[test]
 fn access_field_wrong_type() {
     let source = resource_content(false, &["type", "class"], "access_field_wrong_type.mamba");
-    check_all(&[(*parse(&source).unwrap(), None, None)]).unwrap_err();
+    check_all(&[*parse(&source).unwrap()]).unwrap_err();
 }
 
 #[test]
 fn access_function_wrong_type() {
     let source = resource_content(false, &["type", "class"], "access_function_wrong_type.mamba");
-    check_all(&[(*parse(&source).unwrap(), None, None)]).unwrap_err();
+    check_all(&[*parse(&source).unwrap()]).unwrap_err();
 }
 
 #[test]
 fn class_with_args_and_init() {
     let source = resource_content(false, &["type", "class"], "args_and_init.mamba");
-    check_all(&[(*parse(&source).unwrap(), None, None)]).unwrap_err();
+    check_all(&[*parse(&source).unwrap()]).unwrap_err();
 }
 
 #[test]
 fn assign_to_inner_inner_not_allowed() {
     let source =
         resource_content(false, &["type", "class"], "assign_to_inner_inner_not_allowed.mamba");
-    check_all(&[(*parse(&source).unwrap(), None, None)]).unwrap_err();
+    check_all(&[*parse(&source).unwrap()]).unwrap_err();
 }
 
 #[test]
 fn assign_to_inner_not_allowed() {
     let source = resource_content(false, &["type", "class"], "assign_to_inner_not_allowed.mamba");
-    check_all(&[(*parse(&source).unwrap(), None, None)]).unwrap_err();
+    check_all(&[*parse(&source).unwrap()]).unwrap_err();
 }
 
 #[test]
 #[ignore]
 fn generic_unknown_type() {
     let source = resource_content(false, &["type", "class"], "generic_unknown_type.mamba");
-    check_all(&[(*parse(&source).unwrap(), None, None)]).unwrap_err();
+    check_all(&[*parse(&source).unwrap()]).unwrap_err();
 }
 
 #[test]
 #[ignore]
 fn incompat_parent_generic() {
     let source = resource_content(false, &["type", "class"], "incompat_parent_generic.mamba");
-    check_all(&[(*parse(&source).unwrap(), None, None)]).unwrap_err();
+    check_all(&[*parse(&source).unwrap()]).unwrap_err();
 }
 
 #[test]
 #[ignore]
 fn no_generic_arg() {
     let source = resource_content(false, &["type", "class"], "no_generic_arg.mamba");
-    check_all(&[(*parse(&source).unwrap(), None, None)]).unwrap_err();
+    check_all(&[*parse(&source).unwrap()]).unwrap_err();
 }
 
 #[test]
 fn one_tuple_not_assigned_to() {
     let source = resource_content(false, &["type", "class"], "one_tuple_not_assigned_to.mamba");
-    check_all(&[(*parse(&source).unwrap(), None, None)]).unwrap_err();
+    check_all(&[*parse(&source).unwrap()]).unwrap_err();
 }
 
 #[test]
 #[ignore] // need to fix
 fn reassign_to_unassigned_class_var() {
     let source = resource_content(false, &["type", "class"], "reassign_to_unassigned_class_var.mamba");
-    check_all(&[(*parse(&source).unwrap(), None, None)]).unwrap_err();
+    check_all(&[*parse(&source).unwrap()]).unwrap_err();
 }
 
 #[test]
 fn top_level_class_not_assigned_to() {
     let source =
         resource_content(false, &["type", "class"], "top_level_class_not_assigned_to.mamba");
-    check_all(&[(*parse(&source).unwrap(), None, None)]).unwrap_err();
+    check_all(&[*parse(&source).unwrap()]).unwrap_err();
 }
 
 #[test]
 #[ignore]
 fn wrong_generic_type() {
     let source = resource_content(false, &["type", "class"], "wrong_generic_type.mamba");
-    check_all(&[(*parse(&source).unwrap(), None, None)]).unwrap_err();
+    check_all(&[*parse(&source).unwrap()]).unwrap_err();
 }

--- a/tests/check/invalid/control_flow.rs
+++ b/tests/check/invalid/control_flow.rs
@@ -6,41 +6,41 @@ use crate::common::resource_content;
 #[test]
 fn float_and() {
     let source = resource_content(false, &["type", "control_flow"], "float_and.mamba");
-    check_all(&[(*parse(&source).unwrap(), None, None)]).unwrap_err();
+    check_all(&[*parse(&source).unwrap()]).unwrap_err();
 }
 
 #[test]
 fn for_non_iterable() {
     let source = resource_content(false, &["type", "control_flow"], "for_non_iterable.mamba");
-    check_all(&[(*parse(&source).unwrap(), None, None)]).unwrap_err();
+    check_all(&[*parse(&source).unwrap()]).unwrap_err();
 }
 
 #[test]
 fn for_over_union_one_not_minus() {
     let source = resource_content(false, &["type", "control_flow"], "for_over_union_one_not_minus.mamba");
-    check_all(&[(*parse(&source).unwrap(), None, None)]).unwrap_err();
+    check_all(&[*parse(&source).unwrap()]).unwrap_err();
 }
 
 #[test]
 fn if_not_bool_union() {
     let source = resource_content(false, &["type", "control_flow"], "if_not_bool_union.mamba");
-    check_all(&[(*parse(&source).unwrap(), None, None)]).unwrap_err();
+    check_all(&[*parse(&source).unwrap()]).unwrap_err();
 }
 
 #[test]
 fn if_not_boolean() {
     let source = resource_content(false, &["type", "control_flow"], "if_not_boolean.mamba");
-    check_all(&[(*parse(&source).unwrap(), None, None)]).unwrap_err();
+    check_all(&[*parse(&source).unwrap()]).unwrap_err();
 }
 
 #[test]
 fn not_integer() {
     let source = resource_content(false, &["type", "control_flow"], "not_integer.mamba");
-    check_all(&[(*parse(&source).unwrap(), None, None)]).unwrap_err();
+    check_all(&[*parse(&source).unwrap()]).unwrap_err();
 }
 
 #[test]
 fn or_float() {
     let source = resource_content(false, &["type", "control_flow"], "or_float.mamba");
-    check_all(&[(*parse(&source).unwrap(), None, None)]).unwrap_err();
+    check_all(&[*parse(&source).unwrap()]).unwrap_err();
 }

--- a/tests/check/invalid/definition.rs
+++ b/tests/check/invalid/definition.rs
@@ -10,127 +10,127 @@ fn argument_after_argument_with_default() {
         &["type", "definition"],
         "argument_after_argument_with_default.mamba",
     );
-    check_all(&[(*parse(&source).unwrap(), None, None)]).unwrap_err();
+    check_all(&[*parse(&source).unwrap()]).unwrap_err();
 }
 
 #[test]
 fn assign_wrong_type() {
     let source = resource_content(false, &["type", "definition"], "assign_wrong_type.mamba");
-    check_all(&[(*parse(&source).unwrap(), None, None)]).unwrap_err();
+    check_all(&[*parse(&source).unwrap()]).unwrap_err();
 }
 
 #[test]
 fn assign_to_function_call() {
     let source = resource_content(false, &["type", "definition"], "assign_to_function_call.mamba");
-    check_all(&[(*parse(&source).unwrap(), None, None)]).unwrap_err();
+    check_all(&[*parse(&source).unwrap()]).unwrap_err();
 }
 
 #[test]
 #[ignore] // Ignore mutability for now
 fn assign_to_inner_non_mut() {
     let source = resource_content(false, &["type", "definition"], "assign_to_inner_non_mut.mamba");
-    check_all(&[(*parse(&source).unwrap(), None, None)]).unwrap();
+    check_all(&[*parse(&source).unwrap()]).unwrap_err();
 }
 
 #[test]
 fn assign_to_inner_non_mut2() {
     let source = resource_content(false, &["type", "definition"], "assign_to_inner_non_mut2.mamba");
-    check_all(&[(*parse(&source).unwrap(), None, None)]).unwrap_err();
+    check_all(&[*parse(&source).unwrap()]).unwrap_err();
 }
 
 #[test]
 #[ignore]
 fn assign_to_inner_non_mut3() {
     let source = resource_content(false, &["type", "definition"], "assign_to_inner_non_mut3.mamba");
-    check_all(&[(*parse(&source).unwrap(), None, None)]).unwrap_err();
+    check_all(&[*parse(&source).unwrap()]).unwrap_err();
 }
 
 #[test]
 fn undefined_variable() {
     let source = resource_content(false, &["type", "definition"], "undefined_variable.mamba");
-    check_all(&[(*parse(&source).unwrap(), None, None)]).unwrap_err();
+    check_all(&[*parse(&source).unwrap()]).unwrap_err();
 }
 
 #[test]
 #[ignore] // Ignore mutability for now
 fn nested_non_mut_field() {
     let source = resource_content(false, &["type", "definition"], "nested_non_mut_field.mamba");
-    check_all(&[(*parse(&source).unwrap(), None, None)]).unwrap_err();
+    check_all(&[*parse(&source).unwrap()]).unwrap_err();
 }
 
 #[test]
 #[ignore] // Ignore mutability for now
 fn reassign_non_mut() {
     let source = resource_content(false, &["type", "definition"], "reassign_non_mut.mamba");
-    check_all(&[(*parse(&source).unwrap(), None, None)]).unwrap_err();
+    check_all(&[*parse(&source).unwrap()]).unwrap_err();
 }
 
 #[test]
 fn non_mutable_in_call_chain() {
     let source =
         resource_content(false, &["type", "definition"], "non_mutable_in_call_chain.mamba");
-    check_all(&[(*parse(&source).unwrap(), None, None)]).unwrap_err();
+    check_all(&[*parse(&source).unwrap()]).unwrap_err();
 }
 
 #[test]
 fn raises_unmentioned_exception() {
     let source =
         resource_content(false, &["type", "definition"], "raises_unmentioned_exception.mamba");
-    check_all(&[(*parse(&source).unwrap(), None, None)]).unwrap_err();
+    check_all(&[*parse(&source).unwrap()]).unwrap_err();
 }
 
 #[test]
 fn raises_non_exception() {
     let source = resource_content(false, &["type", "definition"], "raises_non_exception.mamba");
-    check_all(&[(*parse(&source).unwrap(), None, None)]).unwrap_err();
+    check_all(&[*parse(&source).unwrap()]).unwrap_err();
 }
 
 #[test]
 #[ignore] // Ignore mutability for now
 fn reassign_non_mut_field() {
     let source = resource_content(false, &["type", "definition"], "reassign_non_mut_field.mamba");
-    check_all(&[(*parse(&source).unwrap(), None, None)]).unwrap_err();
+    check_all(&[*parse(&source).unwrap()]).unwrap_err();
 }
 
 #[test]
 #[ignore] // Ignore tuples for now
 fn tuple_modify_inner_mut() {
     let source = resource_content(false, &["type", "definition"], "tuple_modify_inner_mut.mamba");
-    check_all(&[(*parse(&source).unwrap(), None, None)]).unwrap_err();
+    check_all(&[*parse(&source).unwrap()]).unwrap_err();
 }
 
 #[test]
 fn tuple_modify_mut() {
     let source = resource_content(false, &["type", "definition"], "tuple_modify_mut.mamba");
-    check_all(&[(*parse(&source).unwrap(), None, None)]).unwrap_err();
+    check_all(&[*parse(&source).unwrap()]).unwrap_err();
 }
 
 #[test]
 fn tuple_modify_mut_entire() {
     let source = resource_content(false, &["type", "definition"], "tuple_modify_mut_entire.mamba");
-    check_all(&[(*parse(&source).unwrap(), None, None)]).unwrap_err();
+    check_all(&[*parse(&source).unwrap()]).unwrap_err();
 }
 
 #[test]
 fn tuple_assign_itself() {
     let source = resource_content(false, &["type", "definition"], "tuple_assign_itself.mamba");
-    check_all(&[(*parse(&source).unwrap(), None, None)]).unwrap_err();
+    check_all(&[*parse(&source).unwrap()]).unwrap_err();
 }
 
 #[test]
 fn wrong_size_tuple() {
     let source = resource_content(false, &["type", "definition"], "wrong_size_tuple.mamba");
-    check_all(&[(*parse(&source).unwrap(), None, None)]).unwrap_err();
+    check_all(&[*parse(&source).unwrap()]).unwrap_err();
 }
 
 #[test]
 fn wrong_size_tuple_2() {
     let source = resource_content(false, &["type", "definition"], "wrong_size_tuple_2.mamba");
-    check_all(&[(*parse(&source).unwrap(), None, None)]).unwrap_err();
+    check_all(&[*parse(&source).unwrap()]).unwrap_err();
 }
 
 #[test]
 fn list_not_a_tuple() {
     let source = resource_content(false, &["type", "definition"], "list_not_a_tuple.mamba");
-    check_all(&[(*parse(&source).unwrap(), None, None)]).unwrap_err();
+    check_all(&[*parse(&source).unwrap()]).unwrap_err();
 }

--- a/tests/check/invalid/error.rs
+++ b/tests/check/invalid/error.rs
@@ -6,17 +6,17 @@ use crate::common::resource_content;
 #[test]
 fn using_old_resource_in_with() {
     let source = resource_content(false, &["type", "error"], "using_old_resource_in_with.mamba");
-    check_all(&[(*parse(&source).unwrap(), None, None)]).unwrap_err();
+    check_all(&[*parse(&source).unwrap()]).unwrap_err();
 }
 
 #[test]
 fn with_wrong_type() {
     let source = resource_content(false, &["type", "error"], "with_wrong_type.mamba");
-    check_all(&[(*parse(&source).unwrap(), None, None)]).unwrap_err();
+    check_all(&[*parse(&source).unwrap()]).unwrap_err();
 }
 
 #[test]
 fn with_not_expression() {
     let source = resource_content(false, &["type", "error"], "with_not_expression.mamba");
-    check_all(&[(*parse(&source).unwrap(), None, None)]).unwrap_err();
+    check_all(&[*parse(&source).unwrap()]).unwrap_err();
 }

--- a/tests/check/invalid/function.rs
+++ b/tests/check/invalid/function.rs
@@ -6,96 +6,96 @@ use crate::common::resource_content;
 #[test]
 fn outside_class_with_self() {
     let source = resource_content(false, &["type", "function"], "outside_class_with_self.mamba");
-    check_all(&[(*parse(&source).unwrap(), None, None)]).unwrap_err();
+    check_all(&[*parse(&source).unwrap()]).unwrap_err();
 }
 
 #[test]
 fn incompatible_types() {
     let source = resource_content(false, &["type", "function"], "incompatible_types.mamba");
-    check_all(&[(*parse(&source).unwrap(), None, None)]).unwrap_err();
+    check_all(&[*parse(&source).unwrap()]).unwrap_err();
 }
 
 #[test]
 fn no_enough_arg() {
     let source = resource_content(false, &["type", "function"], "no_enough_arg.mamba");
-    check_all(&[(*parse(&source).unwrap(), None, None)]).unwrap_err();
+    check_all(&[*parse(&source).unwrap()]).unwrap_err();
 }
 
 #[test]
 fn no_enough_arg_with_default() {
     let source = resource_content(false, &["type", "function"], "not_enough_arg_with_default.mamba");
-    check_all(&[(*parse(&source).unwrap(), None, None)]).unwrap_err();
+    check_all(&[*parse(&source).unwrap()]).unwrap_err();
 }
 
 #[test]
 fn arg_no_type() {
     let source = resource_content(false, &["type", "function"], "arg_no_type.mamba");
-    check_all(&[(*parse(&source).unwrap(), None, None)]).unwrap_err();
+    check_all(&[*parse(&source).unwrap()]).unwrap_err();
 }
 
 #[test]
 fn as_statement() {
     let source = resource_content(false, &["type", "function"], "as_statement.mamba");
-    check_all(&[(*parse(&source).unwrap(), None, None)]).unwrap_err();
+    check_all(&[*parse(&source).unwrap()]).unwrap_err();
 }
 
 #[test]
 fn return_illegal() {
     let source = resource_content(false, &["type", "function"], "return_illegal.mamba");
-    check_all(&[(*parse(&source).unwrap(), None, None)]).unwrap_err();
+    check_all(&[*parse(&source).unwrap()]).unwrap_err();
 }
 
 #[test]
 fn statement_as_param() {
     let source = resource_content(false, &["type", "function"], "statement_as_param.mamba");
-    check_all(&[(*parse(&source).unwrap(), None, None)]).unwrap_err();
+    check_all(&[*parse(&source).unwrap()]).unwrap_err();
 }
 
 #[test]
 fn too_many_arg() {
     let source = resource_content(false, &["type", "function"], "too_many_arg.mamba");
-    check_all(&[(*parse(&source).unwrap(), None, None)]).unwrap_err();
+    check_all(&[*parse(&source).unwrap()]).unwrap_err();
 }
 
 #[test]
 fn too_many_arg_with_default() {
     let source = resource_content(false, &["type", "function"], "too_many_arg_with_default.mamba");
-    check_all(&[(*parse(&source).unwrap(), None, None)]).unwrap_err();
+    check_all(&[*parse(&source).unwrap()]).unwrap_err();
 }
 
 #[test]
 fn unexpected_pass() {
     let source = resource_content(false, &["type", "function"], "unexpected_pass.mamba");
-    check_all(&[(*parse(&source).unwrap(), None, None)]).unwrap_err();
+    check_all(&[*parse(&source).unwrap()]).unwrap_err();
 }
 
 #[test]
 fn unmentioned_exception() {
     let source = resource_content(false, &["type", "function"], "unmentioned_exception.mamba");
-    check_all(&[(*parse(&source).unwrap(), None, None)]).unwrap_err();
+    check_all(&[*parse(&source).unwrap()]).unwrap_err();
 }
 
 #[test]
 fn wrong_exception() {
     let source = resource_content(false, &["type", "function"], "wrong_exception.mamba");
-    check_all(&[(*parse(&source).unwrap(), None, None)]).unwrap_err();
+    check_all(&[*parse(&source).unwrap()]).unwrap_err();
 }
 
 #[test]
 fn wrong_return_type() {
     let source = resource_content(false, &["type", "function"], "wrong_return_type.mamba");
-    check_all(&[(*parse(&source).unwrap(), None, None)]).unwrap_err();
+    check_all(&[*parse(&source).unwrap()]).unwrap_err();
 }
 
 #[test]
 fn return_undefined() {
     let source = resource_content(false, &["type", "function"], "return_undefined.mamba");
-    check_all(&[(*parse(&source).unwrap(), None, None)]).unwrap_err();
+    check_all(&[*parse(&source).unwrap()]).unwrap_err();
 }
 
 #[test]
 #[ignore] // Ignore mutability for now
 fn call_mut_function() {
     let source = resource_content(false, &["type", "function"], "call_mut_function.mamba");
-    check_all(&[(*parse(&source).unwrap(), None, None)]).unwrap_err();
+    check_all(&[*parse(&source).unwrap()]).unwrap_err();
 }

--- a/tests/check/invalid/operation.rs
+++ b/tests/check/invalid/operation.rs
@@ -6,23 +6,23 @@ use crate::common::resource_content;
 #[test]
 fn reassign_to_nullable() {
     let source = resource_content(false, &["type", "operation"], "reassign_to_nullable.mamba");
-    check_all(&[(*parse(&source).unwrap(), None, None)]).unwrap_err();
+    check_all(&[*parse(&source).unwrap()]).unwrap_err();
 }
 
 #[test]
 fn reassign_to_undefined() {
     let source = resource_content(false, &["type", "operation"], "reassign_to_undefined.mamba");
-    check_all(&[(*parse(&source).unwrap(), None, None)]).unwrap_err();
+    check_all(&[*parse(&source).unwrap()]).unwrap_err();
 }
 
 #[test]
 fn string_minus() {
     let source = resource_content(false, &["type", "operation"], "string_minus.mamba");
-    check_all(&[(*parse(&source).unwrap(), None, None)]).unwrap_err();
+    check_all(&[*parse(&source).unwrap()]).unwrap_err();
 }
 
 #[test]
 fn undefined_field_fstring() {
     let source = resource_content(false, &["type", "operation"], "undefined_field_fstring.mamba");
-    check_all(&[(*parse(&source).unwrap(), None, None)]).unwrap_err();
+    check_all(&[*parse(&source).unwrap()]).unwrap_err();
 }

--- a/tests/check/invalid/python_primitives.rs
+++ b/tests/check/invalid/python_primitives.rs
@@ -1,6 +1,6 @@
 use std::convert::TryFrom;
 
-use mamba::check::{check_all, CheckInput};
+use mamba::check::check_all;
 use mamba::check::context::{Context, LookupClass};
 use mamba::check::name::stringname::StringName;
 use mamba::common::position::Position;
@@ -11,12 +11,12 @@ use crate::common::resource_content;
 #[test]
 fn float_and() {
     let source = resource_content(false, &["type", "control_flow"], "float_and.mamba");
-    check_all(&[(*parse(&source).unwrap(), None, None)]).unwrap_err();
+    check_all(&[*parse(&source).unwrap()]).unwrap_err();
 }
 
 #[test]
 pub fn non_existent_primitive() {
-    let files: Vec<CheckInput> = vec![];
+    let files = vec![];
     let context = Context::try_from(files.as_slice()).unwrap();
     let context = context.into_with_primitives().unwrap();
 

--- a/tests/check/mod.rs
+++ b/tests/check/mod.rs
@@ -2,6 +2,7 @@ use std::fmt::{Debug, Formatter};
 
 use mamba::check::check_all;
 use mamba::check::result::TypeErr;
+use mamba::common::result::IntoWithSource;
 use mamba::parse::parse;
 
 pub mod invalid;
@@ -12,7 +13,7 @@ struct CheckTestErr(Vec<TypeErr>);
 type CheckTestRet = Result<(), CheckTestErr>;
 
 fn check_test(source: &String) -> CheckTestRet {
-    check_all(&[(*parse(&source).unwrap(), None, None)])
+    check_all(&[*parse(&source).unwrap()])
         .map(|_| ())
         .map_err(|errs| CheckTestErr(errs.into_iter().map(|err| {
             err.into_with_source(&Some(source.clone()), &None)

--- a/tests/check/mod.rs
+++ b/tests/check/mod.rs
@@ -2,7 +2,7 @@ use std::fmt::{Debug, Formatter};
 
 use mamba::check::check_all;
 use mamba::check::result::TypeErr;
-use mamba::common::result::IntoWithSource;
+use mamba::common::result::WithSource;
 use mamba::parse::parse;
 
 pub mod invalid;
@@ -16,7 +16,7 @@ fn check_test(source: &String) -> CheckTestRet {
     check_all(&[*parse(&source).unwrap()])
         .map(|_| ())
         .map_err(|errs| CheckTestErr(errs.into_iter().map(|err| {
-            err.into_with_source(&Some(source.clone()), &None)
+            err.with_source(&Some(source.clone()), &None)
         }).collect::<Vec<TypeErr>>()))
 }
 

--- a/tests/generate/mod.rs
+++ b/tests/generate/mod.rs
@@ -1,9 +1,9 @@
 macro_rules! to_py {
     ($source:expr) => {{
         let ast = parse(&$source).unwrap();
-        let checked = check_all(&[(*ast, None, None)]).expect("Type checker should pass");
-        let (ast, _, _) = checked.first().expect("Input as lost by checker");
-        let core = gen(&ast).unwrap();
+        let checked = check_all(&[*ast]).expect("Type checker should pass");
+        let ast_ty = checked.first().expect("Input as lost by checker");
+        let core = gen(&ast_ty).unwrap();
         core.to_source();
     }};
 }

--- a/tests/system/mod.rs
+++ b/tests/system/mod.rs
@@ -7,7 +7,7 @@ use itertools::{EitherOrBoth, Itertools};
 use python_parser::ast::Statement;
 
 use mamba::common::delimit::newline_delimited;
-use mamba::transpile_directory;
+use mamba::transpile_dir;
 
 use crate::common::{
     delete_dir, python_src_to_stmts, resource_content, resource_content_path,
@@ -87,8 +87,8 @@ fn fallable(
     let current_dir_string = resource_path(valid, input, "");
     let current_dir = Path::new(&current_dir_string);
 
-    let map_err = |(ty, msg): &(String, String)| format!("[error | {}] {}", ty, msg);
-    transpile_directory(&current_dir, Some(&format!("{}.mamba", file_name)), Some(output_path))
+    let map_err = |msg: &String| format!("error: {}", msg);
+    transpile_dir(&current_dir, Some(&format!("{}.mamba", file_name)), Some(output_path))
         .map_err(|errs| OutTestErr(errs.iter().map(&map_err).collect::<Vec<String>>()))?;
 
     // Check that reference check is proper Python file


### PR DESCRIPTION
### Relevant issues

Working towards #279 

### Summary

- Add ASTTy class, which in future should represent an annotated type tree.
- Interfaces no longer take source and path as input (expect parse, which takes source as input of course).
  Instead, the user can opt to add these to the errors if they so choose.

### Added Tests
