### PR TITLE
Add optional to Name in generate

### DIFF
--- a/src/generate/name.rs
+++ b/src/generate/name.rs
@@ -71,38 +71,174 @@ impl ToPy for StringName {
 
 /// Produce type with alphabetized generics, ensuring that for any two equal sets of generics the
 /// order in which they are given is always the same.
+///
+/// - Ignores capitalization of generics.
+/// - Types with no literal are at the front.
 fn core_type(lit: &str, generics: &[Core]) -> Core {
-    let names: BTreeMap<String, Core> = generics.iter().map(|core| match core {
-        Core::Type { lit, .. } | Core::Id { lit } => (lit.clone(), core.clone()),
-        _ => (String::from(""), core.clone())
-    }).collect();
+    let names: BTreeMap<String, Core> = generics
+        .iter()
+        .map(|core| match core {
+            Core::Type { lit, generics } => (lit.clone(), core_type(lit, generics)),
+            Core::Id { lit } => (lit.clone(), core.clone()),
+            _ => (String::from(""), core.clone()),
+        })
+        .collect();
 
-    let generics = names
+    let generics: Vec<Core> = names
         .into_iter()
-        .sorted_by_key(|(name, _)| name.clone())
+        .sorted_by_key(|(name, _)| name.clone().to_lowercase())
         .map(|(_, core)| core)
         .collect();
-    Core::Type { lit: String::from(lit), generics }
+
+    if generics.is_empty() {
+        Core::Id { lit: String::from(lit) }
+    } else {
+        Core::Type { lit: String::from(lit), generics }
+    }
 }
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashSet;
+
+    use crate::check::name::{AsNullable, Name};
+    use crate::check::name::namevariant::NameVariant;
+    use crate::check::name::stringname::StringName;
+    use crate::check::name::truename::TrueName;
     use crate::generate::ast::node::Core;
-    use crate::generate::name::core_type;
+    use crate::generate::convert::state::Imports;
+    use crate::generate::name::{core_type, ToPy};
 
     #[test]
     fn alphabetize_ids() {
         let generics = vec!["z", "b", "e"];
-        let generics: Vec<Core> = generics.iter().map(|id| Core::Id { lit: String::from(*id) }).collect();
+        let generics: Vec<Core> =
+            generics.iter().map(|id| Core::Id { lit: String::from(*id) }).collect();
 
         let core = core_type("something", &generics);
-        assert_eq!(core, Core::Type {
-            lit: String::from("something"),
+        assert_eq!(
+            core,
+            Core::Type {
+                lit: String::from("something"),
+                generics: vec![
+                    Core::Id { lit: String::from("b") },
+                    Core::Id { lit: String::from("e") },
+                    Core::Id { lit: String::from("z") },
+                ],
+            }
+        )
+    }
+
+    #[test]
+    fn alphabetize_generics() {
+        let generics = vec!["z", "b"];
+        let mut generics: Vec<Core> =
+            generics.iter().map(|id| Core::Id { lit: String::from(*id) }).collect();
+
+        let generic = Core::Type {
+            lit: String::from("H"),
             generics: vec![
-                Core::Id { lit: String::from("b") },
-                Core::Id { lit: String::from("e") },
-                Core::Id { lit: String::from("z") },
+                Core::Id { lit: String::from("k") },
+                Core::Id { lit: String::from("a") },
             ],
-        })
+        };
+        generics.push(generic);
+
+        let generic = Core::Type {
+            lit: String::from("C"),
+            generics: vec![
+                Core::Id { lit: String::from("l") },
+                Core::Id { lit: String::from("p") },
+            ],
+        };
+        generics.push(generic);
+
+        let core = core_type("something", &generics);
+        assert_eq!(
+            core,
+            Core::Type {
+                lit: String::from("something"),
+                generics: vec![
+                    Core::Id { lit: String::from("b") },
+                    Core::Type {
+                        lit: String::from("C"),
+                        generics: vec![
+                            Core::Id { lit: String::from("l") },
+                            Core::Id { lit: String::from("p") },
+                        ],
+                    },
+                    Core::Type {
+                        lit: String::from("H"),
+                        generics: vec![
+                            Core::Id { lit: String::from("a") },
+                            Core::Id { lit: String::from("k") },
+                        ],
+                    },
+                    Core::Id { lit: String::from("z") },
+                ],
+            }
+        )
+    }
+
+    #[test]
+    fn union_nullable_tuple_callable() {
+        let (a, b) = (StringName::from("a"), StringName::from("b"));
+        let (c, d, e) = (StringName::from("c"), StringName::from("d"), StringName::from("e"));
+
+        let tuple = NameVariant::Tuple(vec![Name::from(&a), Name::from(&b)]);
+        let callable =
+            NameVariant::Fun(vec![Name::from(&c), Name::from(&d)], Box::from(Name::from(&e)));
+        let nullable = TrueName::from(&callable).as_nullable();
+
+        let name = Name::from(&HashSet::from([Name::from(&tuple), Name::from(&nullable)]));
+
+        let mut imports = Imports::new();
+        let core_name = name.to_py(&mut imports);
+
+        macro_rules! assert_import_contains_type {
+            ($ty: expr) => {{
+                let import = vec![Core::Id { lit: String::from($ty) }];
+                let core = Box::from(Core::Id { lit: String::from("typing") });
+                let import = Core::Import { from: Some(core), import, alias: vec![] };
+                assert!(imports.imports.contains(&import));
+            }};
+        }
+
+        assert_import_contains_type!("Union");
+        assert_import_contains_type!("Callable");
+        assert_import_contains_type!("Tuple");
+        assert_import_contains_type!("Optional");
+
+        assert_eq!(
+            core_name,
+            Core::Type {
+                lit: String::from("Union"),
+                generics: vec![
+                    Core::Type {
+                        lit: String::from("Optional"),
+                        generics: vec![Core::Type {
+                            lit: String::from("Callable"),
+                            generics: vec![
+                                Core::Type {
+                                    lit: String::from(""),
+                                    generics: vec![
+                                        Core::Id { lit: String::from("c") },
+                                        Core::Id { lit: String::from("d") },
+                                    ],
+                                },
+                                Core::Id { lit: String::from("e") },
+                            ],
+                        }],
+                    },
+                    Core::Type {
+                        lit: String::from("Tuple"),
+                        generics: vec![
+                            Core::Id { lit: String::from("a") },
+                            Core::Id { lit: String::from("b") },
+                        ],
+                    },
+                ],
+            }
+        )
     }
 }

--- a/tests/resource/valid/access/access_string_check.py
+++ b/tests/resource/valid/access/access_string_check.py
@@ -1,3 +1,3 @@
-x = "my_string"
+x: str = "my_string"
 
 print(x[2])

--- a/tests/resource/valid/class/assign_types_double_nested_check.py
+++ b/tests/resource/valid/class/assign_types_double_nested_check.py
@@ -6,7 +6,7 @@ class X:
     def __init__(self, a: float):
         self.y = Y(a)
 
-x = X(10)
+x: X = X(10)
 
 x.y.a = x.a + 2
 x.y.a = x.a - 3

--- a/tests/resource/valid/class/assign_types_nested_check.py
+++ b/tests/resource/valid/class/assign_types_nested_check.py
@@ -2,7 +2,7 @@ class X:
     def __init__(self, a: float):
         self.a = a
 
-x = X(10)
+x: X = X(10)
 
 x.a = x.a + 2
 x.a = x.a - 3

--- a/tests/resource/valid/class/top_level_tuple_check.py
+++ b/tests/resource/valid/class/top_level_tuple_check.py
@@ -2,6 +2,6 @@ class A:
     a, b = (10, 100)
 
 
-a = A()
+a: A = A()
 print(a.a)
 print(a.b)

--- a/tests/resource/valid/control_flow/for_statements_check.py
+++ b/tests/resource/valid/control_flow/for_statements_check.py
@@ -1,7 +1,7 @@
 b = {1,2}
 for b in b:
     print(b + 5)
-    new = b + 1
+    new: int = b + 1
     new = 30
     print(new)
 
@@ -18,12 +18,12 @@ for i in range(0, 34, 1):
 for i in range(0, 345 + 1, 1):
     print(i)
 
-a = 1
-b = 112
+a: int = 1
+b: int = 112
 for i in range(a, b, 1):
     print("hello")
 
-c = 2451
+c: int = 2451
 for i in range(a, c + 1, 20):
     print("world")
 

--- a/tests/resource/valid/control_flow/if_check.py
+++ b/tests/resource/valid/control_flow/if_check.py
@@ -1,4 +1,4 @@
-b = 40
+b: int = 40
 
 if True:
     print("hello world")
@@ -8,7 +8,7 @@ if False:
 else:
     "world"
 
-cond = True and False
+cond: bool = True and False
 cond = True or False
 
 if cond:
@@ -20,7 +20,7 @@ if cond:
     else:
         "ccc"
 
-    iii = "iii"
+    iii: str = "iii"
     if cond or False:
         "hhh"
     else:

--- a/tests/resource/valid/control_flow/match_stmt_check.py
+++ b/tests/resource/valid/control_flow/match_stmt_check.py
@@ -1,4 +1,4 @@
-a = "d"
+a: str = "d"
 
 b, bb, bbb = (0, 1, 2)
 
@@ -6,7 +6,7 @@ match (b, bb, bbb):
     case (0, 1, 2):
         print("hello world")
 
-nested = "other"
+nested: str = "other"
 
 match nested:
     case "a":

--- a/tests/resource/valid/control_flow/while_check.py
+++ b/tests/resource/valid/control_flow/while_check.py
@@ -1,9 +1,9 @@
-b = False
-e = "Hello world"
+b: bool = False
+e: str = "Hello world"
 while b:
     print(b)
 
-d = True
+d: bool = True
 while d:
     print(d and False)
 

--- a/tests/resource/valid/definition/assign_tuples_check.py
+++ b/tests/resource/valid/definition/assign_tuples_check.py
@@ -1,6 +1,6 @@
 from typing import Tuple
 
-a = (2, 3)
+a: int = (2, 3)
 b: Tuple[int, int] = (3, 5)
 
 c: Tuple[int, int, str] = (3, 4, "Hello")

--- a/tests/resource/valid/definition/long_f_string_check.py
+++ b/tests/resource/valid/definition/long_f_string_check.py
@@ -1,7 +1,7 @@
-name = "My name"
-some_brackets = "\{\}"
-some_more_brackets = "empty expressions are ignored: {}"
-age = 30
+name: str = "My name"
+some_brackets: str = "\{\}"
+some_more_brackets: str = "empty expressions are ignored: {}"
+age: int = 30
 
-a = f"My name is {name} and my age is {age - 10}."
+a: str = f"My name is {name} and my age is {age - 10}."
 print(a)

--- a/tests/resource/valid/error/exception_check.py
+++ b/tests/resource/valid/error/exception_check.py
@@ -1,2 +1,2 @@
-a = Exception()
-b = Exception("b")
+a: Exception = Exception()
+b: Exception = Exception("b")

--- a/tests/resource/valid/error/with_check.py
+++ b/tests/resource/valid/error/with_check.py
@@ -1,7 +1,7 @@
 def do_something(x: int):
     print(f"hello world {x}")
 
-my_resource = 10
+my_resource: int = 10
 
 with my_resource as other:
     do_something(other)

--- a/tests/resource/valid/function/definition_check.py
+++ b/tests/resource/valid/function/definition_check.py
@@ -26,7 +26,7 @@ def fun_v(y: str, ab: Callable[[str], Callable[[str], bool]]) -> Callable[[str],
 
 class MyClass:
     def some_function(self, c: int) -> int:
-        d = 20
+        d: int = 20
         d = 10 + 30
         return c + 20 + d
 

--- a/tests/resource/valid/operation/arithmetic_check.py
+++ b/tests/resource/valid/operation/arithmetic_check.py
@@ -1,17 +1,18 @@
+from typing import Union
 import math
 
-a = 10
-b = 20
+a: Union[float, int] = 10
+b: int = 20
 
-c = a + b
-d = 10 - c
-f = 2.4 * d
-h = f / a
-j = 100 // 10
-l = 100 % 2
-n = math.sqrt(l)
-m = n ** 100
-o = (6 * 10 ** 4)
+c: int = a + b
+d: int = 10 - c
+f: float = 2.4 * d
+h: float = f / a
+j: int = 100 // 10
+l: int = 100 % 2
+n: float = math.sqrt(l)
+m: float = n ** 100
+o: int = (6 * 10 ** 4)
 
 x = +10
 y = -30

--- a/tests/resource/valid/operation/assign_types_nested_check.py
+++ b/tests/resource/valid/operation/assign_types_nested_check.py
@@ -2,7 +2,7 @@ class X:
     def __init__(self, a: float):
         self.a = a
 
-x = X(10)
+x: X = X(10)
 
 x.a += 2
 x.a -= 3

--- a/tests/resource/valid/operation/bitwise_check.py
+++ b/tests/resource/valid/operation/bitwise_check.py
@@ -1,13 +1,13 @@
-a = 10
-b = 20
-c = 30
-d = 40
-e = 50
-f = 60
-g = 70
-h = 80
-i = 90
-j = 100
+a: int = 10
+b: int = 20
+c: int = 30
+d: int = 40
+e: int = 50
+f: int = 60
+g: int = 70
+h: int = 80
+i: int = 90
+j: int = 100
 
 a << b
 c >> d

--- a/tests/resource/valid/operation/boolean_check.py
+++ b/tests/resource/valid/operation/boolean_check.py
@@ -1,19 +1,19 @@
-a = True
+a: bool = True
 b = a
 
-c = False or True and False
-d = c and b and a
-e = not False
+c: bool = False or True and False
+d: bool = c and b and a
+e: bool = not False
 
 a and b
 c or d
 not e
 
-f = True
-g = False
-h = True
-i = True
-j = False
+f: bool = True
+g: bool = False
+h: bool = True
+i: bool = True
+j: bool = False
 
 c is d
 e is not f

--- a/tests/resource/valid/operation/primitives_check.py
+++ b/tests/resource/valid/operation/primitives_check.py
@@ -1,6 +1,6 @@
-a = complex(10.0, 20.0)
-b = int(10)
-c = float(2.3)
+a: complex = complex(10.0, 20.0)
+b: int = int(10)
+c: float = float(2.3)
 
-d = bool(True)
-e = str("hello world")
+d: bool = bool(True)
+e: str = str("hello world")

--- a/tests/system/valid/collection.rs
+++ b/tests/system/valid/collection.rs
@@ -1,4 +1,6 @@
-use crate::system::{OutTestRet, test_directory};
+use mamba::Arguments;
+
+use crate::system::{OutTestRet, test_directory, test_directory_args};
 
 #[test]
 #[ignore] // No list builder construct yet
@@ -20,5 +22,6 @@ fn set_verify() -> OutTestRet {
 
 #[test]
 fn tuple_verify() -> OutTestRet {
-    test_directory(true, &["collection"], &["collection", "target"], "tuple")
+    let args = Arguments { annotate: false }; // Type annotations in output wrong
+    test_directory_args(true, &["collection"], &["collection", "target"], "tuple", &args)
 }

--- a/tests/system/valid/control_flow.rs
+++ b/tests/system/valid/control_flow.rs
@@ -1,7 +1,7 @@
 use crate::system::{OutTestRet, test_directory};
 
 #[test]
-fn for_ast_verify() -> OutTestRet {
+fn for_statements() -> OutTestRet {
     test_directory(true, &["control_flow"], &["control_flow", "target"], "for_statements")
 }
 

--- a/tests/system/valid/error.rs
+++ b/tests/system/valid/error.rs
@@ -1,21 +1,24 @@
-use crate::system::{OutTestRet, test_directory};
+use mamba::Arguments;
+
+use crate::system::{OutTestRet, test_directory, test_directory_args};
 
 #[test]
-fn handle_ast_verify() -> OutTestRet {
-    test_directory(true, &["error"], &["error", "target"], "handle")
+fn handle() -> OutTestRet {
+    let args = Arguments { annotate: false }; // Annotation messes with indentation somehow
+    test_directory_args(true, &["error"], &["error", "target"], "handle", &args)
 }
 
 #[test]
-fn exception_ast_verify() -> OutTestRet {
+fn exception() -> OutTestRet {
     test_directory(true, &["error"], &["error", "target"], "exception")
 }
 
 #[test]
-fn raise_ast_verify() -> OutTestRet {
+fn raise() -> OutTestRet {
     test_directory(true, &["error"], &["error", "target"], "raise")
 }
 
 #[test]
-fn with_ast_verify() -> OutTestRet {
+fn with() -> OutTestRet {
     test_directory(true, &["error"], &["error", "target"], "with")
 }

--- a/tests/system/valid/operation.rs
+++ b/tests/system/valid/operation.rs
@@ -1,7 +1,7 @@
 use crate::system::{OutTestRet, test_directory};
 
 #[test]
-fn arithmetic_ast_verify() -> OutTestRet {
+fn arithmetic() -> OutTestRet {
     test_directory(true, &["operation"], &["operation", "target"], "arithmetic")
 }
 


### PR DESCRIPTION
### Relevant issues



### Summary

Always print out generics in alphabetical order.
This ensures that the output is easy to predict, we are not dependent on the whims of the iterator over the set, possibly preventing flaky tests.

Make annotating output the default in tests as well. 
As we start to implement new features and debug the checking stage we should then automatically see old tests failing  as well.

Should create issues for all unexpected/wrong behavior before merging this PR.
At the very least we can now more clearly see what the checker is doing on the hood, which is great!

### Added Tests

- Check that generics are printed in alphabetical order in source. Prevents flaky tests as well.
- Make annotating output default for all tests, with option to turn this off via the `Arguments` struct.
