### PR TITLE
Improve context from python src

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,7 +294,8 @@ USAGE:
     mamba.exe [FLAGS] [OPTIONS]
 
 FLAGS:
-    -a, --annotate          Enable type annotation of the output source
+    -a, --annotate          Enable type annotation of the output source.
+                            Currently still buggy feature.
     -d, --debug             Add line numbers to log statements
     -h, --help              Prints help information
     -l, --level             Print log level
@@ -313,8 +314,7 @@ OPTIONS:
                              If no input given, current directory used as input directory.
     -o, --output <OUTPUT>    Output directory to store Python files.
                              Output directory structure reflects input directory structure.
-                             If no output given, 'target' directory created in current directory and is used as ouput.
-
+                             If no output given, 'target' directory created in current directory.
 ```
 
 You can type `mamba -help` for a message containing roughly the above information.

--- a/src/check/constrain/generate/definition.rs
+++ b/src/check/constrain/generate/definition.rs
@@ -34,7 +34,7 @@ pub fn gen_def(
                     if let Some(class) = constr.current_class() {
                         let class = ctx.class(&class, &id.pos)?;
                         let fields: Vec<&Field> =
-                            class.fields.iter().filter(|f| !f.ty.is_nullable()).collect();
+                            class.fields.iter().filter(|f| !f.ty.is_nullable() && !f.assigned_to).collect();
                         fields.iter().map(|f| f.name.clone()).collect()
                     } else {
                         let msg = format!("Cannot have {} function outside class", function::INIT);

--- a/src/check/context/arg/python.rs
+++ b/src/check/context/arg/python.rs
@@ -15,7 +15,7 @@ impl From<(&String, &Option<Expression>, &Option<Expression>)> for GenericFuncti
             has_default: default.is_some(),
             pos: Default::default(),
             vararg: false,
-            mutable: false,
+            mutable: true,
             ty: ty.clone().map(|e| Name::from(&e)),
         }
     }

--- a/src/check/context/clss/python.rs
+++ b/src/check/context/clss/python.rs
@@ -277,11 +277,9 @@ mod test {
         let parent2 = iter.next().expect("parent in class");
         assert_eq!(parent2.name, TrueName::from("P2"));
         assert!(parent2.is_py_type);
-        assert!(parent2.args.is_empty());
 
         let parent = iter.next().expect("parent in class");
         assert_eq!(parent.name, TrueName::from("ParentClass"));
         assert!(parent.is_py_type);
-        assert!(parent.args.is_empty());
     }
 }

--- a/src/check/context/clss/python.rs
+++ b/src/check/context/clss/python.rs
@@ -282,4 +282,45 @@ mod test {
         assert_eq!(parent.name, TrueName::from("ParentClass"));
         assert!(parent.is_py_type);
     }
+
+    #[test]
+    fn from_class_with_generic() {
+        let source = "class MyClass(Generic[T], P2):\n    pass\n";
+        let (_, statements) =
+            python_parser::file_input(python_parser::make_strspan(&source)).expect("parse source");
+
+        let first = statements.first().expect("non empty statements");
+        let class_def: Classdef = match &first {
+            Statement::Compound(compound) => match compound.deref() {
+                CompoundStatement::Classdef(classdef) => classdef.clone(),
+                other => panic!("Not class def but {:?}", other),
+            },
+            other => panic!("Not compound statement but {:?}", other),
+        };
+
+        let generic_class = GenericClass::try_from(&class_def).expect("generic class");
+
+        let name = StringName::new("MyClass", &[Name::from("T")]);
+        assert_eq!(generic_class.name, TrueName::from(&name));
+        assert!(generic_class.is_py_type);
+
+        assert_eq!(generic_class.parents.len(), 2);
+        let mut iter = generic_class
+            .parents
+            .iter()
+            .sorted_by_key(|p| match &p.name.variant {
+                NameVariant::Single(string_name) => string_name.name.clone(),
+                other => panic!("Expected Single, was {:?}", other)
+            })
+            .into_iter();
+
+        let parent = iter.next().expect("parent in class");
+        let name = StringName::new("Generic", &[Name::from("T")]);
+        assert_eq!(parent.name, TrueName::from(&name));
+        assert!(parent.is_py_type);
+
+        let parent = iter.next().expect("parent in class");
+        assert_eq!(parent.name, TrueName::from("P2"));
+        assert!(parent.is_py_type);
+    }
 }

--- a/src/check/context/field/generic.rs
+++ b/src/check/context/field/generic.rs
@@ -21,6 +21,7 @@ pub struct GenericField {
     pub mutable: bool,
     pub in_class: Option<StringName>,
     pub ty: Option<Name>,
+    pub assigned_to: bool,
 }
 
 pub struct GenericFields {
@@ -44,7 +45,7 @@ impl TryFrom<&AST> for GenericField {
 
     fn try_from(ast: &AST) -> TypeResult<GenericField> {
         match &ast.node {
-            Node::VariableDef { var, mutable, ty, .. } => Ok(GenericField {
+            Node::VariableDef { var, mutable, ty, expr, .. } => Ok(GenericField {
                 is_py_type: false,
                 name: field_name(var.deref())?,
                 mutable: *mutable,
@@ -54,6 +55,7 @@ impl TryFrom<&AST> for GenericField {
                     Some(ty) => Some(Name::try_from(ty.deref())?),
                     None => None,
                 },
+                assigned_to: expr.is_some(),
             }),
             _ => Err(vec![TypeErr::new(&ast.pos, "Expected variable")]),
         }
@@ -66,7 +68,7 @@ impl TryFrom<&AST> for GenericFields {
     fn try_from(ast: &AST) -> TypeResult<GenericFields> {
         Ok(GenericFields {
             fields: match &ast.node {
-                Node::VariableDef { var, ty, mutable, .. } => {
+                Node::VariableDef { var, ty, mutable, expr, .. } => {
                     let identifier = Identifier::try_from(var.deref())?;
                     match &ty {
                         Some(ty) => {
@@ -80,6 +82,7 @@ impl TryFrom<&AST> for GenericFields {
                                     pos: ast.pos.clone(),
                                     ty: Some(ty.clone()),
                                     in_class: None,
+                                    assigned_to: expr.is_some(),
                                 })
                                 .collect())
                         }
@@ -93,6 +96,7 @@ impl TryFrom<&AST> for GenericFields {
                                 mutable: *mutable || *inner_mut,
                                 in_class: None,
                                 ty: None,
+                                assigned_to: expr.is_some(),
                             })
                             .collect()),
                     }

--- a/src/check/context/field/generic.rs
+++ b/src/check/context/field/generic.rs
@@ -116,6 +116,10 @@ impl GenericField {
             Err(Vec::from(TypeErr::new(pos, &String::from("Field must be in class"))))
         }
     }
+
+    pub fn with_ty(&self, name: &Name) -> Self {
+        GenericField { ty: Some(name.clone()), ..self.clone() }
+    }
 }
 
 fn field_name(ast: &AST) -> TypeResult<String> {

--- a/src/check/context/field/mod.rs
+++ b/src/check/context/field/mod.rs
@@ -22,6 +22,7 @@ pub struct Field {
     pub mutable: bool,
     pub in_class: Option<StringName>,
     pub ty: Name,
+    pub assigned_to: bool,
 }
 
 impl Display for Field {
@@ -49,6 +50,7 @@ impl TryFrom<(&GenericField, &HashMap<Name, Name>, &Position)> for Field {
                 Some(ty) => ty.substitute(generics, pos)?,
                 None => Name::empty()
             },
+            assigned_to: field.assigned_to,
         })
     }
 }

--- a/src/check/context/field/python.rs
+++ b/src/check/context/field/python.rs
@@ -8,18 +8,13 @@ use crate::check::name::Name;
 impl From<(&Vec<Expression>, &Option<Expression>)> for GenericFields {
     fn from((ids, ty): (&Vec<Expression>, &Option<Expression>)) -> GenericFields {
         let fields = GenericFields {
-            fields: ids
-                .iter()
-                .flat_map(|id| GenericFields::from(id).fields)
-                .collect()
+            fields: ids.iter().flat_map(|id| GenericFields::from(id).fields).collect(),
         };
 
-        if fields.fields.len() > 1 {
-            fields // cannot type annotate tuples in python
-        } else if let Some(ty) = ty {
+        if let Some(ty) = ty {
             let name = Name::from(ty);
             if let Some(field) = fields.fields.iter().next() {
-                let field = field.with_ty(&name);
+                let field = field.with_ty(&name); // cannot annotate tuples in python
                 GenericFields { fields: HashSet::from([field]) }
             } else {
                 fields
@@ -31,7 +26,9 @@ impl From<(&Vec<Expression>, &Option<Expression>)> for GenericFields {
 }
 
 impl From<(&Expression, &Option<Expression>)> for GenericFields {
-    fn from((id, _): (&Expression, &Option<Expression>)) -> GenericFields { GenericFields::from(id) }
+    fn from((id, _): (&Expression, &Option<Expression>)) -> GenericFields {
+        GenericFields::from(id)
+    }
 }
 
 impl From<&Expression> for GenericFields {
@@ -52,7 +49,7 @@ impl From<&Expression> for GenericFields {
                     .filter(|item| matches!(item, SetItem::Unique(_)))
                     .filter(|item| match &item {
                         SetItem::Star(_) => false,
-                        SetItem::Unique(expr) => matches!(expr, Expression::Name(_))
+                        SetItem::Unique(expr) => matches!(expr, Expression::Name(_)),
                     })
                     .map(|item| match &item {
                         SetItem::Star(_) => unreachable!(),
@@ -66,12 +63,15 @@ impl From<&Expression> for GenericFields {
                                 ty: None,
                                 assigned_to: false, // unknown
                             },
-                            _ => unreachable!()
-                        }
+                            _ => unreachable!(),
+                        },
                     })
                     .collect(),
-                _ => vec![]
-            }).iter().cloned().collect::<HashSet<_>>()
+                _ => vec![],
+            })
+                .iter()
+                .cloned()
+                .collect::<HashSet<_>>(),
         }
     }
 }

--- a/src/check/context/field/python.rs
+++ b/src/check/context/field/python.rs
@@ -45,6 +45,7 @@ impl From<&Expression> for GenericFields {
                     mutable: true,
                     in_class: None,
                     ty: None,
+                    assigned_to: false, // unknown
                 }],
                 Expression::TupleLiteral(items) => items
                     .iter()
@@ -63,6 +64,7 @@ impl From<&Expression> for GenericFields {
                                 mutable: false,
                                 in_class: None,
                                 ty: None,
+                                assigned_to: false, // unknown
                             },
                             _ => unreachable!()
                         }

--- a/src/check/context/function/python.rs
+++ b/src/check/context/function/python.rs
@@ -109,17 +109,21 @@ mod test {
         assert_eq!(generic_function.arguments[0].name, String::from("a"));
         assert_eq!(generic_function.arguments[0].ty, Some(Name::from("Int")));
         assert!(!generic_function.arguments[0].has_default);
+        assert!(generic_function.arguments[0].mutable);
 
         assert_eq!(generic_function.arguments[1].name, String::from("b"));
         assert_eq!(generic_function.arguments[1].ty, None);
         assert!(!generic_function.arguments[1].has_default);
+        assert!(generic_function.arguments[1].mutable);
 
         assert_eq!(generic_function.arguments[2].name, String::from("c"));
         assert_eq!(generic_function.arguments[2].ty, Some(Name::from("String")));
         assert!(!generic_function.arguments[2].has_default);
+        assert!(generic_function.arguments[2].mutable);
 
         assert_eq!(generic_function.arguments[3].name, String::from("d"));
         assert_eq!(generic_function.arguments[3].ty, Some(Name::from("String")));
         assert!(generic_function.arguments[3].has_default);
+        assert!(generic_function.arguments[3].mutable);
     }
 }

--- a/src/check/context/function/python.rs
+++ b/src/check/context/function/python.rs
@@ -69,7 +69,7 @@ fn convert_name(name: &str) -> String {
 
         TRUTHY => String::from(function::TRUTHY),
 
-        other => String::from(other)
+        other => String::from(other),
     }
 }
 
@@ -83,20 +83,24 @@ mod test {
     use crate::check::name::Name;
     use crate::check::name::stringname::StringName;
 
+    fn fun_def(stmt: &Statement) -> Funcdef {
+        match &stmt {
+            Statement::Compound(compound) => match compound.deref() {
+                CompoundStatement::Funcdef(funcdef) => funcdef.clone(),
+                other => panic!("Not func def but {:?}", other),
+            },
+            other => panic!("Not compound statement but {:?}", other),
+        }
+    }
+
     #[test]
     fn from_py() {
         let source = "def f(a: int, b, c: str, d: str = 'default') -> complex: pass";
-        let (_, statements) = python_parser::file_input(python_parser::make_strspan(&source)).expect("parse source");
+        let (_, statements) =
+            python_parser::file_input(python_parser::make_strspan(&source)).expect("parse source");
 
         let first = statements.first().expect("non empty statements");
-        let funcdef: Funcdef = match &first {
-            Statement::Compound(compound) => match compound.deref() {
-                CompoundStatement::Funcdef(funcdef) => funcdef.clone(),
-                other => panic!("Not func def but {:?}", other)
-            }
-            other => panic!("Not compound statement but {:?}", other)
-        };
-
+        let funcdef: Funcdef = fun_def(&first);
         let generic_function = GenericFunction::from(&funcdef);
 
         assert!(generic_function.is_py_type);

--- a/src/check/context/function/python.rs
+++ b/src/check/context/function/python.rs
@@ -72,3 +72,54 @@ fn convert_name(name: &str) -> String {
         other => String::from(other)
     }
 }
+
+#[cfg(test)]
+mod test {
+    use std::ops::Deref;
+
+    use python_parser::ast::{CompoundStatement, Funcdef, Statement};
+
+    use crate::check::context::function::generic::GenericFunction;
+    use crate::check::name::Name;
+    use crate::check::name::stringname::StringName;
+
+    #[test]
+    fn from_py() {
+        let source = "def f(a: int, b, c: str, d: str = 'default') -> complex: pass";
+        let (_, statements) = python_parser::file_input(python_parser::make_strspan(&source)).expect("parse source");
+
+        let first = statements.first().expect("non empty statements");
+        let funcdef: Funcdef = match &first {
+            Statement::Compound(compound) => match compound.deref() {
+                CompoundStatement::Funcdef(funcdef) => funcdef.clone(),
+                other => panic!("Not func def but {:?}", other)
+            }
+            other => panic!("Not compound statement but {:?}", other)
+        };
+
+        let generic_function = GenericFunction::from(&funcdef);
+
+        assert!(generic_function.is_py_type);
+        assert_eq!(generic_function.name, StringName::from("f"));
+        assert!(!generic_function.pure);
+        assert_eq!(generic_function.raises, Name::empty());
+        assert!(generic_function.in_class.is_none());
+        assert_eq!(generic_function.ret_ty, Some(Name::from("Complex")));
+
+        assert_eq!(generic_function.arguments[0].name, String::from("a"));
+        assert_eq!(generic_function.arguments[0].ty, Some(Name::from("Int")));
+        assert!(!generic_function.arguments[0].has_default);
+
+        assert_eq!(generic_function.arguments[1].name, String::from("b"));
+        assert_eq!(generic_function.arguments[1].ty, None);
+        assert!(!generic_function.arguments[1].has_default);
+
+        assert_eq!(generic_function.arguments[2].name, String::from("c"));
+        assert_eq!(generic_function.arguments[2].ty, Some(Name::from("String")));
+        assert!(!generic_function.arguments[2].has_default);
+
+        assert_eq!(generic_function.arguments[3].name, String::from("d"));
+        assert_eq!(generic_function.arguments[3].ty, Some(Name::from("String")));
+        assert!(generic_function.arguments[3].has_default);
+    }
+}

--- a/src/check/context/mod.rs
+++ b/src/check/context/mod.rs
@@ -415,12 +415,41 @@ mod tests {
 
     #[test]
     pub fn lookup_custom_list_type() -> TypeResult<()> {
-        let generics = &[Name::from("Int")];
+        let generics = &[Name::from("Custom")];
         let list_type = StringName::new("List", generics);
         let ctx = Context::default().into_with_primitives().unwrap();
 
-        let clss = ctx.class(&list_type, &Position::default())?;
+        let pos = Position::default();
+        let clss = ctx.class(&list_type, &pos)?;
         assert_eq!(clss.name, TrueName::from(&list_type));
+
+        let iter_name = clss.fun(&StringName::from("__iter__"), &ctx, &pos)?.ret_ty;
+        for name in iter_name.as_direct("iterator", &pos)? {
+            let iter_class = ctx.class(&name, &pos)?;
+            let next_ty = iter_class.fun(&StringName::from("__next__"), &ctx, &pos)?.ret_ty;
+            assert_eq!(next_ty, Name::from("Custom"))
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    pub fn lookup_custom_set_type() -> TypeResult<()> {
+        let generics = &[Name::from("Custom")];
+        let list_type = StringName::new("Set", generics);
+        let ctx = Context::default().into_with_primitives().unwrap();
+
+        let pos = Position::default();
+        let clss = ctx.class(&list_type, &pos)?;
+        assert_eq!(clss.name, TrueName::from(&list_type));
+
+        let iter_name = clss.fun(&StringName::from("__iter__"), &ctx, &pos)?.ret_ty;
+        for name in iter_name.as_direct("iterator", &pos)? {
+            let iter_class = ctx.class(&name, &pos)?;
+            let next_ty = iter_class.fun(&StringName::from("__next__"), &ctx, &pos)?.ret_ty;
+            assert_eq!(next_ty, Name::from("Custom"))
+        }
+
         Ok(())
     }
 

--- a/src/check/context/parameter/generic.rs
+++ b/src/check/context/parameter/generic.rs
@@ -1,10 +1,7 @@
-use std::convert::TryFrom;
 use std::fmt::{Display, Error, Formatter};
 
 use crate::check::name::stringname::StringName;
 use crate::check::name::truename::TrueName;
-use crate::check::result::{TypeErr, TypeResult};
-use crate::parse::ast::{AST, Node};
 
 #[derive(Debug, Clone, Eq, PartialEq, Hash)]
 pub struct GenericParameter {
@@ -25,20 +22,5 @@ impl Display for GenericParameter {
                 String::new()
             }
         )
-    }
-}
-
-impl TryFrom<&AST> for GenericParameter {
-    type Error = Vec<TypeErr>;
-
-    fn try_from(ast: &AST) -> TypeResult<GenericParameter> {
-        match &ast.node {
-            Node::Generic { id, isa } => {
-                let name = StringName::try_from(id)?;
-                let parent = if let Some(isa) = isa { Some(TrueName::try_from(isa)?) } else { None };
-                Ok(GenericParameter { is_py_type: false, name, parent })
-            }
-            _ => Err(vec![TypeErr::new(&ast.pos.clone(), "Expected generic")])
-        }
     }
 }

--- a/src/check/context/parameter/python.rs
+++ b/src/check/context/parameter/python.rs
@@ -11,7 +11,6 @@ pub struct GenericParameters {
     pub parameters: Vec<GenericParameter>,
 }
 
-// TODO add check that Python file does indeed import generic from typing
 impl From<&Vec<Argument>> for GenericParameters {
     fn from(args: &Vec<Argument>) -> Self {
         let mut parameters = vec![];

--- a/src/check/context/parent/generic.rs
+++ b/src/check/context/parent/generic.rs
@@ -1,7 +1,6 @@
 use std::convert::TryFrom;
 use std::hash::Hash;
 
-use crate::check::name::Name;
 use crate::check::name::truename::TrueName;
 use crate::check::result::{TypeErr, TypeResult};
 use crate::common::position::Position;
@@ -12,7 +11,6 @@ pub struct GenericParent {
     pub is_py_type: bool,
     pub name: TrueName,
     pub pos: Position,
-    pub args: Vec<Name>,
 }
 
 impl TryFrom<&AST> for GenericParent {
@@ -24,7 +22,6 @@ impl TryFrom<&AST> for GenericParent {
                 is_py_type: false,
                 name: TrueName::try_from(ty)?,
                 pos: ast.pos.clone(),
-                args: vec![],
             }),
             _ => {
                 let msg = format!("Expected parent, was {}", ast.node);

--- a/src/check/context/parent/generic.rs
+++ b/src/check/context/parent/generic.rs
@@ -20,8 +20,6 @@ impl TryFrom<&AST> for GenericParent {
 
     fn try_from(ast: &AST) -> TypeResult<GenericParent> {
         match &ast.node {
-            // TODO infer types of arguments passed to parent
-            // TODO use arguments
             Node::Parent { ty, .. } => Ok(GenericParent {
                 is_py_type: false,
                 name: TrueName::try_from(ty)?,

--- a/src/check/context/parent/python.rs
+++ b/src/check/context/parent/python.rs
@@ -25,7 +25,7 @@ impl From<&Argument> for GenericParent {
         };
 
         let name = TrueName::from(&name);
-        GenericParent { is_py_type: true, name, pos: Position::default(), args: vec![] }
+        GenericParent { is_py_type: true, name, pos: Position::default() }
     }
 }
 

--- a/src/check/context/python.rs
+++ b/src/check/context/python.rs
@@ -28,7 +28,7 @@ pub fn python_files(
         let python_src_path = path
             .as_os_str()
             .to_str()
-            .ok_or_else(|| TypeErr::new_no_pos("Unable to build context for primitive"))?;
+            .ok_or_else(|| TypeErr::new_no_pos("Unable to build context for python resource"))?;
 
         let mut python_src = String::new();
         match File::open(python_src_path) {

--- a/src/check/context/python.rs
+++ b/src/check/context/python.rs
@@ -44,11 +44,10 @@ pub fn python_files(
 
         for statement in statements {
             match &statement {
-                Statement::Assignment(left, right) => fields
-                    .append(&mut GenericFields::from((left, right)).fields.into_iter().collect()),
-                // TODO use type hints
-                Statement::TypedAssignment(left, _, right) => fields
-                    .append(&mut GenericFields::from((left, right)).fields.into_iter().collect()),
+                Statement::Assignment(left, _) => fields
+                    .append(&mut GenericFields::from((left, &None)).fields.into_iter().collect()),
+                Statement::TypedAssignment(left, ty, _) => fields
+                    .append(&mut GenericFields::from((left, &Some(ty.clone()))).fields.into_iter().collect()),
                 Statement::Compound(compound_stmt) => match compound_stmt.deref() {
                     CompoundStatement::Funcdef(func_def) =>
                         functions.push(GenericFunction::from(func_def)),

--- a/src/check/name/truename/generic.rs
+++ b/src/check/name/truename/generic.rs
@@ -28,9 +28,9 @@ impl TryFrom<&AST> for TrueName {
             Node::Tuple { elements } => {
                 let elements = elements.iter().map(Name::try_from).collect::<Result<_, _>>()?;
                 Ok(TrueName::from(&NameVariant::Tuple(elements)))
-            },
+            }
             Node::QuestionOp { expr } => Ok(TrueName::try_from(expr)?.as_nullable()),
-            Node::Type { id, .. } => Ok(TrueName::try_from(id)?),
+            Node::Type { .. } => Ok(TrueName::from(&StringName::try_from(ast)?)),
             Node::TypeTup { types } => {
                 let names = types.iter().map(Name::try_from).collect::<Result<_, _>>()?;
                 Ok(TrueName::from(&NameVariant::Tuple(names)))

--- a/src/cli.yml
+++ b/src/cli.yml
@@ -20,7 +20,7 @@ args:
       help: |
         Output directory to store Python files.
         Output directory structure reflects input directory structure.
-        If no output given, 'target' directory created in current directory and is used as ouput.
+        If no output given, 'target' directory created in current directory.
       takes_value: true
   - v:
       short: v
@@ -47,4 +47,6 @@ args:
   - annotate:
       short: a
       long: annotate
-      help: Enable type annotation of the output source
+      help: |
+        Enable type annotation of the output source.
+        Currently still buggy feature.

--- a/src/generate/name.rs
+++ b/src/generate/name.rs
@@ -1,5 +1,9 @@
+use std::collections::BTreeMap;
+
+use itertools::Itertools;
+
 use crate::check::context::clss::concrete_to_python;
-use crate::check::name::Name;
+use crate::check::name::{IsNullable, Name};
 use crate::check::name::namevariant::NameVariant;
 use crate::check::name::stringname::StringName;
 use crate::check::name::truename::TrueName;
@@ -14,8 +18,8 @@ impl ToPy for Name {
     fn to_py(&self, imp: &mut Imports) -> Core {
         if self.names.len() > 1 {
             imp.add_from_import("typing", "Union");
-            let names = self.names.iter().map(|name| name.to_py(imp)).collect();
-            Core::Type { lit: String::from("Union"), generics: names }
+            let generics: Vec<Core> = self.names.iter().map(|name| name.to_py(imp)).collect();
+            core_type("Union", &generics)
         } else if let Some(name) = self.names.iter().next() {
             name.to_py(imp)
         } else {
@@ -26,7 +30,13 @@ impl ToPy for Name {
 
 impl ToPy for TrueName {
     fn to_py(&self, imp: &mut Imports) -> Core {
-        self.variant.to_py(imp)
+        if self.is_nullable() {
+            imp.add_from_import("typing", "Optional");
+            let generics: Vec<Core> = vec![self.variant.to_py(imp)];
+            core_type("Optional", &generics)
+        } else {
+            self.variant.to_py(imp)
+        }
     }
 }
 
@@ -36,18 +46,16 @@ impl ToPy for NameVariant {
             NameVariant::Single(name) => name.to_py(imp),
             NameVariant::Tuple(names) => {
                 imp.add_from_import("typing", "Tuple");
-                let names = names.iter().map(|name| name.to_py(imp)).collect();
-                Core::Type { lit: String::from("Tuple"), generics: names }
+                let generics: Vec<Core> = names.iter().map(|name| name.to_py(imp)).collect();
+                core_type("Tuple", &generics)
             }
             NameVariant::Fun(args, ret) => {
                 imp.add_from_import("typing", "Callable");
                 let args = args.iter().map(|name| name.to_py(imp)).collect();
                 let ret = ret.to_py(imp);
 
-                Core::Type {
-                    lit: String::from("Callable"),
-                    generics: vec![Core::Type { lit: String::new(), generics: args }, ret],
-                }
+                let generics = vec![Core::Type { lit: String::new(), generics: args }, ret];
+                core_type("Callable", &generics)
             }
         }
     }
@@ -56,7 +64,181 @@ impl ToPy for NameVariant {
 impl ToPy for StringName {
     fn to_py(&self, imp: &mut Imports) -> Core {
         let lit = concrete_to_python(&self.name);
-        let generics = self.generics.iter().map(|name| name.to_py(imp)).collect();
-        Core::Type { lit, generics }
+        let generics: Vec<Core> = self.generics.iter().map(|name| name.to_py(imp)).collect();
+        core_type(&lit, &generics)
+    }
+}
+
+/// Produce type with alphabetized generics, ensuring that for any two equal sets of generics the
+/// order in which they are given is always the same.
+///
+/// - Ignores capitalization of generics.
+/// - Types with no literal are at the front.
+fn core_type(lit: &str, generics: &[Core]) -> Core {
+    let names: BTreeMap<String, Core> = generics
+        .iter()
+        .map(|core| match core {
+            Core::Type { lit, generics } => (lit.clone(), core_type(lit, generics)),
+            Core::Id { lit } => (lit.clone(), core.clone()),
+            _ => (String::from(""), core.clone()),
+        })
+        .collect();
+
+    let generics: Vec<Core> = names
+        .into_iter()
+        .sorted_by_key(|(name, _)| name.clone().to_lowercase())
+        .map(|(_, core)| core)
+        .collect();
+
+    if generics.is_empty() {
+        Core::Id { lit: String::from(lit) }
+    } else {
+        Core::Type { lit: String::from(lit), generics }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashSet;
+
+    use crate::check::name::{AsNullable, Name};
+    use crate::check::name::namevariant::NameVariant;
+    use crate::check::name::stringname::StringName;
+    use crate::check::name::truename::TrueName;
+    use crate::generate::ast::node::Core;
+    use crate::generate::convert::state::Imports;
+    use crate::generate::name::{core_type, ToPy};
+
+    #[test]
+    fn alphabetize_ids() {
+        let generics = vec!["z", "b", "e"];
+        let generics: Vec<Core> =
+            generics.iter().map(|id| Core::Id { lit: String::from(*id) }).collect();
+
+        let core = core_type("something", &generics);
+        assert_eq!(
+            core,
+            Core::Type {
+                lit: String::from("something"),
+                generics: vec![
+                    Core::Id { lit: String::from("b") },
+                    Core::Id { lit: String::from("e") },
+                    Core::Id { lit: String::from("z") },
+                ],
+            }
+        )
+    }
+
+    #[test]
+    fn alphabetize_generics() {
+        let generics = vec!["z", "b"];
+        let mut generics: Vec<Core> =
+            generics.iter().map(|id| Core::Id { lit: String::from(*id) }).collect();
+
+        let generic = Core::Type {
+            lit: String::from("H"),
+            generics: vec![
+                Core::Id { lit: String::from("k") },
+                Core::Id { lit: String::from("a") },
+            ],
+        };
+        generics.push(generic);
+
+        let generic = Core::Type {
+            lit: String::from("C"),
+            generics: vec![
+                Core::Id { lit: String::from("l") },
+                Core::Id { lit: String::from("p") },
+            ],
+        };
+        generics.push(generic);
+
+        let core = core_type("something", &generics);
+        assert_eq!(
+            core,
+            Core::Type {
+                lit: String::from("something"),
+                generics: vec![
+                    Core::Id { lit: String::from("b") },
+                    Core::Type {
+                        lit: String::from("C"),
+                        generics: vec![
+                            Core::Id { lit: String::from("l") },
+                            Core::Id { lit: String::from("p") },
+                        ],
+                    },
+                    Core::Type {
+                        lit: String::from("H"),
+                        generics: vec![
+                            Core::Id { lit: String::from("a") },
+                            Core::Id { lit: String::from("k") },
+                        ],
+                    },
+                    Core::Id { lit: String::from("z") },
+                ],
+            }
+        )
+    }
+
+    #[test]
+    fn union_nullable_tuple_callable() {
+        let (a, b) = (StringName::from("a"), StringName::from("b"));
+        let (c, d, e) = (StringName::from("c"), StringName::from("d"), StringName::from("e"));
+
+        let tuple = NameVariant::Tuple(vec![Name::from(&a), Name::from(&b)]);
+        let callable =
+            NameVariant::Fun(vec![Name::from(&c), Name::from(&d)], Box::from(Name::from(&e)));
+        let nullable = TrueName::from(&callable).as_nullable();
+
+        let name = Name::from(&HashSet::from([Name::from(&tuple), Name::from(&nullable)]));
+
+        let mut imports = Imports::new();
+        let core_name = name.to_py(&mut imports);
+
+        macro_rules! assert_import_contains_type {
+            ($ty: expr) => {{
+                let import = vec![Core::Id { lit: String::from($ty) }];
+                let core = Box::from(Core::Id { lit: String::from("typing") });
+                let import = Core::Import { from: Some(core), import, alias: vec![] };
+                assert!(imports.imports.contains(&import));
+            }};
+        }
+
+        assert_import_contains_type!("Union");
+        assert_import_contains_type!("Callable");
+        assert_import_contains_type!("Tuple");
+        assert_import_contains_type!("Optional");
+
+        assert_eq!(
+            core_name,
+            Core::Type {
+                lit: String::from("Union"),
+                generics: vec![
+                    Core::Type {
+                        lit: String::from("Optional"),
+                        generics: vec![Core::Type {
+                            lit: String::from("Callable"),
+                            generics: vec![
+                                Core::Type {
+                                    lit: String::from(""),
+                                    generics: vec![
+                                        Core::Id { lit: String::from("c") },
+                                        Core::Id { lit: String::from("d") },
+                                    ],
+                                },
+                                Core::Id { lit: String::from("e") },
+                            ],
+                        }],
+                    },
+                    Core::Type {
+                        lit: String::from("Tuple"),
+                        generics: vec![
+                            Core::Id { lit: String::from("a") },
+                            Core::Id { lit: String::from("b") },
+                        ],
+                    },
+                ],
+            }
+        )
     }
 }

--- a/src/parse/mod.rs
+++ b/src/parse/mod.rs
@@ -32,7 +32,7 @@ pub fn parse(input: &str) -> ParseResult {
 }
 
 #[cfg(test)]
-fn parse_direct(input: &str) -> ParseResult<Vec<AST>> {
+pub fn parse_direct(input: &str) -> ParseResult<Vec<AST>> {
     match parse(input)?.node {
         Node::File { statements, .. } => Ok(statements),
         _ => Ok(vec![]),

--- a/tests/check/invalid/class.rs
+++ b/tests/check/invalid/class.rs
@@ -65,7 +65,6 @@ fn assign_to_inner_not_allowed() {
 }
 
 #[test]
-#[ignore]
 fn generic_unknown_type() {
     let source = resource_content(false, &["type", "class"], "generic_unknown_type.mamba");
     check_all(&[*parse(&source).unwrap()]).unwrap_err();
@@ -79,7 +78,6 @@ fn incompat_parent_generic() {
 }
 
 #[test]
-#[ignore]
 fn no_generic_arg() {
     let source = resource_content(false, &["type", "class"], "no_generic_arg.mamba");
     check_all(&[*parse(&source).unwrap()]).unwrap_err();
@@ -106,7 +104,6 @@ fn top_level_class_not_assigned_to() {
 }
 
 #[test]
-#[ignore]
 fn wrong_generic_type() {
     let source = resource_content(false, &["type", "class"], "wrong_generic_type.mamba");
     check_all(&[*parse(&source).unwrap()]).unwrap_err();

--- a/tests/resource/invalid/type/class/generic_unknown_type.mamba
+++ b/tests/resource/invalid/type/class/generic_unknown_type.mamba
@@ -1,2 +1,5 @@
-class MyClass[A is UnknownType]
+class MyClass[A: UnknownType]
     def f() -> Int => 10
+
+# should error because suddenly we are using an ill-typed class.
+def my_class := MyClass[10]()

--- a/tests/resource/invalid/type/class/no_generic_arg.mamba
+++ b/tests/resource/invalid/type/class/no_generic_arg.mamba
@@ -1,4 +1,4 @@
 class MyClass[A]
     def my_fun(x: A) -> A => x
 
-def my_class = MyClass()
+def my_class := MyClass()

--- a/tests/resource/invalid/type/class/wrong_generic_type.mamba
+++ b/tests/resource/invalid/type/class/wrong_generic_type.mamba
@@ -1,4 +1,4 @@
 class MyClass[A: String]
     def my_fun(x: A) -> A => x
 
-def my_class = MyClass[Int]()
+def my_class := MyClass[Int]()

--- a/tests/resource/valid/access/access_string_check.py
+++ b/tests/resource/valid/access/access_string_check.py
@@ -1,3 +1,3 @@
-x = "my_string"
+x: str = "my_string"
 
 print(x[2])

--- a/tests/resource/valid/class/assign_types_double_nested_check.py
+++ b/tests/resource/valid/class/assign_types_double_nested_check.py
@@ -6,7 +6,7 @@ class X:
     def __init__(self, a: float):
         self.y = Y(a)
 
-x = X(10)
+x: X = X(10)
 
 x.y.a = x.a + 2
 x.y.a = x.a - 3

--- a/tests/resource/valid/class/assign_types_nested_check.py
+++ b/tests/resource/valid/class/assign_types_nested_check.py
@@ -2,7 +2,7 @@ class X:
     def __init__(self, a: float):
         self.a = a
 
-x = X(10)
+x: X = X(10)
 
 x.a = x.a + 2
 x.a = x.a - 3

--- a/tests/resource/valid/class/generic_unknown_type_unused.mamba
+++ b/tests/resource/valid/class/generic_unknown_type_unused.mamba
@@ -1,0 +1,2 @@
+class MyClass[A: UnknownType]
+    def f() -> Int => 10

--- a/tests/resource/valid/class/generic_unknown_type_unused_check.py
+++ b/tests/resource/valid/class/generic_unknown_type_unused_check.py
@@ -1,0 +1,3 @@
+class MyClass:
+    def f() -> int:
+        10

--- a/tests/resource/valid/class/generics.mamba
+++ b/tests/resource/valid/class/generics.mamba
@@ -1,11 +1,11 @@
-class Err1(msg: String) isa Exception(msg)
-class Err2(msg: String) isa Exception(msg)
+class Err1(msg: String): Exception(msg)
+class Err2(msg: String): Exception(msg)
 
 class MyGeneric: String
 
-class MyType[A isa MyGeneric, C](def super_field: String)
+class MyType[A: MyGeneric, C](def super_field: String)
 
-class MyClass2[C, A isa MyGeneric]: MyType[A, C]("the quick brown fox jumped over the slow donkey")
+class MyClass2[C, A: MyGeneric]: MyType[A, C]("the quick brown fox jumped over the slow donkey")
     def fin z_modified: String := "asdf"
     def other_field: Int := 10
 
@@ -17,32 +17,23 @@ class MyClass2[C, A isa MyGeneric]: MyType[A, C]("the quick brown fox jumped ove
         def (a, b) := (30, 40)
         (a, b) := (0, 10)
 
-        def something := match z
-            10 => z + 10
-            _ => z + 100
-
         def my_bool := True
-        def other := match my_bool
-            True => 2
-            False => 3
 
         def a := self.error_function() handle
             err1: Err1 =>
-                print err1
+                print(err1)
                 -1
             err2: Err2 =>
-                print err2
+                print(err2)
                 -2
 
-        print a
+        print(a)
 
-    def error_function(self) -> Int raise [Err, Err2] => 200
+    def error_function(self) -> Int raise [Err1, Err2] => 200
 
     def connect(self) => self.other_field := 200
 
-    def fun_a(self) => print self
-
-    def private fun_b(self) => print "this function is private!"
+    def _fun_b(self) => print("this function is private!")
 
     def factorial(self, x: Int := 0) -> Int => x * self.factorial(x - 1)
     def factorial_infinite(self, x: Int) -> Int => x * self.factorial(x)
@@ -51,5 +42,5 @@ class MyClass2[C, A isa MyGeneric]: MyType[A, C]("the quick brown fox jumped ove
     def b(self, c: Int) -> Int => self.a()
     def c(self, d: Int) -> Int => self.b(self.c(20))
 
-    def some_higher_order(self, fun: Int -> Int) -> Int? => fun(10)
-    def fancy(self) -> Int => self.some_higher_order(\x: Int => x * 2) ? 10
+    def some_higher_order(self, fun: Int -> Int) -> Int => fun(10)
+    def fancy(self) -> Int => self.some_higher_order(\x: Int => x * 2)

--- a/tests/resource/valid/class/generics_check.py
+++ b/tests/resource/valid/class/generics_check.py
@@ -1,4 +1,3 @@
-from collections import defaultdict
 from typing import Callable
 from typing import Optional
 
@@ -24,43 +23,9 @@ class MyClass2(MyType):
     z_modified: str = "asdf"
     other_field: int = 10
 
-    def __init__(self, other_field: int, z: int):
-        super().__init__("the quick brown fox jumped over the slow donkey")
-        if z > 10:
-            raise Err1("Something is wrong!")
-        self.z_modified = "fdsa"
-
-        (a, b) = (10, 20)
-        (a, b) = (30, 40)
-        (a, b) = (0, 10)
-
-        something = defaultdict(lambda: z + 100, {
-            10: z + 10,
-        })[z]
-
-        my_bool = True
-        other = {
-            True: 2,
-            False: 3,
-        }[my_bool]
-
-        a = None
-        try:
-            a = self.error_function()
-        except Err1 as err1:
-            print(err1)
-            a = -1
-        except Err2 as err2:
-            print(err2)
-            a = -2
-
-        print(a)
-
     def error_function(self) -> int: return 200
 
     def connect(self): self.other_field = 200
-
-    def fun_a(self): print(self)
 
     def _fun_b(self): print("this function is private!")
 
@@ -77,3 +42,27 @@ class MyClass2(MyType):
     def some_higher_order(self, fun: Callable[[int], int]) -> Optional[int]: return fun(10)
 
     def fancy(self) -> int: return self.some_higher_order(lambda x: x * 2) or 10
+
+    def __init__(self, other_field: int, z: int):
+        super().__init__("the quick brown fox jumped over the slow donkey")
+        if z > 10:
+            raise Err1("Something is wrong!")
+        self.z_modified = "fdsa"
+
+        (a, b) = (10, 20)
+        (a, b) = (30, 40)
+        (a, b) = (0, 10)
+
+        my_bool = True
+
+        a = None
+        try:
+            a = self.error_function()
+        except Err1 as err1:
+            print(err1)
+            a = -1
+        except Err2 as err2:
+            print(err2)
+            a = -2
+
+        print(a)

--- a/tests/resource/valid/class/multiple_parent.mamba
+++ b/tests/resource/valid/class/multiple_parent.mamba
@@ -1,0 +1,5 @@
+class MyType(a: String)
+class MyType2(b: String)
+
+class MyClass1: MyType("asdf"), MyType("qwerty")
+    def other: Int

--- a/tests/resource/valid/class/multiple_parent_check.py
+++ b/tests/resource/valid/class/multiple_parent_check.py
@@ -1,0 +1,14 @@
+class MyType:
+    def __init__(self, a: str):
+        self.a = a
+
+class MyType2:
+    def __init__(self, b: str):
+        self.b = b
+
+class MyClass1(MyType, MyType2):
+    other: int = None
+
+    def __init__(self):
+        MyType.__init__(self, "asdf")
+        MyType2.__init__(self, "qwerty")

--- a/tests/resource/valid/class/top_level_tuple_check.py
+++ b/tests/resource/valid/class/top_level_tuple_check.py
@@ -2,6 +2,6 @@ class A:
     a, b = (10, 100)
 
 
-a = A()
+a: A = A()
 print(a.a)
 print(a.b)

--- a/tests/resource/valid/control_flow/for_statements_check.py
+++ b/tests/resource/valid/control_flow/for_statements_check.py
@@ -1,7 +1,7 @@
 b = {1,2}
 for b in b:
     print(b + 5)
-    new = b + 1
+    new: int = b + 1
     new = 30
     print(new)
 
@@ -18,12 +18,12 @@ for i in range(0, 34, 1):
 for i in range(0, 345 + 1, 1):
     print(i)
 
-a = 1
-b = 112
+a: int = 1
+b: int = 112
 for i in range(a, b, 1):
     print("hello")
 
-c = 2451
+c: int = 2451
 for i in range(a, c + 1, 20):
     print("world")
 

--- a/tests/resource/valid/control_flow/if_check.py
+++ b/tests/resource/valid/control_flow/if_check.py
@@ -1,4 +1,4 @@
-b = 40
+b: int = 40
 
 if True:
     print("hello world")
@@ -8,7 +8,7 @@ if False:
 else:
     "world"
 
-cond = True and False
+cond: bool = True and False
 cond = True or False
 
 if cond:
@@ -20,7 +20,7 @@ if cond:
     else:
         "ccc"
 
-    iii = "iii"
+    iii: str = "iii"
     if cond or False:
         "hhh"
     else:

--- a/tests/resource/valid/control_flow/match_stmt_check.py
+++ b/tests/resource/valid/control_flow/match_stmt_check.py
@@ -1,4 +1,4 @@
-a = "d"
+a: str = "d"
 
 b, bb, bbb = (0, 1, 2)
 
@@ -6,7 +6,7 @@ match (b, bb, bbb):
     case (0, 1, 2):
         print("hello world")
 
-nested = "other"
+nested: str = "other"
 
 match nested:
     case "a":

--- a/tests/resource/valid/control_flow/while_check.py
+++ b/tests/resource/valid/control_flow/while_check.py
@@ -1,9 +1,9 @@
-b = False
-e = "Hello world"
+b: bool = False
+e: str = "Hello world"
 while b:
     print(b)
 
-d = True
+d: bool = True
 while d:
     print(d and False)
 

--- a/tests/resource/valid/definition/assign_tuples_check.py
+++ b/tests/resource/valid/definition/assign_tuples_check.py
@@ -1,6 +1,6 @@
 from typing import Tuple
 
-a = (2, 3)
+a: int = (2, 3)
 b: Tuple[int, int] = (3, 5)
 
 c: Tuple[int, int, str] = (3, 4, "Hello")

--- a/tests/resource/valid/definition/long_f_string_check.py
+++ b/tests/resource/valid/definition/long_f_string_check.py
@@ -1,7 +1,7 @@
-name = "My name"
-some_brackets = "\{\}"
-some_more_brackets = "empty expressions are ignored: {}"
-age = 30
+name: str = "My name"
+some_brackets: str = "\{\}"
+some_more_brackets: str = "empty expressions are ignored: {}"
+age: int = 30
 
-a = f"My name is {name} and my age is {age - 10}."
+a: str = f"My name is {name} and my age is {age - 10}."
 print(a)

--- a/tests/resource/valid/error/exception_check.py
+++ b/tests/resource/valid/error/exception_check.py
@@ -1,2 +1,2 @@
-a = Exception()
-b = Exception("b")
+a: Exception = Exception()
+b: Exception = Exception("b")

--- a/tests/resource/valid/error/with_check.py
+++ b/tests/resource/valid/error/with_check.py
@@ -1,7 +1,7 @@
 def do_something(x: int):
     print(f"hello world {x}")
 
-my_resource = 10
+my_resource: int = 10
 
 with my_resource as other:
     do_something(other)

--- a/tests/resource/valid/function/definition_check.py
+++ b/tests/resource/valid/function/definition_check.py
@@ -26,7 +26,7 @@ def fun_v(y: str, ab: Callable[[str], Callable[[str], bool]]) -> Callable[[str],
 
 class MyClass:
     def some_function(self, c: int) -> int:
-        d = 20
+        d: int = 20
         d = 10 + 30
         return c + 20 + d
 

--- a/tests/resource/valid/operation/arithmetic_check.py
+++ b/tests/resource/valid/operation/arithmetic_check.py
@@ -1,17 +1,18 @@
+from typing import Union
 import math
 
-a = 10
-b = 20
+a: Union[float, int] = 10
+b: int = 20
 
-c = a + b
-d = 10 - c
-f = 2.4 * d
-h = f / a
-j = 100 // 10
-l = 100 % 2
-n = math.sqrt(l)
-m = n ** 100
-o = (6 * 10 ** 4)
+c: int = a + b
+d: int = 10 - c
+f: float = 2.4 * d
+h: float = f / a
+j: int = 100 // 10
+l: int = 100 % 2
+n: float = math.sqrt(l)
+m: float = n ** 100
+o: int = (6 * 10 ** 4)
 
 x = +10
 y = -30

--- a/tests/resource/valid/operation/assign_types_nested_check.py
+++ b/tests/resource/valid/operation/assign_types_nested_check.py
@@ -2,7 +2,7 @@ class X:
     def __init__(self, a: float):
         self.a = a
 
-x = X(10)
+x: X = X(10)
 
 x.a += 2
 x.a -= 3

--- a/tests/resource/valid/operation/bitwise_check.py
+++ b/tests/resource/valid/operation/bitwise_check.py
@@ -1,13 +1,13 @@
-a = 10
-b = 20
-c = 30
-d = 40
-e = 50
-f = 60
-g = 70
-h = 80
-i = 90
-j = 100
+a: int = 10
+b: int = 20
+c: int = 30
+d: int = 40
+e: int = 50
+f: int = 60
+g: int = 70
+h: int = 80
+i: int = 90
+j: int = 100
 
 a << b
 c >> d

--- a/tests/resource/valid/operation/boolean_check.py
+++ b/tests/resource/valid/operation/boolean_check.py
@@ -1,19 +1,19 @@
-a = True
+a: bool = True
 b = a
 
-c = False or True and False
-d = c and b and a
-e = not False
+c: bool = False or True and False
+d: bool = c and b and a
+e: bool = not False
 
 a and b
 c or d
 not e
 
-f = True
-g = False
-h = True
-i = True
-j = False
+f: bool = True
+g: bool = False
+h: bool = True
+i: bool = True
+j: bool = False
 
 c is d
 e is not f

--- a/tests/resource/valid/operation/primitives_check.py
+++ b/tests/resource/valid/operation/primitives_check.py
@@ -1,6 +1,6 @@
-a = complex(10.0, 20.0)
-b = int(10)
-c = float(2.3)
+a: complex = complex(10.0, 20.0)
+b: int = int(10)
+c: float = float(2.3)
 
-d = bool(True)
-e = str("hello world")
+d: bool = bool(True)
+e: str = str("hello world")

--- a/tests/system/valid/class.rs
+++ b/tests/system/valid/class.rs
@@ -2,7 +2,7 @@ use crate::system::{OutTestRet, test_directory};
 
 #[test]
 #[ignore]
-fn generics_ast_verify() -> OutTestRet {
+fn generics() -> OutTestRet {
     test_directory(true, &["class"], &["class", "target"], "generics")
 }
 
@@ -23,17 +23,23 @@ fn import_ast_verify() -> OutTestRet {
 }
 
 #[test]
-fn doc_strings_ast_verify() -> OutTestRet {
+fn doc_strings() -> OutTestRet {
     test_directory(true, &["class"], &["class", "target"], "doc_strings")
 }
 
 #[test]
-fn parent_ast_verify() -> OutTestRet {
+#[ignore] // See #314, #315
+fn multiple_parent() -> OutTestRet {
+    test_directory(true, &["class"], &["class", "target"], "multiple_parent")
+}
+
+#[test]
+fn parent() -> OutTestRet {
     test_directory(true, &["class"], &["class", "target"], "parent")
 }
 
 #[test]
-fn types_ast_verify() -> OutTestRet {
+fn types() -> OutTestRet {
     test_directory(true, &["class"], &["class", "target"], "types")
 }
 
@@ -48,7 +54,7 @@ fn top_level_unassigned_but_nullable() -> OutTestRet {
 }
 
 #[test]
-fn tuple_as_class_verify() -> OutTestRet {
+fn tuple_as_class() -> OutTestRet {
     test_directory(true, &["class"], &["class", "target"], "tuple_as_class")
 }
 

--- a/tests/system/valid/class.rs
+++ b/tests/system/valid/class.rs
@@ -23,6 +23,11 @@ fn import_ast_verify() -> OutTestRet {
 }
 
 #[test]
+fn generic_unknown_type_unused() -> OutTestRet {
+    test_directory(true, &["class"], &["class", "target"], "generic_unknown_type_unused")
+}
+
+#[test]
 fn doc_strings() -> OutTestRet {
     test_directory(true, &["class"], &["class", "target"], "doc_strings")
 }

--- a/tests/system/valid/class.rs
+++ b/tests/system/valid/class.rs
@@ -1,7 +1,7 @@
 use crate::system::{OutTestRet, test_directory};
 
 #[test]
-#[ignore]
+#[ignore] // See #320
 fn generics() -> OutTestRet {
     test_directory(true, &["class"], &["class", "target"], "generics")
 }

--- a/tests/system/valid/collection.rs
+++ b/tests/system/valid/collection.rs
@@ -1,4 +1,6 @@
-use crate::system::{OutTestRet, test_directory};
+use mamba::Arguments;
+
+use crate::system::{OutTestRet, test_directory, test_directory_args};
 
 #[test]
 #[ignore] // No list builder construct yet
@@ -20,5 +22,6 @@ fn set_verify() -> OutTestRet {
 
 #[test]
 fn tuple_verify() -> OutTestRet {
-    test_directory(true, &["collection"], &["collection", "target"], "tuple")
+    let args = Arguments { annotate: false }; // Type annotations in output wrong
+    test_directory_args(true, &["collection"], &["collection", "target"], "tuple", &args)
 }

--- a/tests/system/valid/control_flow.rs
+++ b/tests/system/valid/control_flow.rs
@@ -1,7 +1,7 @@
 use crate::system::{OutTestRet, test_directory};
 
 #[test]
-fn for_ast_verify() -> OutTestRet {
+fn for_statements() -> OutTestRet {
     test_directory(true, &["control_flow"], &["control_flow", "target"], "for_statements")
 }
 

--- a/tests/system/valid/error.rs
+++ b/tests/system/valid/error.rs
@@ -1,21 +1,24 @@
-use crate::system::{OutTestRet, test_directory};
+use mamba::Arguments;
+
+use crate::system::{OutTestRet, test_directory, test_directory_args};
 
 #[test]
-fn handle_ast_verify() -> OutTestRet {
-    test_directory(true, &["error"], &["error", "target"], "handle")
+fn handle() -> OutTestRet {
+    let args = Arguments { annotate: false }; // Annotation messes with indentation somehow
+    test_directory_args(true, &["error"], &["error", "target"], "handle", &args)
 }
 
 #[test]
-fn exception_ast_verify() -> OutTestRet {
+fn exception() -> OutTestRet {
     test_directory(true, &["error"], &["error", "target"], "exception")
 }
 
 #[test]
-fn raise_ast_verify() -> OutTestRet {
+fn raise() -> OutTestRet {
     test_directory(true, &["error"], &["error", "target"], "raise")
 }
 
 #[test]
-fn with_ast_verify() -> OutTestRet {
+fn with() -> OutTestRet {
     test_directory(true, &["error"], &["error", "target"], "with")
 }

--- a/tests/system/valid/operation.rs
+++ b/tests/system/valid/operation.rs
@@ -1,7 +1,7 @@
 use crate::system::{OutTestRet, test_directory};
 
 #[test]
-fn arithmetic_ast_verify() -> OutTestRet {
+fn arithmetic() -> OutTestRet {
     test_directory(true, &["operation"], &["operation", "target"], "arithmetic")
 }
 


### PR DESCRIPTION
### Relevant issues

- Closes #307 
- Closes #298 

Flagged some issues when generating Context from Python source:
- Made note of https://github.com/JSAbrahams/mamba/issues/314
- Made note of https://github.com/JSAbrahams/mamba/issues/315
- Made note of https://github.com/JSAbrahams/mamba/issues/316
- Made note of https://github.com/JSAbrahams/mamba/issues/317
- Made note of https://github.com/JSAbrahams/mamba/issues/318
- Made note of https://github.com/JSAbrahams/mamba/issues/319
- Made note of https://github.com/JSAbrahams/mamba/issues/320

### Summary

A lot of the behaviour of the context has assumed to been correct.
However, as we implement more advanced features, verifying the behaviour of the Context will save us some time.
For instance, inferring expected behaviour from Python primitives and standard library from the built-in resources.

It might also help in future if we ever decide to do a major refactor.
For instance, we may need to update our dependencies if it cannot parse properly the newest Python constructs.

- Don't include Python init in GenericClassDef
- When generating class from Python source, set `in_class` of Field to class name
- Class generics are also taken from Mamba classes
- Type definitions and aliases have self as argument
- `self` in a class has the class as type
- Fix #298 by marking a field as assigned to if it is assigned to directly in the definition

### Added Tests

- Converting Python class to `GenericClass`.
- Converting Python function to `GenericFunction`.
