### PR TITLE
Check access to unassigned self fields

### DIFF
--- a/tests/check/invalid/class.rs
+++ b/tests/check/invalid/class.rs
@@ -90,9 +90,14 @@ fn one_tuple_not_assigned_to() {
 }
 
 #[test]
-#[ignore] // need to fix
 fn reassign_to_unassigned_class_var() {
     let source = resource_content(false, &["type", "class"], "reassign_to_unassigned_class_var.mamba");
+    check_all(&[*parse(&source).unwrap()]).unwrap_err();
+}
+
+#[test]
+fn access_unassigned_class_var() {
+    let source = resource_content(false, &["type", "class"], "access_unassigned_class_var.mamba");
     check_all(&[*parse(&source).unwrap()]).unwrap_err();
 }
 

--- a/tests/check/invalid/class.rs
+++ b/tests/check/invalid/class.rs
@@ -84,6 +84,12 @@ fn no_generic_arg() {
 }
 
 #[test]
+fn object_has_no_attribute_self() {
+    let source = resource_content(false, &["type", "class"], "object_has_no_attribute_self.mamba");
+    check_all(&[*parse(&source).unwrap()]).unwrap_err();
+}
+
+#[test]
 fn one_tuple_not_assigned_to() {
     let source = resource_content(false, &["type", "class"], "one_tuple_not_assigned_to.mamba");
     check_all(&[*parse(&source).unwrap()]).unwrap_err();

--- a/tests/resource/invalid/type/class/access_unassigned_class_var.mamba
+++ b/tests/resource/invalid/type/class/access_unassigned_class_var.mamba
@@ -1,0 +1,3 @@
+class X
+    def init(self) =>
+        print(self.z)

--- a/tests/resource/invalid/type/class/access_unassigned_class_var.mamba
+++ b/tests/resource/invalid/type/class/access_unassigned_class_var.mamba
@@ -1,3 +1,5 @@
 class X
+    def z: Int
+
     def init(self) =>
-        print(self.z)
+        self.z

--- a/tests/resource/invalid/type/class/object_has_no_attribute_self.mamba
+++ b/tests/resource/invalid/type/class/object_has_no_attribute_self.mamba
@@ -1,0 +1,4 @@
+class X(def a: Int)
+
+def x := X(10)
+x.self


### PR DESCRIPTION
### Relevant issues

Closes #303

### Summary

- Add check to see if we access unassigned class field in access
- When generating a new reassign, check this first before continuing.

### Added Tests

- Access unassigned class field
- Perform `+=` on unassigned class field.

