### PR TITLE
Check for duplicate parents

### DIFF
--- a/tests/check/invalid/class.rs
+++ b/tests/check/invalid/class.rs
@@ -97,6 +97,12 @@ fn reassign_to_unassigned_class_var() {
 }
 
 #[test]
+fn same_parent_twice() {
+    let source = resource_content(false, &["type", "class"], "same_parent_twice.mamba");
+    check_all(&[*parse(&source).unwrap()]).unwrap_err();
+}
+
+#[test]
 fn top_level_class_not_assigned_to() {
     let source =
         resource_content(false, &["type", "class"], "top_level_class_not_assigned_to.mamba");

--- a/tests/resource/invalid/type/class/same_parent_twice.mamba
+++ b/tests/resource/invalid/type/class/same_parent_twice.mamba
@@ -1,0 +1,4 @@
+class MyType(a: String)
+
+class MyClass1: MyType("asdf"), MyType("qwerty")
+    def other: Int

--- a/tests/resource/valid/class/multiple_parent.mamba
+++ b/tests/resource/valid/class/multiple_parent.mamba
@@ -1,5 +1,5 @@
 class MyType(a: String)
 class MyType2(b: String)
 
-class MyClass1: MyType("asdf"), MyType("qwerty")
+class MyClass1: MyType("asdf"), MyType2("qwerty")
     def other: Int

--- a/tests/system/valid/class.rs
+++ b/tests/system/valid/class.rs
@@ -37,7 +37,6 @@ fn doc_strings() -> OutTestRet {
 }
 
 #[test]
-#[ignore] // See #314, #315
 fn multiple_parent() -> OutTestRet {
     test_directory(true, &["class"], &["class", "target"], "multiple_parent")
 }


### PR DESCRIPTION
### Relevant issues
- Closes #315 , This was just an error in the test.

### Summary

The type checker does now error when we have a class with multiple parents with the same name.
This check is done in the context generation stage.

### Added Tests

- Re-add multiple parents
- *sad* class with multiple parents with the same name

