### PR TITLE
Remove trailing slash from path in errs

### DIFF
--- a/src/check/constrain/constraint/builder.rs
+++ b/src/check/constrain/constraint/builder.rs
@@ -74,7 +74,7 @@ impl ConstrBuilder {
     }
 
     pub fn add_constr(&mut self, constraint: &Constraint) {
-        trace!("Constr: {}", constraint);
+        trace!("Constr: {} == {}, {}: {}", constraint.left.pos, constraint.right.pos, self.level, constraint);
         self.constraints[self.level].1.push(constraint.clone())
     }
 

--- a/src/check/result.rs
+++ b/src/check/result.rs
@@ -1,7 +1,7 @@
 use std::fmt;
 use std::fmt::{Display, Formatter};
 use std::hash::{Hash, Hasher};
-use std::path::PathBuf;
+use std::path::{MAIN_SEPARATOR, PathBuf};
 
 use crate::check::ast::ASTTy;
 use crate::common::position::Position;
@@ -38,7 +38,9 @@ impl PartialEq for TypeErr {
 }
 
 impl From<TypeErr> for Vec<TypeErr> {
-    fn from(type_err: TypeErr) -> Self { vec![type_err] }
+    fn from(type_err: TypeErr) -> Self {
+        vec![type_err]
+    }
 }
 
 impl TypeErr {
@@ -80,7 +82,7 @@ impl WithSource for TypeErr {
                     } else {
                         None
                     },
-                    source.lines().nth(position.start.line as usize)
+                    source.lines().nth(position.start.line as usize),
                 )
             } else {
                 (None, None, None)
@@ -102,7 +104,8 @@ impl WithSource for TypeErr {
 
 impl Display for TypeErr {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-        let path = self.path.clone().map_or(String::from("<unknown>"), |p| p.display().to_string());
+        let path = self.path.as_ref().map_or("<unknown>", |p| p.to_str().unwrap_or_default());
+
         let msg = {
             let mut string = String::from(self.msg.trim());
             if string.ends_with('\n') {
@@ -116,7 +119,7 @@ impl Display for TypeErr {
                 f,
                 "{}\n --> {}:{}:{}\n{}{:4} | {}\n       {}{}{}",
                 msg,
-                path,
+                path.strip_suffix(MAIN_SEPARATOR).unwrap_or(path),
                 position.start.line,
                 position.start.pos,
                 self.source_before.clone().map_or_else(String::new, |src| if src.is_empty() {

--- a/src/generate/result.rs
+++ b/src/generate/result.rs
@@ -1,6 +1,6 @@
 use std::fmt;
 use std::fmt::{Display, Formatter};
-use std::path::PathBuf;
+use std::path::{MAIN_SEPARATOR, PathBuf};
 
 use crate::ASTTy;
 use crate::common::position::Position;
@@ -55,10 +55,11 @@ impl WithSource for UnimplementedErr {
 
 impl Display for UnimplementedErr {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        let path = self.path.as_ref().map_or("<unknown>", |p| p.to_str().unwrap_or_default());
         write!(
             f,
             "--> {}:{}:{}\n     | {}\n{:3}  |- {}\n     | {}{}",
-            self.path.clone().map_or(String::from("<unknown>"), |path| format!("{:#?}", path)),
+            path.strip_suffix(MAIN_SEPARATOR).unwrap_or(path),
             self.position.start.line,
             self.position.start.pos,
             self.msg,

--- a/src/parse/result.rs
+++ b/src/parse/result.rs
@@ -1,7 +1,7 @@
 use std::cmp::min;
 use std::fmt;
 use std::fmt::{Display, Formatter};
-use std::path::PathBuf;
+use std::path::{MAIN_SEPARATOR, PathBuf};
 
 use crate::common::delimit::comma_delm;
 use crate::common::position::Position;
@@ -173,6 +173,7 @@ impl Display for ParseErr {
                 )
             });
 
+        let path = self.path.as_ref().map_or("<unknown>", |path| path.to_str().unwrap_or_default());
         let source_line = match &self.source {
             Some(source) => {
                 source.lines().nth(self.position.start.line as usize - 1).unwrap_or("<unknown>")
@@ -184,7 +185,7 @@ impl Display for ParseErr {
             f,
             "{}\n --> {}:{}:{}\n {:3} |- {}\n     | {}{}\n{}",
             self.msg,
-            self.path.clone().map_or(String::from("<unknown>"), |path| path.display().to_string()),
+            path.strip_suffix(MAIN_SEPARATOR).unwrap_or(path),
             self.position.start.line,
             self.position.start.pos,
             self.position.start.line,


### PR DESCRIPTION
### Summary

- Only print "an" or "a" before type name in top level name.
  In nested, this is no longer done for more readable traces and error messages where relevant.
- Improve constr trace message


