### PR TITLE
Change codecov comment to diff and files

### DIFF
--- a/.github/.codecov.yml
+++ b/.github/.codecov.yml
@@ -2,7 +2,7 @@ codecov:
     branch: main
 
 comment:
-    layout: "reach, diff"
+    layout: "diff, files"
 
 coverage:
     status:


### PR DESCRIPTION
### Summary

Also test PR to see if we can jumpstart codecov again after setting default to main in codecov settings.
These settings were modified via the web app, as it did not retrieve these from the `.codecov.yml`
