### PR TITLE
ABC

### DIFF
--- a/src/generate/ast/mod.rs
+++ b/src/generate/ast/mod.rs
@@ -78,11 +78,18 @@ fn to_py(core: &Core, ind: usize) -> String {
 
         Core::FunDefOp { op, arg, ty, body } => {
             let id = format!("{}", op);
-            to_py(&Core::FunDef { id, arg: arg.clone(), ty: ty.clone(), body: body.clone() }, ind)
+            let dec = vec![];
+            to_py(
+                &Core::FunDef { dec, id, arg: arg.clone(), ty: ty.clone(), body: body.clone() },
+                ind,
+            )
         }
-        Core::FunDef { id, arg, ty, body } => {
+        Core::FunDef { dec, id, arg, ty, body } => {
+            let dec: Vec<Core> = dec.iter().map(|d| Core::Id { lit: format!("@{}", d) }).collect();
             format!(
-                "def {}({}){}: {}\n",
+                "{}{}def {}({}){}: {}\n",
+                if dec.is_empty() { String::from("") } else { newline_delimited(&dec, ind - 1) },
+                if dec.is_empty() { String::from("") } else { indent(ind) },
                 id,
                 comma_delimited(arg, ind),
                 if let Some(ret_ty) = ty {
@@ -321,7 +328,7 @@ fn newline_if_body(core: &Core, ind: usize) -> String {
 fn newline_delimited(items: &[Core], ind: usize) -> String {
     let mut s = String::new();
     items.iter().for_each(|item| writeln!(s, "{}{}", indent(ind), to_py(item, ind)).unwrap());
-    String::from(s.trim_end())
+    s
 }
 
 fn comma_delimited(items: &[Core], ind: usize) -> String {

--- a/src/generate/ast/node.rs
+++ b/src/generate/ast/node.rs
@@ -18,7 +18,7 @@ pub enum Core {
     Assign { left: Box<Core>, right: Box<Core>, op: CoreOp },
     VarDef { var: Box<Core>, ty: Option<Box<Core>>, expr: Option<Box<Core>> },
     FunDefOp { op: CoreFunOp, arg: Vec<Core>, ty: Option<Box<Core>>, body: Box<Core> },
-    FunDef { id: String, arg: Vec<Core>, ty: Option<Box<Core>>, body: Box<Core> },
+    FunDef { dec: Vec<String>, id: String, arg: Vec<Core>, ty: Option<Box<Core>>, body: Box<Core> },
     FunArg { vararg: bool, var: Box<Core>, ty: Option<Box<Core>>, default: Option<Box<Core>> },
     AnonFun { args: Vec<Core>, body: Box<Core> },
     Block { statements: Vec<Core> },

--- a/src/generate/convert/class.rs
+++ b/src/generate/convert/class.rs
@@ -298,7 +298,7 @@ mod tests {
             Ok(Core::Import { from, import, alias }) => {
                 (from.clone(), import.clone(), alias.clone())
             }
-            other => panic!("Expected tuple but got {:?}", other),
+            other => panic!("Expected import but got {:?}", other),
         };
 
         assert_eq!(*from.unwrap(), Core::Break);

--- a/src/generate/convert/class.rs
+++ b/src/generate/convert/class.rs
@@ -145,6 +145,13 @@ fn extract_class(
         })
         .collect::<GenResult<Vec<Core>>>()?;
 
+    let parent_names = if state.interface {
+        imp.add_from_import("abc", "ABC");
+        parent_names.into_iter().chain(vec![Core::Id { lit: String::from("ABC") }]).collect()
+    } else {
+        parent_names
+    };
+
     let body_stmts: Vec<Core> = body_name_stmts
         .values()
         .into_iter()
@@ -250,7 +257,8 @@ fn init(
 
     let id = String::from(function::python::INIT);
     Ok(if !statements.is_empty() {
-        Some(Core::FunDef { id, arg: args, ty: None, body: Box::new(Core::Block { statements }) })
+        let dec = vec![];
+        Some(Core::FunDef { dec, id, arg: args, ty: None, body: Box::new(Core::Block { statements }) })
     } else {
         None
     })

--- a/src/generate/convert/definition.rs
+++ b/src/generate/convert/definition.rs
@@ -63,7 +63,7 @@ pub fn convert_def(ast: &ASTTy, imp: &mut Imports, state: &State) -> GenResult {
                 Some(ret_ty) => Some(Box::from(convert_node(ret_ty, imp, state)?)),
                 None => None,
             };
-            let (dec, body) = if state.interface {
+            let (dec, body) = if state.interface && expression.is_none() {
                 imp.add_from_import("abc", "abstractmethod");
                 (vec![String::from("abstractmethod")], Box::from(Core::Pass))
             } else {

--- a/src/generate/convert/definition.rs
+++ b/src/generate/convert/definition.rs
@@ -63,13 +63,14 @@ pub fn convert_def(ast: &ASTTy, imp: &mut Imports, state: &State) -> GenResult {
                 Some(ret_ty) => Some(Box::from(convert_node(ret_ty, imp, state)?)),
                 None => None,
             };
-            let body = if state.interface {
-                Box::from(Core::Pass)
+            let (dec, body) = if state.interface {
+                imp.add_from_import("abc", "abstractmethod");
+                (vec![String::from("abstractmethod")], Box::from(Core::Pass))
             } else {
-                Box::from(match expression {
+                (vec![], Box::from(match expression {
                     Some(expr) => convert_node(expr, imp, &state.expand_ty(true))?,
                     None => Core::Pass,
-                })
+                }))
             };
 
             let c_id = Box::from(convert_node(id, imp, state)?);
@@ -89,7 +90,7 @@ pub fn convert_def(ast: &ASTTy, imp: &mut Imports, state: &State) -> GenResult {
                         }
                     };
 
-                    Core::FunDef { id, arg, ty, body }
+                    Core::FunDef { dec, id, arg, ty, body }
                 }),
                 _ => Err(UnimplementedErr::new(id, "Non-id function")),
             }

--- a/src/generate/convert/state.rs
+++ b/src/generate/convert/state.rs
@@ -62,8 +62,8 @@ impl State {
 }
 
 pub struct Imports {
-    pub imports: Vec<Core>,
-    pub from_imports: BTreeMap<String, Core>,
+    imports: Vec<Core>,
+    from_imports: BTreeMap<String, Core>,
 }
 
 impl Default for Imports {
@@ -121,5 +121,15 @@ impl Imports {
             alias: vec![],
         };
         self.from_imports.insert(String::from(from), import);
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.imports.is_empty() && self.from_imports.is_empty()
+    }
+
+    pub fn imports(&self) -> Vec<Core> {
+        let mut statements = self.imports.clone();
+        statements.append(&mut self.from_imports.clone().into_values().collect());
+        statements
     }
 }

--- a/src/generate/mod.rs
+++ b/src/generate/mod.rs
@@ -80,11 +80,13 @@ pub fn gen_arguments(ast_ty: &ASTTy, gen_args: &GenArguments) -> GenResult {
     match convert_node(ast_ty, import, &state)? {
         Core::Block { statements: mut old_stmts } => {
             let mut statements = import.imports.clone();
+            statements.append(&mut import.from_imports.clone().into_values().collect());
             statements.append(&mut old_stmts);
             Ok(Core::Block { statements })
         }
         other if !import.imports.is_empty() => {
             let mut statements = import.imports.clone();
+            statements.append(&mut import.from_imports.clone().into_values().collect());
             statements.push(other);
             Ok(Core::Block { statements })
         }

--- a/src/generate/mod.rs
+++ b/src/generate/mod.rs
@@ -78,17 +78,11 @@ pub fn gen_arguments(ast_ty: &ASTTy, gen_args: &GenArguments) -> GenResult {
 
     let import = &mut Imports::new();
     match convert_node(ast_ty, import, &state)? {
-        Core::Block { statements: mut old_stmts } => {
-            let mut statements = import.imports.clone();
-            statements.append(&mut import.from_imports.clone().into_values().collect());
-            statements.append(&mut old_stmts);
-            Ok(Core::Block { statements })
+        Core::Block { statements } => {
+            Ok(Core::Block { statements: import.imports().into_iter().chain(statements).collect() })
         }
-        other if !import.imports.is_empty() => {
-            let mut statements = import.imports.clone();
-            statements.append(&mut import.from_imports.clone().into_values().collect());
-            statements.push(other);
-            Ok(Core::Block { statements })
+        other if !import.is_empty() => {
+            Ok(Core::Block { statements: import.imports().into_iter().chain(vec![other]).collect() })
         }
         other => Ok(other)
     }

--- a/src/generate/name.rs
+++ b/src/generate/name.rs
@@ -199,7 +199,7 @@ mod tests {
         let import = import.iter().map(|ty| Core::Id { lit: String::from(*ty) }).collect();
         let core = Box::from(Core::Id { lit: String::from("typing") });
         let import = Core::Import { from: Some(core), import, alias: vec![] };
-        assert!(imports.from_imports.into_iter().map(|(_, v)| v).collect::<Vec<Core>>().contains(&import));
+        assert!(imports.imports().contains(&import));
 
         assert_eq!(
             core_name,

--- a/src/generate/name.rs
+++ b/src/generate/name.rs
@@ -195,19 +195,11 @@ mod tests {
         let mut imports = Imports::new();
         let core_name = name.to_py(&mut imports);
 
-        macro_rules! assert_import_contains_type {
-            ($ty: expr) => {{
-                let import = vec![Core::Id { lit: String::from($ty) }];
-                let core = Box::from(Core::Id { lit: String::from("typing") });
-                let import = Core::Import { from: Some(core), import, alias: vec![] };
-                assert!(imports.imports.contains(&import));
-            }};
-        }
-
-        assert_import_contains_type!("Union");
-        assert_import_contains_type!("Callable");
-        assert_import_contains_type!("Tuple");
-        assert_import_contains_type!("Optional");
+        let import = vec!["Callable", "Optional", "Tuple", "Union"];
+        let import = import.iter().map(|ty| Core::Id { lit: String::from(*ty) }).collect();
+        let core = Box::from(Core::Id { lit: String::from("typing") });
+        let import = Core::Import { from: Some(core), import, alias: vec![] };
+        assert!(imports.from_imports.into_iter().map(|(_, v)| v).collect::<Vec<Core>>().contains(&import));
 
         assert_eq!(
             core_name,

--- a/tests/resource/valid/class/fun_with_body_in_interface.mamba
+++ b/tests/resource/valid/class/fun_with_body_in_interface.mamba
@@ -1,0 +1,4 @@
+type MyType
+    def abstract_fun(my_arg: Int) -> String
+
+    def concrete_fun(x: Int) -> Int => return x + 10

--- a/tests/resource/valid/class/fun_with_body_in_interface_check.py
+++ b/tests/resource/valid/class/fun_with_body_in_interface_check.py
@@ -1,0 +1,9 @@
+from abc import ABC, abstractmethod
+
+class MyType(ABC):
+    @abstractmethod
+    def abstract_fun(my_arg: int) -> str:
+        pass
+
+    def concrete_fun(x: int) -> int:
+        return x + 10

--- a/tests/resource/valid/class/generics_check.py
+++ b/tests/resource/valid/class/generics_check.py
@@ -1,5 +1,4 @@
-from typing import Callable
-from typing import Optional
+from typing import Callable, Optional
 
 class Err1(Exception):
     def __init__(self, msg: str):

--- a/tests/resource/valid/class/parent_check.py
+++ b/tests/resource/valid/class/parent_check.py
@@ -1,5 +1,9 @@
-class MyType:
+from abc import ABC, abstractmethod
+
+class MyType(ABC):
+    @abstractmethod
     def fun_a(self): pass
+    @abstractmethod
     def factorial(self, x: int) -> int: pass
 
 

--- a/tests/resource/valid/class/types_check.py
+++ b/tests/resource/valid/class/types_check.py
@@ -1,5 +1,5 @@
-from typing import NewType
-from typing import Callable
+from abc import ABC, abstractmethod
+from typing import Callable, NewType
 
 class MyGeneric(str):
     def __init__(self):
@@ -12,15 +12,16 @@ class MyType:
 SomeState = NewType("SomeState", MyClass)
 OtherState = NewType("OtherState", MyClass)
 
-class SuperInterface:
+class SuperInterface(ABC):
     bar: int = None
 
-class MyInterface(SuperInterface):
+class MyInterface(SuperInterface, ABC):
     required_field: int = None
 
     def __init__(self):
         SuperInterface.__init__(self)
 
+    @abstractmethod
     def higher_order(self) -> int:
         pass
 

--- a/tests/resource/valid/definition/function_ret_super_check.py
+++ b/tests/resource/valid/definition/function_ret_super_check.py
@@ -1,5 +1,4 @@
-from typing import Callable
-from typing import Optional
+from typing import Callable, Optional
 
 def some_higher_order(fun: Callable[[int], int]) -> int:
     fun(10)

--- a/tests/resource/valid/definition/function_ret_super_in_class_check.py
+++ b/tests/resource/valid/definition/function_ret_super_in_class_check.py
@@ -1,5 +1,4 @@
-from typing import Callable
-from typing import Optional
+from typing import Callable, Optional
 
 class X:
     def some_higher_order(self, fun: Callable[[int], int]) -> int:

--- a/tests/resource/valid/function/definition_check.py
+++ b/tests/resource/valid/function/definition_check.py
@@ -1,6 +1,4 @@
-from typing import Optional
-from typing import Tuple
-from typing import Callable
+from typing import Callable, Optional, Tuple
 
 def fun_a() -> Optional[int]:
     print(11)

--- a/tests/resource/valid/operation/arithmetic_check.py
+++ b/tests/resource/valid/operation/arithmetic_check.py
@@ -1,5 +1,5 @@
-from typing import Union
 import math
+from typing import Union
 
 a: Union[float, int] = 10
 b: int = 20

--- a/tests/system/valid/class.rs
+++ b/tests/system/valid/class.rs
@@ -41,6 +41,11 @@ fn doc_strings() -> OutTestRet {
 }
 
 #[test]
+fn fun_with_body_in_interface() -> OutTestRet {
+    test_directory(true, &["class"], &["class", "target"], "fun_with_body_in_interface")
+}
+
+#[test]
 fn multiple_parent() -> OutTestRet {
     test_directory(true, &["class"], &["class", "target"], "multiple_parent")
 }


### PR DESCRIPTION
### Relevant issues

- Partially fixes #331

### Summary

- Group from imports together
- Specify @abstractmethod
- Specify ABC class if abstract.
  However, also added to classes which already
  have a parent which is abstract.
  This redundancy can be fixed in the next PR.

However, generate stage does not use a Context to check whether an abstract class already had a parent which is abstract. 
This results in redundant `ABC` parents.
This should be also fixed (in a separate PR) before closing #331.

### Added Tests
- Update some test to check that `ABC` and `@abstractmethod` imported and used.
- Concrete method in abstract class (interface)
