### PR TITLE
Check if function body statement

### DIFF
--- a/src/check/constrain/generate/call.rs
+++ b/src/check/constrain/generate/call.rs
@@ -72,7 +72,7 @@ pub fn gen_call(
                     acc
                 });
 
-                let name = Name::from(clss::STRING);
+                let name = Name::empty();
                 let parent = Expected::new(ast.pos, &Expect::Type { name });
                 constr.add("print", &parent, &Expected::try_from((ast, &env.var_mappings))?);
                 return Ok((constr, env));

--- a/src/check/constrain/generate/call.rs
+++ b/src/check/constrain/generate/call.rs
@@ -67,10 +67,14 @@ pub fn gen_call(
                     .collect::<TypeResult<Vec<Expected>>>()?;
                 let args: Vec<Constraint> =
                     args.iter().map(|exp| Constraint::stringy("print", exp)).collect();
-                let constr = args.iter().fold(constr.clone(), |mut acc, a| {
+                let mut constr = args.iter().fold(constr.clone(), |mut acc, a| {
                     acc.add_constr(a);
                     acc
                 });
+
+                let name = Name::from(clss::STRING);
+                let parent = Expected::new(ast.pos, &Expect::Type { name });
+                constr.add("print", &parent, &Expected::try_from((ast, &env.var_mappings))?);
                 return Ok((constr, env));
             } else if let Some(functions) = env.get_var(&f_name.name) {
                 if !f_name.generics.is_empty() {

--- a/src/check/constrain/generate/statement.rs
+++ b/src/check/constrain/generate/statement.rs
@@ -21,7 +21,12 @@ pub fn gen_stmt(
             let mut constr = constrain_raises(&raise_expected, &env.raises, constr)?;
             generate(error, env, ctx, &mut constr)
         }
-        Node::ReturnEmpty => Ok((constr.clone(), env.clone())),
+        Node::ReturnEmpty => if let Some(exp) = &env.return_type {
+            let msg = format!("Empty return in function which returns {}", exp);
+            Err(vec![TypeErr::new(ast.pos, &msg)])
+        } else {
+            Ok((constr.clone(), env.clone()))
+        },
         Node::Return { expr } =>
             if let Some(expected_ret_ty) = &env.return_type {
                 constr.add("return", expected_ret_ty, &Expected::try_from((expr, &env.var_mappings))?);

--- a/src/check/constrain/generate/statement.rs
+++ b/src/check/constrain/generate/statement.rs
@@ -21,19 +21,27 @@ pub fn gen_stmt(
             let mut constr = constrain_raises(&raise_expected, &env.raises, constr)?;
             generate(error, env, ctx, &mut constr)
         }
-        Node::ReturnEmpty => if let Some(exp) = &env.return_type {
-            let msg = format!("Empty return in function which returns {}", exp);
-            Err(vec![TypeErr::new(ast.pos, &msg)])
-        } else {
-            Ok((constr.clone(), env.clone()))
-        },
-        Node::Return { expr } =>
+        Node::ReturnEmpty => {
+            if let Some(exp) = &env.return_type {
+                let msg = format!("Empty return in function which returns {}", exp);
+                Err(vec![TypeErr::new(ast.pos, &msg)])
+            } else {
+                Ok((constr.clone(), env.clone()))
+            }
+        }
+        Node::Return { expr } => {
             if let Some(expected_ret_ty) = &env.return_type {
-                constr.add("return", expected_ret_ty, &Expected::try_from((expr, &env.var_mappings))?);
-                generate(expr, env, ctx, constr)
+                let (mut constr, env) = generate(expr, env, ctx, constr)?;
+                constr.add(
+                    "return",
+                    expected_ret_ty,
+                    &Expected::try_from((expr, &env.var_mappings))?,
+                );
+                Ok((constr, env))
             } else {
                 Err(vec![TypeErr::new(ast.pos, "Return outside function with return type")])
-            },
-        _ => Err(vec![TypeErr::new(ast.pos, "Expected statement")])
+            }
+        }
+        _ => Err(vec![TypeErr::new(ast.pos, "Expected statement")]),
     }
 }

--- a/src/parse/expression.rs
+++ b/src/parse/expression.rs
@@ -29,7 +29,6 @@ pub fn parse_inner_expression(it: &mut LexIterator) -> ParseResult {
         Token::LRBrack,
         Token::LSBrack,
         Token::LCBrack,
-        Token::Ret,
         Token::Underscore,
         Token::_Self,
         Token::Real(String::new()),
@@ -51,7 +50,6 @@ pub fn parse_inner_expression(it: &mut LexIterator) -> ParseResult {
         &|it, lex| match &lex.token {
             Token::If | Token::Match => parse_cntrl_flow_expr(it),
             Token::LRBrack | Token::LSBrack | Token::LCBrack => parse_collection(it),
-            Token::Ret => parse_return(it),
             Token::Underscore => parse_underscore(it),
 
             Token::Id(_) => parse_id(it),
@@ -139,19 +137,6 @@ fn parse_index(pre: &AST, it: &mut LexIterator) -> ParseResult {
     let node = Node::Index { item, range };
     let end = it.eat(&Token::RSBrack, "index")?;
     Ok(Box::from(AST::new(pre.pos.union(end), node)))
-}
-
-fn parse_return(it: &mut LexIterator) -> ParseResult {
-    let start = it.start_pos("return")?;
-    it.eat(&Token::Ret, "return")?;
-
-    if let Some(end) = it.eat_if(&Token::NL) {
-        let node = Node::ReturnEmpty;
-        return Ok(Box::from(AST::new(start.union(end), node)));
-    }
-
-    let expr = it.parse(&parse_expression, "return", start)?;
-    Ok(Box::from(AST::new(start.union(expr.pos), Node::Return { expr })))
 }
 
 /// Excluding unary addition and subtraction

--- a/src/parse/lex/tokenize.rs
+++ b/src/parse/lex/tokenize.rs
@@ -309,6 +309,30 @@ mod test {
     use crate::parse::lex::tokenize;
 
     #[test]
+    fn function_with_ret() -> Result<(), LexErr> {
+        let source = "def f(x: Int) -> Int =>\n    return";
+        let tokens = tokenize(&source)
+            .map_err(|e| e.into_with_source(&Some(String::from(source)), &None))?;
+
+        assert_eq!(tokens[0].token, Token::Def);
+        assert_eq!(tokens[1].token, Token::Id(String::from("f")));
+        assert_eq!(tokens[2].token, Token::LRBrack);
+        assert_eq!(tokens[3].token, Token::Id(String::from("x")));
+        assert_eq!(tokens[4].token, Token::DoublePoint);
+        assert_eq!(tokens[5].token, Token::Id(String::from("Int")));
+        assert_eq!(tokens[6].token, Token::RRBrack);
+        assert_eq!(tokens[7].token, Token::To);
+        assert_eq!(tokens[8].token, Token::Id(String::from("Int")));
+        assert_eq!(tokens[9].token, Token::BTo);
+        assert_eq!(tokens[10].token, Token::NL);
+        assert_eq!(tokens[11].token, Token::Indent);
+        assert_eq!(tokens[12].token, Token::Ret);
+        assert_eq!(tokens[13].token, Token::Dedent);
+
+        Ok(())
+    }
+
+    #[test]
     fn class_with_body_class_right_after() -> Result<(), LexErr> {
         let source = "class MyClass\n    def var := 10\nclass MyClass1\n";
         let tokens = tokenize(&source)

--- a/tests/check/invalid/function.rs
+++ b/tests/check/invalid/function.rs
@@ -82,6 +82,24 @@ fn wrong_exception() {
 }
 
 #[test]
+fn function_with_stmt_body() {
+    let source = resource_content(false, &["type", "function"], "function_with_stmt_body.mamba");
+    check_all(&[*parse(&source).unwrap()]).unwrap_err();
+}
+
+#[test]
+fn function_with_stmt_body_ret() {
+    let source = resource_content(false, &["type", "function"], "function_with_stmt_body_ret.mamba");
+    check_all(&[*parse(&source).unwrap()]).unwrap_err();
+}
+
+#[test]
+fn return_exp_expr() {
+    let source = resource_content(false, &["type", "function"], "return_exp_expr.mamba");
+    check_all(&[*parse(&source).unwrap()]).unwrap_err();
+}
+
+#[test]
 fn wrong_return_type() {
     let source = resource_content(false, &["type", "function"], "wrong_return_type.mamba");
     check_all(&[*parse(&source).unwrap()]).unwrap_err();

--- a/tests/check/invalid/function.rs
+++ b/tests/check/invalid/function.rs
@@ -1,3 +1,5 @@
+use loggerv::Logger;
+
 use mamba::check::check_all;
 use mamba::parse::parse;
 

--- a/tests/check/invalid/function.rs
+++ b/tests/check/invalid/function.rs
@@ -1,5 +1,3 @@
-use loggerv::Logger;
-
 use mamba::check::check_all;
 use mamba::parse::parse;
 
@@ -84,6 +82,7 @@ fn wrong_exception() {
 }
 
 #[test]
+#[ignore]  // must construct system which identifies exit points in function
 fn function_with_stmt_body() {
     let source = resource_content(false, &["type", "function"], "function_with_stmt_body.mamba");
     check_all(&[*parse(&source).unwrap()]).unwrap_err();

--- a/tests/resource/invalid/type/function/function_with_stmt_body.mamba
+++ b/tests/resource/invalid/type/function/function_with_stmt_body.mamba
@@ -1,0 +1,1 @@
+def f(x: Int) -> Int => print(x)

--- a/tests/resource/invalid/type/function/function_with_stmt_body_ret.mamba
+++ b/tests/resource/invalid/type/function/function_with_stmt_body_ret.mamba
@@ -1,0 +1,1 @@
+def f(x: Int) -> Int => return print(x)

--- a/tests/resource/invalid/type/function/return_exp_expr.mamba
+++ b/tests/resource/invalid/type/function/return_exp_expr.mamba
@@ -1,0 +1,2 @@
+def f(x: Int) -> Int =>
+    return

--- a/tests/resource/invalid/type/function/return_statemet.mamba
+++ b/tests/resource/invalid/type/function/return_statemet.mamba
@@ -1,0 +1,1 @@
+def f(x: Int) => return print(x)


### PR DESCRIPTION
### Relevant issues

- Closes #343 
- Implementing #164 should allow one of the ignored tests to pass.

### Summary

- Fix some return parse rules.
- Check that function has no empty return if return type.
- Add `String` constraint to `print` function calls.

### Added Tests

- *Sad* empty return in function with return type
- *Sad* return statement in function with expression return type
