### PR TITLE
Fix redundant ABC

### DIFF
--- a/src/generate/convert/call.rs
+++ b/src/generate/convert/call.rs
@@ -1,4 +1,4 @@
-use crate::ASTTy;
+use crate::{ASTTy, Context};
 use crate::check::ast::NodeTy;
 use crate::generate::ast::node::Core;
 use crate::generate::convert::common::convert_vec;
@@ -6,15 +6,15 @@ use crate::generate::convert::convert_node;
 use crate::generate::convert::state::{Imports, State};
 use crate::generate::result::{GenResult, UnimplementedErr};
 
-pub fn convert_call(ast: &ASTTy, imp: &mut Imports, state: &State) -> GenResult {
+pub fn convert_call(ast: &ASTTy, imp: &mut Imports, state: &State, ctx: &Context) -> GenResult {
     Ok(match &ast.node {
         NodeTy::PropertyCall { instance, property } => Core::PropertyCall {
-            object: Box::from(convert_node(instance, imp, state)?),
-            property: Box::from(convert_node(property, imp, state)?),
+            object: Box::from(convert_node(instance, imp, state, ctx)?),
+            property: Box::from(convert_node(property, imp, state, ctx)?),
         },
         NodeTy::FunctionCall { name, args } => Core::FunctionCall {
-            function: Box::from(convert_node(name, imp, state)?),
-            args: convert_vec(args, imp, state)?,
+            function: Box::from(convert_node(name, imp, state, ctx)?),
+            args: convert_vec(args, imp, state, ctx)?,
         },
         other => {
             let msg = format!("Expected call flow but was: {:?}.", other);

--- a/src/generate/convert/common.rs
+++ b/src/generate/convert/common.rs
@@ -1,13 +1,13 @@
-use crate::ASTTy;
+use crate::{ASTTy, Context};
 use crate::generate::ast::node::Core;
 use crate::generate::convert::convert_node;
 use crate::generate::convert::state::{Imports, State};
 use crate::generate::result::GenResult;
 
-pub fn convert_vec(node_vec: &[ASTTy], imp: &mut Imports, state: &State) -> GenResult<Vec<Core>> {
+pub fn convert_vec(node_vec: &[ASTTy], imp: &mut Imports, state: &State, ctx: &Context) -> GenResult<Vec<Core>> {
     let mut result = vec![];
     for ast in node_vec {
-        result.push(convert_node(ast, imp, state)?)
+        result.push(convert_node(ast, imp, state, ctx)?)
     }
 
     Ok(result)
@@ -17,14 +17,15 @@ pub fn convert_stmts(
     node_vec: &[ASTTy],
     imp: &mut Imports,
     state: &State,
+    ctx: &Context,
 ) -> GenResult<Vec<Core>> {
     let mut result = vec![];
     for (i, ast) in node_vec.iter().enumerate() {
         if i == node_vec.len() - 1 {
             // only force the last node to be a return or expression if applicable
-            result.push(convert_node(ast, imp, state)?)
+            result.push(convert_node(ast, imp, state, ctx)?)
         } else {
-            result.push(convert_node(ast, imp, &state.assign_to(None))?)
+            result.push(convert_node(ast, imp, &state.assign_to(None), ctx)?)
         }
     }
 

--- a/src/generate/convert/control_flow.rs
+++ b/src/generate/convert/control_flow.rs
@@ -1,33 +1,33 @@
-use crate::ASTTy;
+use crate::{ASTTy, Context};
 use crate::check::ast::NodeTy;
 use crate::generate::ast::node::Core;
 use crate::generate::convert::convert_node;
 use crate::generate::convert::state::{Imports, State};
 use crate::generate::result::{GenResult, UnimplementedErr};
 
-pub fn convert_cntrl_flow(ast: &ASTTy, imp: &mut Imports, state: &State) -> GenResult {
+pub fn convert_cntrl_flow(ast: &ASTTy, imp: &mut Imports, state: &State, ctx: &Context) -> GenResult {
     Ok(match &ast.node {
         NodeTy::IfElse { cond, then, el } => match el {
             Some(el) => Core::IfElse {
-                cond: Box::from(convert_node(cond, imp, state)?),
-                then: Box::from(convert_node(then, imp, state)?),
-                el: Box::from(convert_node(el, imp, state)?),
+                cond: Box::from(convert_node(cond, imp, state, ctx)?),
+                then: Box::from(convert_node(then, imp, state, ctx)?),
+                el: Box::from(convert_node(el, imp, state, ctx)?),
             },
             None => Core::If {
-                cond: Box::from(convert_node(cond, imp, state)?),
-                then: Box::from(convert_node(then, imp, state)?),
+                cond: Box::from(convert_node(cond, imp, state, ctx)?),
+                then: Box::from(convert_node(then, imp, state, ctx)?),
             },
         },
         NodeTy::Match { cond, cases: match_cases } => {
-            let expr = Box::from(convert_node(cond, imp, state)?);
+            let expr = Box::from(convert_node(cond, imp, state, ctx)?);
 
             let mut cases = vec![];
             for case in match_cases {
                 if let NodeTy::Case { cond, body } = &case.node {
                     if let NodeTy::ExpressionType { expr, .. } = &cond.node {
                         cases.push(Core::Case {
-                            expr: Box::from(convert_node(expr.as_ref(), imp, state)?),
-                            body: Box::from(convert_node(body.as_ref(), imp, state)?),
+                            expr: Box::from(convert_node(expr.as_ref(), imp, state, ctx)?),
+                            body: Box::from(convert_node(body.as_ref(), imp, state, ctx)?),
                         })
                     }
                 }
@@ -36,13 +36,13 @@ pub fn convert_cntrl_flow(ast: &ASTTy, imp: &mut Imports, state: &State) -> GenR
             Core::Match { expr, cases }
         }
         NodeTy::While { cond, body } => Core::While {
-            cond: Box::from(convert_node(cond, imp, state)?),
-            body: Box::from(convert_node(body, imp, state)?),
+            cond: Box::from(convert_node(cond, imp, state, ctx)?),
+            body: Box::from(convert_node(body, imp, state, ctx)?),
         },
         NodeTy::For { expr, col, body } => Core::For {
-            expr: Box::from(convert_node(expr, imp, state)?),
-            col: Box::from(convert_node(col, imp, state)?),
-            body: Box::from(convert_node(body, imp, state)?),
+            expr: Box::from(convert_node(expr, imp, state, ctx)?),
+            col: Box::from(convert_node(col, imp, state, ctx)?),
+            body: Box::from(convert_node(body, imp, state, ctx)?),
         },
 
         NodeTy::Break => Core::Break,

--- a/src/generate/convert/handle.rs
+++ b/src/generate/convert/handle.rs
@@ -1,21 +1,21 @@
-use crate::ASTTy;
+use crate::{ASTTy, Context};
 use crate::check::ast::NodeTy;
 use crate::generate::ast::node::Core;
 use crate::generate::convert::convert_node;
 use crate::generate::convert::state::{Imports, State};
 use crate::generate::result::{GenResult, UnimplementedErr};
 
-pub fn convert_handle(ast: &ASTTy, imp: &mut Imports, state: &State) -> GenResult {
+pub fn convert_handle(ast: &ASTTy, imp: &mut Imports, state: &State, ctx: &Context) -> GenResult {
     Ok(match &ast.node {
-        NodeTy::Raises { expr_or_stmt, .. } => convert_node(expr_or_stmt, imp, state)?,
-        NodeTy::Raise { error } => Core::Raise { error: Box::from(convert_node(error, imp, state)?) },
+        NodeTy::Raises { expr_or_stmt, .. } => convert_node(expr_or_stmt, imp, state, ctx)?,
+        NodeTy::Raise { error } => Core::Raise { error: Box::from(convert_node(error, imp, state, ctx)?) },
 
         NodeTy::Handle { expr_or_stmt, cases } => {
             let (var, ty) = if let NodeTy::VariableDef { var, ty, .. } = &expr_or_stmt.node {
                 (
-                    Some(Box::from(convert_node(var, imp, state)?)),
+                    Some(Box::from(convert_node(var, imp, state, ctx)?)),
                     if let Some(ty) = ty {
-                        Some(Box::from(convert_node(ty, imp, state)?))
+                        Some(Box::from(convert_node(ty, imp, state, ctx)?))
                     } else {
                         None
                     },
@@ -27,7 +27,7 @@ pub fn convert_handle(ast: &ASTTy, imp: &mut Imports, state: &State) -> GenResul
 
             Core::TryExcept {
                 setup: var.map(|var| Box::from(Core::VarDef { var, ty, expr: None })),
-                attempt: Box::from(convert_node(&expr_or_stmt.clone(), imp, state)?),
+                attempt: Box::from(convert_node(&expr_or_stmt.clone(), imp, state, ctx)?),
                 except: {
                     let mut except = Vec::new();
                     for case in cases {
@@ -41,13 +41,13 @@ pub fn convert_handle(ast: &ASTTy, imp: &mut Imports, state: &State) -> GenResul
 
                         match &cond.node {
                             NodeTy::ExpressionType { expr, ty, .. } => except.push(Core::Except {
-                                id: Box::from(convert_node(expr, imp, state)?),
+                                id: Box::from(convert_node(expr, imp, state, ctx)?),
                                 class: if let Some(ty) = ty {
-                                    Some(Box::from(convert_node(ty, imp, state)?))
+                                    Some(Box::from(convert_node(ty, imp, state, ctx)?))
                                 } else {
                                     None
                                 },
-                                body: Box::from(convert_node(body, imp, &assign_state)?),
+                                body: Box::from(convert_node(body, imp, &assign_state, ctx)?),
                             }),
                             other => {
                                 let msg = format!("Expected id type but was {:?}", other);

--- a/src/generate/convert/range_slice.rs
+++ b/src/generate/convert/range_slice.rs
@@ -1,4 +1,4 @@
-use crate::ASTTy;
+use crate::{ASTTy, Context};
 use crate::check::ast::NodeTy;
 use crate::check::context::clss;
 use crate::generate::ast::node::Core;
@@ -6,22 +6,22 @@ use crate::generate::convert::convert_node;
 use crate::generate::convert::state::{Imports, State};
 use crate::generate::result::{GenResult, UnimplementedErr};
 
-pub fn convert_range_slice(ast: &ASTTy, imp: &mut Imports, state: &State) -> GenResult {
+pub fn convert_range_slice(ast: &ASTTy, imp: &mut Imports, state: &State, ctx: &Context) -> GenResult {
     match &ast.node {
         NodeTy::Range { from, to, inclusive, step } => Ok(Core::FunctionCall {
             function: Box::from(Core::Id { lit: String::from(clss::python::RANGE) }),
             args: vec![
-                convert_node(from, imp, state)?,
+                convert_node(from, imp, state, ctx)?,
                 if *inclusive {
                     Core::Add {
-                        left: Box::from(convert_node(to, imp, state)?),
+                        left: Box::from(convert_node(to, imp, state, ctx)?),
                         right: Box::from(Core::Int { int: String::from("1") }),
                     }
                 } else {
-                    convert_node(to, imp, state)?
+                    convert_node(to, imp, state, ctx)?
                 },
                 if let Some(step) = step {
-                    convert_node(step, imp, state)?
+                    convert_node(step, imp, state, ctx)?
                 } else {
                     Core::Int { int: String::from("1") }
                 },
@@ -30,17 +30,17 @@ pub fn convert_range_slice(ast: &ASTTy, imp: &mut Imports, state: &State) -> Gen
         NodeTy::Slice { from, to, inclusive, step } => Ok(Core::FunctionCall {
             function: Box::from(Core::Id { lit: String::from(clss::python::SLICE) }),
             args: vec![
-                convert_node(from, imp, state)?,
+                convert_node(from, imp, state, ctx)?,
                 if !inclusive {
                     Core::Sub {
-                        left: Box::from(convert_node(to, imp, state)?),
+                        left: Box::from(convert_node(to, imp, state, ctx)?),
                         right: Box::from(Core::Int { int: String::from("1") }),
                     }
                 } else {
-                    convert_node(to, imp, state)?
+                    convert_node(to, imp, state, ctx)?
                 },
                 if let Some(step) = step {
-                    convert_node(step, imp, state)?
+                    convert_node(step, imp, state, ctx)?
                 } else {
                     Core::Int { int: String::from("1") }
                 },

--- a/src/generate/mod.rs
+++ b/src/generate/mod.rs
@@ -1,9 +1,9 @@
+use crate::{Context, PipelineArguments};
 use crate::check::ast::ASTTy;
 use crate::generate::ast::node::Core;
 use crate::generate::convert::convert_node;
 use crate::generate::convert::state::{Imports, State};
 use crate::generate::result::GenResult;
-use crate::PipelineArguments;
 
 mod convert;
 
@@ -73,11 +73,11 @@ impl From<&PipelineArguments> for GenArguments {
 ///
 /// A malformed [AST](crate::parser::ast::AST) causes this stage
 /// to panic.
-pub fn gen_arguments(ast_ty: &ASTTy, gen_args: &GenArguments) -> GenResult {
+pub fn gen_arguments(ast_ty: &ASTTy, gen_args: &GenArguments, ctx: &Context) -> GenResult {
     let state = State::from(gen_args);
 
     let import = &mut Imports::new();
-    match convert_node(ast_ty, import, &state)? {
+    match convert_node(ast_ty, import, &state, ctx)? {
         Core::Block { statements } => {
             Ok(Core::Block { statements: import.imports().into_iter().chain(statements).collect() })
         }
@@ -89,5 +89,5 @@ pub fn gen_arguments(ast_ty: &ASTTy, gen_args: &GenArguments) -> GenResult {
 }
 
 pub fn gen(ast_ty: &ASTTy) -> GenResult {
-    gen_arguments(ast_ty, &GenArguments::default())
+    gen_arguments(ast_ty, &GenArguments::default(), &Context::default())
 }

--- a/tests/resource/valid/class/types_check.py
+++ b/tests/resource/valid/class/types_check.py
@@ -15,7 +15,7 @@ OtherState = NewType("OtherState", MyClass)
 class SuperInterface(ABC):
     bar: int = None
 
-class MyInterface(SuperInterface, ABC):
+class MyInterface(SuperInterface):
     required_field: int = None
 
     def __init__(self):


### PR DESCRIPTION
### Relevant issues

- Closes #331 

### Summary

If a class has a parent which is already abstract,
then we don't need to mark this class as abstract.
We do this check recursively.

Also added context to generate stage to perform
this check.
More advanced language constructs could benefit
from a context in the generate stage in future.

### Added Tests

- Modified types test
