### PR TITLE
Automatically convert last expression to return

### DIFF
--- a/src/generate/convert/control_flow.rs
+++ b/src/generate/convert/control_flow.rs
@@ -9,7 +9,7 @@ pub fn convert_cntrl_flow(ast: &ASTTy, imp: &mut Imports, state: &State, ctx: &C
     Ok(match &ast.node {
         NodeTy::IfElse { cond, then, el } => match el {
             Some(el) => Core::IfElse {
-                cond: Box::from(convert_node(cond, imp, state, ctx)?),
+                cond: Box::from(convert_node(cond, imp, &state.last_ret(false), ctx)?),
                 then: Box::from(convert_node(then, imp, state, ctx)?),
                 el: Box::from(convert_node(el, imp, state, ctx)?),
             },

--- a/src/generate/convert/definition.rs
+++ b/src/generate/convert/definition.rs
@@ -68,7 +68,7 @@ pub fn convert_def(ast: &ASTTy, imp: &mut Imports, state: &State, ctx: &Context)
                 (vec![String::from("abstractmethod")], Box::from(Core::Pass))
             } else {
                 (vec![], Box::from(match expression {
-                    Some(expr) => convert_node(expr, imp, &state.expand_ty(true), ctx)?,
+                    Some(expr) => convert_node(expr, imp, &state.expand_ty(true).last_ret(ty.is_some()), ctx)?,
                     None => Core::Pass,
                 }))
             };

--- a/src/generate/convert/state.rs
+++ b/src/generate/convert/state.rs
@@ -12,6 +12,7 @@ pub struct State {
     pub expand_ty: bool,
     pub def_as_fun_arg: bool,
     pub tup_lit: bool,
+    pub last_return: bool,
     pub assign_to: Option<Core>,
 
     pub annotate: bool,
@@ -31,6 +32,7 @@ impl State {
             expand_ty: true,
             def_as_fun_arg: false,
             tup_lit: false,
+            last_return: false,
             assign_to: None,
             annotate: false,
         }
@@ -51,6 +53,8 @@ impl State {
     pub fn expand_ty(&self, expand_ty: bool) -> State {
         State { expand_ty, ..self.clone() }
     }
+
+    pub fn last_ret(&self, last_return: bool) -> State { State { last_return, ..self.clone() } }
 
     pub fn def_as_fun_arg(&self, def_as_fun_arg: bool) -> State {
         State { def_as_fun_arg, ..self.clone() }
@@ -90,7 +94,7 @@ impl Imports {
 
     pub fn add_from_import(&mut self, from: &str, import: &str) {
         if let Some(Core::Import { import: imports, alias, .. }) =
-        self.from_imports.get(&String::from(from))
+            self.from_imports.get(&String::from(from))
         {
             let new = Core::Id { lit: String::from(import) };
             let imports: Vec<Core> = if !imports.contains(&new) {

--- a/tests/check/invalid/definition.rs
+++ b/tests/check/invalid/definition.rs
@@ -20,7 +20,6 @@ fn assign_wrong_type() {
 }
 
 #[test]
-#[ignore] // see #343
 fn body_is_stmt() {
     let source = resource_content(false, &["type", "definition"], "body_is_stmt.mamba");
     check_all(&[*parse(&source).unwrap()]).unwrap_err();

--- a/tests/resource/valid/access/index_via_function_check.py
+++ b/tests/resource/valid/access/index_via_function_check.py
@@ -1,12 +1,12 @@
 def f() -> slice:
-    slice(0, 2 - 1, 3)
+    return slice(0, 2 - 1, 3)
 def g() -> slice:
-    slice(0, 2, 3)
+    return slice(0, 2, 3)
 
 def i() -> range:
-    range(0, 2, 3)
+    return range(0, 2, 3)
 def j() -> range:
-    range(0, 2 + 1, 3)
+    return range(0, 2 + 1, 3)
 
 x = [1, 2, 3]
 x[f()]

--- a/tests/resource/valid/class/doc_strings_check.py
+++ b/tests/resource/valid/class/doc_strings_check.py
@@ -13,4 +13,4 @@ class MyClass:
         """
         This is my function, it can't do so much
         """
-        200
+        return 200

--- a/tests/resource/valid/class/generic_unknown_type_unused_check.py
+++ b/tests/resource/valid/class/generic_unknown_type_unused_check.py
@@ -1,3 +1,3 @@
 class MyClass:
     def f() -> int:
-        10
+        return 10

--- a/tests/resource/valid/class/generics_check.py
+++ b/tests/resource/valid/class/generics_check.py
@@ -39,22 +39,22 @@ class MyClass2(MyType):
             print(err2)
             a = -2
 
-    def error_function(self) -> int: 200
+    def error_function(self) -> int: return 200
 
     def connect(self): self.other_field = 200
 
     def _fun_b(self): print("this function is private!")
 
-    def factorial(self, x: int = 0) -> int: x * self.factorial(x - 1)
+    def factorial(self, x: int = 0) -> int: return x * self.factorial(x - 1)
 
-    def factorial_infinite(self, x: int) -> int: x * self.factorial(x)
+    def factorial_infinite(self, x: int) -> int: return x * self.factorial(x)
 
-    def a(self) -> int: self.b(10)
+    def a(self) -> int: return self.b(10)
 
-    def b(self, c: int) -> int: self.a()
+    def b(self, c: int) -> int: return self.a()
 
-    def c(self, d: int) -> int: self.b(self.c(20))
+    def c(self, d: int) -> int: return self.b(self.c(20))
 
-    def some_higher_order(self, fun: Callable[[int], int]) -> Optional[int]: fun(10)
+    def some_higher_order(self, fun: Callable[[int], int]) -> Optional[int]: return fun(10)
 
-    def fancy(self) -> Optional[int]: self.some_higher_order(lambda x: x * 2)
+    def fancy(self) -> Optional[int]: return self.some_higher_order(lambda x: x * 2)

--- a/tests/resource/valid/control_flow/for_over_range_from_func_check.py
+++ b/tests/resource/valid/control_flow/for_over_range_from_func_check.py
@@ -1,5 +1,5 @@
 def f() -> range:
-    range(0,2,1)
+    return range(0,2,1)
 
 for x in f():
     print(x)

--- a/tests/resource/valid/definition/function_ret_super_check.py
+++ b/tests/resource/valid/definition/function_ret_super_check.py
@@ -1,7 +1,7 @@
 from typing import Callable, Optional
 
 def some_higher_order(fun: Callable[[int], int]) -> int:
-    fun(10)
+    return fun(10)
 
 def fancy() -> Optional[int]:
-    some_higher_order(lambda x: x * 2)
+    return some_higher_order(lambda x: x * 2)

--- a/tests/resource/valid/definition/function_ret_super_in_class_check.py
+++ b/tests/resource/valid/definition/function_ret_super_in_class_check.py
@@ -2,10 +2,10 @@ from typing import Callable, Optional
 
 class X:
     def some_higher_order(self, fun: Callable[[int], int]) -> int:
-        fun(10)
+        return fun(10)
 
     def fancy(self) -> Optional[int]:
-        self.some_higher_order(lambda x: x * 2)
+        return self.some_higher_order(lambda x: x * 2)
 
 x: X = X()
 x.fancy()

--- a/tests/resource/valid/function/definition.mamba
+++ b/tests/resource/valid/function/definition.mamba
@@ -38,7 +38,7 @@ class MyClass(def a: Int, def b: Int)
     def sqrt(self) -> MyClass => return MyClass(self.a // self.b, self.a // self.b)
     def mod(self, other: MyClass) -> MyClass => return MyClass(self.a mod self.b, self.b)
 
-def factorial(x: Int) -> Int => return x * factorial(x - 1)
+def factorial(x: Int) -> Int => x * factorial(x - 1)
 
 def some_higher_order(f: (Int) -> Int, x: Int) -> Int => return f(x)
 

--- a/tests/resource/valid/function/function_with_defaults_check.py
+++ b/tests/resource/valid/function/function_with_defaults_check.py
@@ -1,4 +1,5 @@
-def my_fun(a: int, b: int = 10, c: str = "Hello") -> str: c + b + a
+def my_fun(a: int, b: int = 10, c: str = "Hello") -> str:
+    return c + b + a
 
 my_fun(1, 2, "hello world")
 my_fun(1, 2)

--- a/tests/resource/valid/function/return_last_expression.mamba
+++ b/tests/resource/valid/function/return_last_expression.mamba
@@ -1,0 +1,5 @@
+def my_fun() -> String =>
+    print("a statement")
+    "a"
+
+print(my_fun())

--- a/tests/resource/valid/function/return_last_expression_check.py
+++ b/tests/resource/valid/function/return_last_expression_check.py
@@ -1,0 +1,5 @@
+def my_fun() -> str:
+    print("a statement")
+    return "a"
+
+print(my_fun())

--- a/tests/system/valid/function.rs
+++ b/tests/system/valid/function.rs
@@ -14,3 +14,8 @@ fn definition_ast_verify() -> OutTestRet {
 fn function_with_defaults_ast_verify() -> OutTestRet {
     test_directory(true, &["function"], &["function", "target"], "function_with_defaults")
 }
+
+#[test]
+fn return_last_expression() -> OutTestRet {
+    test_directory(true, &["function"], &["function", "target"], "return_last_expression")
+}


### PR DESCRIPTION
### Relevant issues

Resolves #164 

### Summary

Function with return last item in function body.
We do this by making use of the state in the generate stage.
When a function has a return in the signature, a flag is set in the state.
This flag is then used in the generate of the body, but it is not propagated further to prevent returns being inserted deep within the AST where they shouldn't be.
If set to true, then we in most situations wrap the final item of the function body in a core return node.
Exceptions are explained below.

If function body does not end with an expression, then the check stage already gives an error (we tested this before, right? Maybe check).
We have some exceptions:
- If last item is a return, which the check stage does allow (meaning we must deal with in the generate stage), we do not generate an additional return.
- If the last item is an if-else, then we do not insert a return here (which would result in incorrect syntax), and instead propagate forward the state to the branches if the if-else. We take care not to propagate into the condition of the if-else.
- In all other cases, an expression is wrapped by a return core node

Also exposed a weird error in check stage. 
In `function/definition.mamba`, line 7:
Change
`    if True then return 10 else return None`
To
`    if True then 10 else None`
Gives type error:
`Unifying two types: Expected an Int, was a None`
Not something to fix in this PR, it is erroneous behaviour as the mamba script is well-typed according to current spec.

### Added Tests

- Check that function with statement and expression return last statement
- Modified current tests to conform to new behaviour