### PR TITLE
Fix Windows build

### DIFF
--- a/tests/system/common.rs
+++ b/tests/system/common.rs
@@ -3,4 +3,4 @@ pub static PYTHON: &str = "python3.10";
 #[cfg(target_os = "macos")]
 pub static PYTHON: &str = "python3";
 #[cfg(target_os = "windows")]
-pub static PYTHON: &str = "py";
+pub static PYTHON: &str = "python";

--- a/tests/system/mod.rs
+++ b/tests/system/mod.rs
@@ -129,7 +129,7 @@ fn fallable(
         {}\n\
         ----------",
             String::from_utf8(cmd1.stderr).unwrap(),
-            resource_content_path(&resource_path(valid, input, &format!("{}_check.py", file_name))),
+            resource_path(valid, input, &format!("{}_check.py", file_name)),
             check_src
                 .lines()
                 .enumerate()

--- a/tests/system/mod.rs
+++ b/tests/system/mod.rs
@@ -128,7 +128,7 @@ fn fallable(
         ----------\n\
         {}\n\
         ----------",
-            String::from_utf8(cmd1.stderr).unwrap(),
+            String::from_utf8(cmd1.stderr).unwrap().trim(),
             resource_path(valid, input, &format!("{}_check.py", file_name)),
             check_src
                 .lines()
@@ -140,12 +140,12 @@ fn fallable(
         Err(OutTestErr(vec![msg]))
     } else if cmd2.status.code().unwrap() != 0 {
         let msg = format!(
-            "Running Python command on Mamba output: {}\n\
+            "{}Running Python command on Mamba output.\n\
         Source:\n\
         ----------\n\
         {}\n\
         ----------",
-            String::from_utf8(cmd2.stderr).unwrap(),
+            String::from_utf8(cmd2.stderr).unwrap().trim(),
             out_src
                 .lines()
                 .enumerate()

--- a/tests/system/mod.rs
+++ b/tests/system/mod.rs
@@ -123,12 +123,13 @@ fn fallable(
     let width = 3;
     if cmd1.status.code().unwrap() != 0 {
         let msg = format!(
-            "Running Python command on reference resource: {}\n\
+            "{}\nRunning Python command on reference resource: {}\n\
         Source:\n\
         ----------\n\
         {}\n\
         ----------",
             String::from_utf8(cmd1.stderr).unwrap(),
+            resource_content_path(&resource_path(valid, input, &format!("{}_check.py", file_name))),
             check_src
                 .lines()
                 .enumerate()


### PR DESCRIPTION
### Summary

The fix apparently was changing the python command from `py` to `python` in the windows config.
I'm guessing `py` has been dropped in the latest version of windows, though I haven't checked.
