### PR TITLE
Also propagate return to match arms

### DIFF
--- a/src/generate/convert/control_flow.rs
+++ b/src/generate/convert/control_flow.rs
@@ -19,14 +19,14 @@ pub fn convert_cntrl_flow(ast: &ASTTy, imp: &mut Imports, state: &State, ctx: &C
             },
         },
         NodeTy::Match { cond, cases: match_cases } => {
-            let expr = Box::from(convert_node(cond, imp, state, ctx)?);
+            let expr = Box::from(convert_node(cond, imp, &state.last_ret(false), ctx)?);
 
             let mut cases = vec![];
             for case in match_cases {
                 if let NodeTy::Case { cond, body } = &case.node {
                     if let NodeTy::ExpressionType { expr, .. } = &cond.node {
                         cases.push(Core::Case {
-                            expr: Box::from(convert_node(expr.as_ref(), imp, state, ctx)?),
+                            expr: Box::from(convert_node(expr.as_ref(), imp, &state.last_ret(false), ctx)?),
                             body: Box::from(convert_node(body.as_ref(), imp, state, ctx)?),
                         })
                     }

--- a/src/generate/convert/mod.rs
+++ b/src/generate/convert/mod.rs
@@ -96,11 +96,8 @@ pub fn convert_node(ast: &ASTTy, imp: &mut Imports, state: &State, ctx: &Context
         }
 
         NodeTy::IfElse { .. } => convert_cntrl_flow(ast, imp, &state.last_ret(last_ret), ctx)?,
-        NodeTy::While { .. }
-        | NodeTy::For { .. }
-        | NodeTy::Break
-        | NodeTy::Continue => convert_cntrl_flow(ast, imp, state, ctx)?,
-        NodeTy::Match { .. } => convert_cntrl_flow(ast, imp, &state.expand_ty(false), ctx)?,
+        NodeTy::Match { .. } => convert_cntrl_flow(ast, imp, &state.expand_ty(false).last_ret(last_ret), ctx)?,
+        NodeTy::While { .. } | NodeTy::For { .. } | NodeTy::Break | NodeTy::Continue => convert_cntrl_flow(ast, imp, state, ctx)?,
 
         NodeTy::Not { expr } => Core::Not { expr: Box::from(convert_node(expr, imp, state, ctx)?) },
         NodeTy::And { left, right } => Core::And {
@@ -311,6 +308,7 @@ fn skip_return(core: &Core) -> bool {
     matches!(core,
         Core::Return { .. } |
         Core::IfElse { .. } |
+        Core::Match { .. } |
         Core::Raise { .. } |
         Core::TryExcept {..}
     )

--- a/tests/resource/valid/function/match_function.mamba
+++ b/tests/resource/valid/function/match_function.mamba
@@ -1,0 +1,5 @@
+def f(x: Int) -> String =>
+    match x
+        1 => "One"
+        2 => "Two"
+        _ => "Three"

--- a/tests/resource/valid/function/match_function_check.py
+++ b/tests/resource/valid/function/match_function_check.py
@@ -1,0 +1,8 @@
+def f(x: int) -> str:
+    match x:
+        case 1:
+            return "One"
+        case 2:
+            return "Two"
+        case _:
+            return "Three"

--- a/tests/system/valid/function.rs
+++ b/tests/system/valid/function.rs
@@ -16,6 +16,11 @@ fn function_with_defaults_ast_verify() -> OutTestRet {
 }
 
 #[test]
+fn match_function() -> OutTestRet {
+    test_directory(true, &["function"], &["function", "target"], "match_function")
+}
+
+#[test]
 fn return_last_expression() -> OutTestRet {
     test_directory(true, &["function"], &["function", "target"], "return_last_expression")
 }


### PR DESCRIPTION
### Relevant issues

Resolves #164 

### Summary

Similar to #360 , but now in addition to if-else, we also propagate returns to match arms.

### Added Tests

- *Happy* Test that `return` is propagated to match arms
