### PR TITLE
Ternary expressions

### DIFF
--- a/src/check/constrain/constraint/expected.rs
+++ b/src/check/constrain/constraint/expected.rs
@@ -9,7 +9,7 @@ use itertools::{EitherOrBoth, Itertools};
 
 use crate::check::constrain::constraint::expected::Expect::*;
 use crate::check::context::clss::{BOOL, FLOAT, INT, NONE, STRING};
-use crate::check::name::{Name, Nullable};
+use crate::check::name::{Any, Name, Nullable};
 use crate::check::name::string_name::StringName;
 use crate::check::result::{TypeErr, TypeResult};
 use crate::common::delimit::comma_delm;
@@ -76,6 +76,10 @@ pub enum Expect {
     Type { name: Name },
 }
 
+impl Any for Expect {
+    fn any() -> Self { Type { name: Name::any() } }
+}
+
 impl TryFrom<(&AST, &HashMap<String, String>)> for Expect {
     type Error = Vec<TypeErr>;
 
@@ -126,14 +130,14 @@ impl Display for Expect {
                 let elements: Vec<Expected> = elements.iter().map(|a| a.and_or_a(false)).collect();
                 write!(f, "({})", comma_delm(elements))
             }
-            Raises { name: ty } => write!(f, "Raises {}", ty),
+            Raises { name: ty } => write!(f, "Raises {ty}"),
             Access { entity, name } => write!(f, "{}.{}", entity.and_or_a(false), name.and_or_a(false)),
             Function { name, args } => {
                 let args: Vec<Expected> = args.iter().map(|a| a.and_or_a(false)).collect();
                 write!(f, "{}({})", name, comma_delm(args))
             }
-            Field { name } => write!(f, "{}", name),
-            Type { name } => write!(f, "{}", name),
+            Field { name } => write!(f, "{name}"),
+            Type { name } => write!(f, "{name}"),
         }
     }
 }

--- a/src/check/constrain/constraint/iterator.rs
+++ b/src/check/constrain/constraint/iterator.rs
@@ -2,7 +2,7 @@ use std::collections::{HashMap, VecDeque};
 
 use crate::check::constrain::constraint::Constraint;
 use crate::check::constrain::constraint::expected::Expected;
-use crate::check::name::{Name, Union};
+use crate::check::name::{Any, Name, Union};
 use crate::check::name::string_name::StringName;
 use crate::check::result::{TypeErr, TypeResult};
 use crate::common::position::Position;
@@ -30,9 +30,14 @@ impl Constraints {
     ///
     /// If already present at position, then union is created between current [Name] and given
     /// [Name].
-    /// Returns [Name] which was already at that position, which might be [None]
+    /// Ignores [Any] type, and trims from union.
     pub fn push_ty(&mut self, pos: Position, name: &Name) {
-        let name = self.finished.get(&pos).map_or(name.clone(), |s_name| s_name.union(name));
+        if *name == Name::any() {
+            return;
+        }
+        let name = name.trim_any();
+
+        let name = self.finished.get(&pos).map_or(name.clone(), |s_name| s_name.union(&name));
         if self.finished.insert(pos, name.clone()).is_none() {
             trace!("{:width$}type at {}: {}", "", pos, name, width = 0);
         }

--- a/src/check/constrain/constraint/mod.rs
+++ b/src/check/constrain/constraint/mod.rs
@@ -89,4 +89,10 @@ impl Constraint {
 
         Constraint::new(msg, &bool, &Expected::new(expected.pos, &access))
     }
+
+    pub fn undefined(msg: &str, expected: &Expected) -> Constraint {
+        let none =
+            Expected::new(expected.pos, &Type { name: Name::from(clss::NONE) });
+        Constraint::new(msg, expected, &none)
+    }
 }

--- a/src/check/constrain/constraint/mod.rs
+++ b/src/check/constrain/constraint/mod.rs
@@ -10,7 +10,7 @@ pub mod builder;
 pub mod expected;
 pub mod iterator;
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct Constraint {
     pub is_flag: bool,
     pub is_sub: bool,
@@ -20,7 +20,7 @@ pub struct Constraint {
     pub superset: ConstrVariant,
 }
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub enum ConstrVariant {
     Left,
     Right,

--- a/src/check/constrain/generate/collection.rs
+++ b/src/check/constrain/generate/collection.rs
@@ -51,7 +51,7 @@ pub fn constr_col(
                 }
                 Box::from(Expected::new(first.pos, &Expect::try_from((first, &env.var_mappings))?))
             } else {
-                Box::from(Expected::new(collection.pos, &Type { name: Name::any() }))
+                Box::from(Expected::new(collection.pos, &Expect::any()))
             };
 
             ("collection", Collection { ty })
@@ -63,7 +63,7 @@ pub fn constr_col(
         }
 
         _ => {
-            let expect = if let Some(name) = temp_type { Type { name } } else { Type { name: Name::any() } };
+            let expect = if let Some(name) = temp_type { Type { name } } else { Expect::any() };
             let expected = Collection { ty: Box::from(Expected::new(collection.pos, &expect)) };
             ("collection", expected)
         }
@@ -88,14 +88,43 @@ pub fn gen_collection_lookup(
     // Make col constraint before inserting environment, in case shadowed here
     let col_exp = Expected::try_from((col, &env.var_mappings))?;
     for (mutable, var) in Identifier::try_from(lookup)?.fields(lookup.pos)? {
-        env = env.insert_var(mutable, &var, &Expected::new(lookup.pos, &Type { name: Name::any() }));
+        env = env.insert_var(mutable, &var, &Expected::new(lookup.pos, &Expect::any()));
     }
 
-    let lookup_exp = Expected::new(
-        lookup.pos,
+    let col_ty_exp = Expected::new(
+        col.pos,
         &Collection { ty: Box::from(Expected::try_from((lookup, &env.var_mappings))?) },
     );
 
-    constr.add("collection lookup", &lookup_exp, &col_exp);
+    constr.add("collection lookup", &col_ty_exp, &col_exp);
     Ok((constr.clone(), env))
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::check::ast::NodeTy;
+    use crate::check::check_all;
+    use crate::check::name::Name;
+    use crate::parse::parse;
+
+    #[test]
+    fn for_col_variable_ty() {
+        let src = "def a := 0 ..= 2\nfor i in a do\n    print(\"hello\")";
+        let ast = parse(src).unwrap();
+        let result = check_all(&[*ast]).unwrap();
+
+        let statements = if let NodeTy::Block { statements } = &result[0].node {
+            statements.clone()
+        } else {
+            panic!()
+        };
+
+        let (col, expr) = match &statements[1].node {
+            NodeTy::For { col, expr, .. } => (col.clone(), expr.clone()),
+            other => panic!("Expected for: {:?}", other)
+        };
+
+        assert_eq!(expr.ty, Some(Name::from("Int")));
+        assert_eq!(col.ty, Some(Name::from("Range")));
+    }
 }

--- a/src/check/constrain/generate/control_flow.rs
+++ b/src/check/constrain/generate/control_flow.rs
@@ -40,12 +40,12 @@ pub fn gen_flow(
 
             if env.exp_expression {
                 let if_expr = Expected::try_from((ast, &env.var_mappings))?;
-                let left = Expected::try_from((then, &env.var_mappings))?;
-                let right = Expected::try_from((el, &env.var_mappings))?;
+                let then = Expected::try_from((then, &env.var_mappings))?;
+                let el = Expected::try_from((el, &env.var_mappings))?;
 
-                let then_constr = Constraint::new_variant("if left branch", &if_expr, &left, &ConstrVariant::Either);
+                let then_constr = Constraint::new_variant("if then branch", &if_expr, &then, &ConstrVariant::Either);
                 constr.add_constr(&then_constr);
-                let else_constr = Constraint::new_variant("if right branch", &if_expr, &right, &ConstrVariant::Either);
+                let else_constr = Constraint::new_variant("if else branch", &if_expr, &el, &ConstrVariant::Either);
                 constr.add_constr(&else_constr);
             }
 

--- a/src/check/constrain/generate/definition.rs
+++ b/src/check/constrain/generate/definition.rs
@@ -13,7 +13,7 @@ use crate::check::context::arg::SELF;
 use crate::check::context::clss::HasParent;
 use crate::check::context::field::Field;
 use crate::check::ident::Identifier;
-use crate::check::name::{Empty, match_name, Name, Nullable, Union};
+use crate::check::name::{Any, Empty, match_name, Name, Nullable, Union};
 use crate::check::result::{TypeErr, TypeResult};
 use crate::common::position::Position;
 use crate::parse::ast::{AST, Node};
@@ -111,7 +111,7 @@ pub fn constrain_args(
     ctx: &Context,
     constr: &ConstrBuilder,
 ) -> Constrained {
-    let mut res = (constr.clone(), env.clone());
+    let mut res = (constr.clone(), env.clone().exp_expression(true));
     for arg in args {
         match &arg.node {
             Node::FunArg { mutable, var, ty, default, .. } => {
@@ -149,7 +149,7 @@ pub fn identifier_from_var(
     env: &Environment,
 ) -> Constrained {
     let (mut constr, mut env) = if let Some(expr) = expr {
-        generate(expr, env, ctx, constr)?
+        generate(expr, &env.exp_expression(true), ctx, constr)?
     } else {
         (constr.clone(), env.clone())
     };
@@ -162,7 +162,7 @@ pub fn identifier_from_var(
             env = env.insert_var(mutable && f_mut, &f_name, &ty);
         }
     } else {
-        let any = Expected::new(var.pos, &ExpressionAny);
+        let any = Expected::new(var.pos, &Type { name: Name::any() });
         for (f_mut, f_name) in identifier.fields(var.pos)? {
             env = env.insert_var(mutable && f_mut, &f_name, &any);
         }
@@ -228,9 +228,36 @@ fn identifier_to_tuple(
                 .into_iter()
                 .map(|elements| {
                     let elements = elements.into_iter().cloned().collect();
-                    Expected::new(pos, &Expect::Tuple { elements })
+                    Expected::new(pos, &Tuple { elements })
                 })
                 .collect())
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashSet;
+
+    use crate::check::constrain::constraint::builder::ConstrBuilder;
+    use crate::check::constrain::generate::env::Environment;
+    use crate::check::constrain::generate::generate;
+    use crate::check::context::Context;
+    use crate::parse::parse;
+
+    #[test]
+    fn if_else_as_expr() {
+        let src = "def a := if True then 10 else 20";
+        let ast = parse(src).unwrap();
+        let (builder, _) = generate(&ast, &Environment::default(), &Context::default(), &mut ConstrBuilder::new()).unwrap();
+
+        // Ignore then and else branches
+        let mut constraints = builder.all_constr()[2].clone();
+
+        let mut popped = HashSet::new();
+        while let Some(pop) = constraints.pop_constr() {
+            popped.insert(pop);
+        }
+        assert_eq!(popped.len(), 3);
     }
 }

--- a/src/check/constrain/generate/definition.rs
+++ b/src/check/constrain/generate/definition.rs
@@ -4,8 +4,8 @@ use std::ops::Deref;
 use permutate::Permutator;
 
 use crate::check::constrain::constraint::builder::ConstrBuilder;
+use crate::check::constrain::constraint::expected::{Expect, Expected};
 use crate::check::constrain::constraint::expected::Expect::*;
-use crate::check::constrain::constraint::expected::Expected;
 use crate::check::constrain::generate::{Constrained, generate};
 use crate::check::constrain::generate::env::Environment;
 use crate::check::context::{clss, Context, function, LookupClass};
@@ -170,7 +170,7 @@ pub fn identifier_from_var(
             env = env.insert_var(mutable && f_mut, &f_name, &ty);
         }
     } else {
-        let any = Expected::new(var.pos, &Type { name: Name::any() });
+        let any = Expected::new(var.pos, &Expect::any());
         for (f_mut, f_name) in identifier.fields(var.pos)? {
             env = env.insert_var(mutable && f_mut, &f_name, &any);
         }

--- a/src/check/constrain/generate/definition.rs
+++ b/src/check/constrain/generate/definition.rs
@@ -66,6 +66,9 @@ pub fn gen_def(
                 let inner_env = inner_env.insert_raises(&r_res, ast.pos);
                 if let Some(ret_ty) = ret_ty {
                     let name = Name::try_from(ret_ty)?;
+                    let ret_ty_raises_exp = Expected::new(body.pos, &Type { name: name.clone() });
+                    constr.add("fun body type", &ret_ty_raises_exp, &Expected::try_from((body, &env.var_mappings))?);
+
                     let ret_ty_exp = Expected::new(ret_ty.pos, &Type { name });
                     let inner_env = inner_env.return_type(&ret_ty_exp);
                     generate(body, &inner_env, ctx, &mut constr)?

--- a/src/check/constrain/generate/definition.rs
+++ b/src/check/constrain/generate/definition.rs
@@ -4,7 +4,7 @@ use std::ops::Deref;
 use permutate::Permutator;
 
 use crate::check::constrain::constraint::builder::ConstrBuilder;
-use crate::check::constrain::constraint::expected::{Expect, Expected};
+use crate::check::constrain::constraint::expected::Expected;
 use crate::check::constrain::constraint::expected::Expect::*;
 use crate::check::constrain::generate::{Constrained, generate};
 use crate::check::constrain::generate::env::Environment;

--- a/src/check/constrain/generate/definition.rs
+++ b/src/check/constrain/generate/definition.rs
@@ -4,8 +4,8 @@ use std::ops::Deref;
 use permutate::Permutator;
 
 use crate::check::constrain::constraint::builder::ConstrBuilder;
-use crate::check::constrain::constraint::expected::Expected;
 use crate::check::constrain::constraint::expected::Expect::*;
+use crate::check::constrain::constraint::expected::Expected;
 use crate::check::constrain::generate::{Constrained, generate};
 use crate::check::constrain::generate::env::Environment;
 use crate::check::context::{clss, Context, function, LookupClass};
@@ -111,7 +111,10 @@ pub fn constrain_args(
     ctx: &Context,
     constr: &ConstrBuilder,
 ) -> Constrained {
+    let exp_expression = env.exp_expression;
     let mut res = (constr.clone(), env.clone().exp_expression(true));
+    let env = env.exp_expression(exp_expression);
+
     for arg in args {
         match &arg.node {
             Node::FunArg { mutable, var, ty, default, .. } => {
@@ -148,11 +151,13 @@ pub fn identifier_from_var(
     constr: &mut ConstrBuilder,
     env: &Environment,
 ) -> Constrained {
+    let exp_expression = env.exp_expression;
     let (mut constr, mut env) = if let Some(expr) = expr {
         generate(expr, &env.exp_expression(true), ctx, constr)?
     } else {
         (constr.clone(), env.clone())
     };
+    env = env.exp_expression(exp_expression);
 
     let identifier = Identifier::try_from(var.deref())?.as_mutable(mutable);
     if let Some(ty) = ty {

--- a/src/check/constrain/generate/env.rs
+++ b/src/check/constrain/generate/env.rs
@@ -11,6 +11,7 @@ use crate::common::position::Position;
 #[derive(Clone, Debug, Default)]
 pub struct Environment {
     pub in_loop: bool,
+    pub exp_expression: bool,
     pub last_stmt_in_function: bool,
     pub is_define_mode: bool,
     pub return_type: Option<Expected>,
@@ -37,6 +38,10 @@ impl Environment {
     /// Causes all identifiers to be treated as definitions.
     pub fn define_mode(&self, is_define_mode: bool) -> Environment {
         Environment { is_define_mode, ..self.clone() }
+    }
+
+    pub fn exp_expression(&self, exp_expression: bool) -> Environment {
+        Environment { exp_expression, ..self.clone() }
     }
 
     /// Insert a variable.

--- a/src/check/constrain/generate/mod.rs
+++ b/src/check/constrain/generate/mod.rs
@@ -82,6 +82,7 @@ pub fn generate(
         Mod { .. } => gen_op(ast, env, ctx, constr),
         AddU { .. } | SubU { .. } => gen_op(ast, env, ctx, constr),
         Sqrt { .. } => gen_op(ast, env, ctx, constr),
+        Undefined => gen_op(ast, env, ctx, constr),
 
         BOneCmpl { .. } => gen_op(ast, env, ctx, constr),
         BAnd { .. } | BOr { .. } | BXOr { .. } => gen_op(ast, env, ctx, constr),
@@ -103,7 +104,6 @@ pub fn generate(
         | ExpressionType { .. }
         | DocStr { .. }
         | Underscore
-        | Undefined
         | Comment { .. } => Ok((constr.clone(), env.clone())),
     }
 }

--- a/src/check/constrain/generate/operation.rs
+++ b/src/check/constrain/generate/operation.rs
@@ -70,6 +70,13 @@ pub fn gen_op(
             ));
             Ok((constr.clone(), env.clone()))
         }
+        Node::Undefined => {
+            constr.add_constr(&Constraint::undefined(
+                "undefined",
+                &Expected::try_from((ast, &env.var_mappings))?,
+            ));
+            Ok((constr.clone(), env.clone()))
+        }
 
         Node::Add { left, right } => impl_magic(ADD, ast, left, right, env, ctx, constr),
         Node::Sub { left, right } => impl_magic(SUB, ast, left, right, env, ctx, constr),

--- a/src/check/constrain/generate/operation.rs
+++ b/src/check/constrain/generate/operation.rs
@@ -2,8 +2,8 @@ use std::convert::TryFrom;
 
 use crate::check::constrain::constraint::builder::ConstrBuilder;
 use crate::check::constrain::constraint::Constraint;
+use crate::check::constrain::constraint::expected::{Expect, Expected};
 use crate::check::constrain::constraint::expected::Expect::*;
-use crate::check::constrain::constraint::expected::Expected;
 use crate::check::constrain::generate::{Constrained, gen_vec, generate};
 use crate::check::constrain::generate::collection::{constr_col, gen_collection_lookup};
 use crate::check::constrain::generate::env::Environment;
@@ -123,22 +123,22 @@ pub fn gen_op(
 
         Node::BOneCmpl { expr } => {
             let left = Expected::try_from((expr, &env.var_mappings))?;
-            constr.add("binary compliment", &left, &Expected::new(expr.pos, &Type { name: Name::any() }));
+            constr.add("binary compliment", &left, &Expected::new(expr.pos, &Expect::any()));
             generate(expr, env, ctx, constr)
         }
         Node::BAnd { left, right } | Node::BOr { left, right } | Node::BXOr { left, right } => {
             let l_exp = Expected::try_from((left, &env.var_mappings))?;
-            constr.add("binary logical op", &l_exp, &Expected::new(left.pos, &Type { name: Name::any() }));
+            constr.add("binary logical op", &l_exp, &Expected::new(left.pos, &Expect::any()));
 
             let l_exp = Expected::try_from((right, &env.var_mappings))?;
-            constr.add("binary logical op", &l_exp, &Expected::new(right.pos, &Type { name: Name::any() }));
+            constr.add("binary logical op", &l_exp, &Expected::new(right.pos, &Expect::any()));
 
             let (mut constr, env) = generate(right, env, ctx, constr)?;
             generate(left, &env, ctx, &mut constr)
         }
         Node::BLShift { left, right } | Node::BRShift { left, right } => {
             let l_exp = Expected::try_from((left, &env.var_mappings))?;
-            constr.add("binary shift", &l_exp, &Expected::new(right.pos, &Type { name: Name::any() }));
+            constr.add("binary shift", &l_exp, &Expected::new(right.pos, &Expect::any()));
 
             let name = Name::from(INT);
             let l_exp = Expected::try_from((right, &env.var_mappings))?;

--- a/src/check/constrain/generate/resources.rs
+++ b/src/check/constrain/generate/resources.rs
@@ -1,13 +1,13 @@
 use std::convert::TryFrom;
 
 use crate::check::constrain::constraint::builder::ConstrBuilder;
-use crate::check::constrain::constraint::expected::Expect::{ExpressionAny, Raises, Type};
+use crate::check::constrain::constraint::expected::Expect::{Raises, Type};
 use crate::check::constrain::constraint::expected::Expected;
 use crate::check::constrain::generate::{Constrained, generate};
 use crate::check::constrain::generate::definition::identifier_from_var;
 use crate::check::constrain::generate::env::Environment;
 use crate::check::context::Context;
-use crate::check::name::Name;
+use crate::check::name::{Any, Name};
 use crate::check::result::{TypeErr, TypeResult};
 use crate::parse::ast::{AST, Node};
 
@@ -32,7 +32,7 @@ pub fn gen_resources(
             constr.new_set(true);
             let resource_exp = Expected::try_from((resource, &env.var_mappings))?;
             constr.add("with as", &resource_exp, &Expected::try_from((alias, &env.var_mappings))?);
-            constr.add("with as", &resource_exp, &Expected::new(resource.pos, &ExpressionAny));
+            constr.add("with as", &resource_exp, &Expected::new(resource.pos, &Type { name: Name::any() }));
 
             if let Some(ty) = ty {
                 let ty_exp = Type { name: Name::try_from(ty)? };
@@ -63,7 +63,7 @@ pub fn gen_resources(
             constr.add(
                 "with",
                 &Expected::try_from((resource, &env.var_mappings))?,
-                &Expected::new(resource.pos, &ExpressionAny),
+                &Expected::new(resource.pos, &Type { name: Name::any() }),
             );
             let (mut constr, env) = generate(resource, env, ctx, constr)?;
             constr.exit_set(ast.pos)?;

--- a/src/check/constrain/generate/resources.rs
+++ b/src/check/constrain/generate/resources.rs
@@ -32,7 +32,7 @@ pub fn gen_resources(
             constr.new_set(true);
             let resource_exp = Expected::try_from((resource, &env.var_mappings))?;
             constr.add("with as", &resource_exp, &Expected::try_from((alias, &env.var_mappings))?);
-            constr.add("with as", &Expected::new(resource.pos, &Expect::any()), &resource_exp);
+            constr.add("with as", &resource_exp, &Expected::new(resource.pos, &Expect::any()));
 
             if let Some(ty) = ty {
                 let ty_exp = Type { name: Name::try_from(ty)? };

--- a/src/check/constrain/generate/resources.rs
+++ b/src/check/constrain/generate/resources.rs
@@ -1,8 +1,8 @@
 use std::convert::TryFrom;
 
 use crate::check::constrain::constraint::builder::ConstrBuilder;
+use crate::check::constrain::constraint::expected::{Expect, Expected};
 use crate::check::constrain::constraint::expected::Expect::{Raises, Type};
-use crate::check::constrain::constraint::expected::Expected;
 use crate::check::constrain::generate::{Constrained, generate};
 use crate::check::constrain::generate::definition::identifier_from_var;
 use crate::check::constrain::generate::env::Environment;
@@ -32,7 +32,7 @@ pub fn gen_resources(
             constr.new_set(true);
             let resource_exp = Expected::try_from((resource, &env.var_mappings))?;
             constr.add("with as", &resource_exp, &Expected::try_from((alias, &env.var_mappings))?);
-            constr.add("with as", &Expected::new(resource.pos, &Type { name: Name::any() }), &resource_exp);
+            constr.add("with as", &Expected::new(resource.pos, &Expect::any()), &resource_exp);
 
             if let Some(ty) = ty {
                 let ty_exp = Type { name: Name::try_from(ty)? };
@@ -63,7 +63,7 @@ pub fn gen_resources(
             constr.add(
                 "with",
                 &Expected::try_from((resource, &env.var_mappings))?,
-                &Expected::new(resource.pos, &Type { name: Name::any() }),
+                &Expected::new(resource.pos, &Expect::any()),
             );
             let (mut constr, env) = generate(resource, env, ctx, constr)?;
             constr.exit_set(ast.pos)?;

--- a/src/check/constrain/generate/resources.rs
+++ b/src/check/constrain/generate/resources.rs
@@ -32,7 +32,7 @@ pub fn gen_resources(
             constr.new_set(true);
             let resource_exp = Expected::try_from((resource, &env.var_mappings))?;
             constr.add("with as", &resource_exp, &Expected::try_from((alias, &env.var_mappings))?);
-            constr.add("with as", &resource_exp, &Expected::new(resource.pos, &Type { name: Name::any() }));
+            constr.add("with as", &Expected::new(resource.pos, &Type { name: Name::any() }), &resource_exp);
 
             if let Some(ty) = ty {
                 let ty_exp = Type { name: Name::try_from(ty)? };

--- a/src/check/constrain/mod.rs
+++ b/src/check/constrain/mod.rs
@@ -16,3 +16,61 @@ pub fn constraints(ast: &AST, ctx: &Context) -> Unified<Vec<Constraints>> {
     let constrained = gen_all(ast, ctx)?;
     unify(&constrained, ctx)
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::check::constrain::constraints;
+    use crate::check::context::Context;
+    use crate::check::name::Name;
+    use crate::common::position::{CaretPos, Position};
+    use crate::parse::parse;
+
+    #[test]
+    fn if_stmt_no_type() {
+        let src = "if True then 10 else 20";
+        let ast = parse(src).unwrap();
+        let constraints = constraints(&ast, &Context::default().into_with_primitives().unwrap()).unwrap();
+
+        // if and then branch
+        let inner_constr = constraints[0].clone();
+
+        assert_eq!(inner_constr.finished.len(), 2);
+        let pos_10 = Position::new(CaretPos::new(1, 14), CaretPos::new(1, 16));
+        assert_eq!(inner_constr.finished[&pos_10], Name::from("Int"));
+        let pos_bool = Position::new(CaretPos::new(1, 4), CaretPos::new(1, 8));
+        assert_eq!(inner_constr.finished[&pos_bool], Name::from("Bool"));
+
+        // if and else branch
+        let inner_constr = constraints[1].clone();
+
+        assert_eq!(inner_constr.finished.len(), 2);
+        let pos_20 = Position::new(CaretPos::new(1, 22), CaretPos::new(1, 24));
+        assert_eq!(inner_constr.finished[&pos_20], Name::from("Int"));
+        let pos_bool = Position::new(CaretPos::new(1, 4), CaretPos::new(1, 8));
+        assert_eq!(inner_constr.finished[&pos_bool], Name::from("Bool"));
+
+        // if
+        let inner_constr = constraints[2].clone();
+        assert_eq!(inner_constr.len(), 0);
+    }
+
+    #[test]
+    fn it_stmt_as_expression() {
+        let src = "def a := if True then 10 else 20";
+        let ast = parse(src).unwrap();
+        let constraints = constraints(&ast, &Context::default().into_with_primitives().unwrap()).unwrap();
+
+        // Ignore then and else branch
+        let inner_constr = constraints[2].clone();
+        assert_eq!(inner_constr.finished.len(), 4);
+        let pos_20 = Position::new(CaretPos::new(1, 31), CaretPos::new(1, 33));
+        assert_eq!(inner_constr.finished[&pos_20], Name::from("Int"));
+        let pos_10 = Position::new(CaretPos::new(1, 23), CaretPos::new(1, 25));
+        assert_eq!(inner_constr.finished[&pos_10], Name::from("Int"));
+        let pos_bool = Position::new(CaretPos::new(1, 13), CaretPos::new(1, 17));
+        assert_eq!(inner_constr.finished[&pos_bool], Name::from("Bool"));
+
+        let pos_if = Position::new(CaretPos::new(1, 10), CaretPos::new(1, 33));
+        assert_eq!(inner_constr.finished[&pos_if], Name::from("Int"));
+    }
+}

--- a/src/check/constrain/unify/expression/mod.rs
+++ b/src/check/constrain/unify/expression/mod.rs
@@ -39,7 +39,7 @@ pub fn unify_expression(constraint: &Constraint, constraints: &mut Constraints, 
             unify_link(&mut constraints, ctx, total)
         }
 
-        (Expression { .. }, _) if constraint.superset == ConstrVariant::Left || constraint.superset == ConstrVariant::Either => {
+        (Expression { .. }, _) if constraint.superset == ConstrVariant::Left => {
             let mut constraints = substitute(right, left, constraints, count, total)?;
             unify_link(&mut constraints, ctx, total)
         }

--- a/src/check/constrain/unify/function.rs
+++ b/src/check/constrain/unify/function.rs
@@ -180,7 +180,7 @@ fn function_access(
 }
 
 fn unify_fun_arg(
-    f_args: &Vec<HashSet<FunctionArg>>,
+    f_args: &[HashSet<FunctionArg>],
     args: &[Expected],
     constr: &Constraints,
     pos: Position,

--- a/src/check/constrain/unify/link.rs
+++ b/src/check/constrain/unify/link.rs
@@ -8,7 +8,6 @@ use crate::check::constrain::unify::expression::unify_expression;
 use crate::check::constrain::unify::function::unify_function;
 use crate::check::constrain::unify::ty::unify_type;
 use crate::check::context::Context;
-use crate::check::name::{Any, Name};
 
 /// Unifies all constraints.
 ///
@@ -28,10 +27,10 @@ pub fn unify_link(constraints: &mut Constraints, ctx: &Context, total: usize) ->
         trace!("{:width$}[{}{}]  {}", pos, unify, msg, constraint, width = 27);
 
         if let Type { name } = &left.expect {
-            if name != &Name::any() { constraints.push_ty(right.pos, name); }
+            constraints.push_ty(right.pos, name);
         }
         if let Type { name } = &right.expect {
-            if name != &Name::any() { constraints.push_ty(left.pos, name); }
+            constraints.push_ty(left.pos, name);
         }
 
         match (&left.expect, &right.expect) {

--- a/src/check/constrain/unify/link.rs
+++ b/src/check/constrain/unify/link.rs
@@ -8,6 +8,7 @@ use crate::check::constrain::unify::expression::unify_expression;
 use crate::check::constrain::unify::function::unify_function;
 use crate::check::constrain::unify::ty::unify_type;
 use crate::check::context::Context;
+use crate::check::name::{Any, Name};
 
 /// Unifies all constraints.
 ///
@@ -27,10 +28,14 @@ pub fn unify_link(constraints: &mut Constraints, ctx: &Context, total: usize) ->
         trace!("{:width$}[{}{}]  {}", pos, unify, msg, constraint, width = 27);
 
         if let Type { name } = &left.expect {
-            constraints.push_ty(right.pos, name);
+            if !(name == &Name::any()) {
+                constraints.push_ty(right.pos, name);
+            }
         }
         if let Type { name } = &right.expect {
-            constraints.push_ty(left.pos, name);
+            if !(name == &Name::any()) {
+                constraints.push_ty(left.pos, name);
+            }
         }
 
         match (&left.expect, &right.expect) {

--- a/src/check/constrain/unify/link.rs
+++ b/src/check/constrain/unify/link.rs
@@ -28,14 +28,10 @@ pub fn unify_link(constraints: &mut Constraints, ctx: &Context, total: usize) ->
         trace!("{:width$}[{}{}]  {}", pos, unify, msg, constraint, width = 27);
 
         if let Type { name } = &left.expect {
-            if !(name == &Name::any()) {
-                constraints.push_ty(right.pos, name);
-            }
+            if name != &Name::any() { constraints.push_ty(right.pos, name); }
         }
         if let Type { name } = &right.expect {
-            if !(name == &Name::any()) {
-                constraints.push_ty(left.pos, name);
-            }
+            if name != &Name::any() { constraints.push_ty(left.pos, name); }
         }
 
         match (&left.expect, &right.expect) {

--- a/src/check/constrain/unify/ty.rs
+++ b/src/check/constrain/unify/ty.rs
@@ -171,6 +171,10 @@ pub fn unify_type(
                     Err(vec![TypeErr::new(left.pos, &msg)])
                 }
             }
+
+            // Ignore raises
+            (Type { .. }, Raises { .. }) | (Raises { .. }, Type { .. }) => unify_link(constraints, ctx, total),
+
             _ => {
                 if l_exp.is_none() && r_exp.is_none() {
                     unify_link(constraints, ctx, total)

--- a/src/check/constrain/unify/ty.rs
+++ b/src/check/constrain/unify/ty.rs
@@ -9,7 +9,7 @@ use crate::check::constrain::Unified;
 use crate::check::constrain::unify::expression::substitute::substitute;
 use crate::check::constrain::unify::link::unify_link;
 use crate::check::context::{Context, LookupClass};
-use crate::check::name::{Any, ColType, IsSuperSet, Name};
+use crate::check::name::{Any, ColType, IsSuperSet, Name, Union};
 use crate::check::name::name_variant::NameVariant;
 use crate::check::result::{TypeErr, TypeResult};
 use crate::common::position::Position;
@@ -45,6 +45,11 @@ pub fn unify_type(
             } else if left_is_super || right_is_super || either_is_super {
                 ctx.class(l_ty, left.pos)?;
                 ctx.class(r_ty, right.pos)?;
+                unify_link(constraints, ctx, total)
+            } else if constraint.superset == ConstrVariant::Either {
+                let name = l_ty.union(r_ty);
+                constraints.push_ty(left.pos, &name);
+                constraints.push_ty(right.pos, &name);
                 unify_link(constraints, ctx, total)
             } else if constraint.superset == ConstrVariant::Left {
                 let msg = format!("Unifying two types: Expected {}, was {}", left, right);

--- a/src/check/constrain/unify/ty.rs
+++ b/src/check/constrain/unify/ty.rs
@@ -47,9 +47,8 @@ pub fn unify_type(
                 ctx.class(r_ty, right.pos)?;
                 unify_link(constraints, ctx, total)
             } else if constraint.superset == ConstrVariant::Either {
-                let name = l_ty.union(r_ty);
-                constraints.push_ty(left.pos, &name);
-                constraints.push_ty(right.pos, &name);
+                constraints.push_ty(left.pos, &l_ty.union(r_ty));
+                constraints.push_ty(right.pos, &l_ty.union(r_ty));
                 unify_link(constraints, ctx, total)
             } else if constraint.superset == ConstrVariant::Left {
                 let msg = format!("Unifying two types: Expected {}, was {}", left, right);

--- a/src/check/constrain/unify/ty.rs
+++ b/src/check/constrain/unify/ty.rs
@@ -2,16 +2,14 @@ use EitherOrBoth::Both;
 use itertools::{EitherOrBoth, Itertools};
 
 use crate::check::constrain::constraint::{Constraint, ConstrVariant};
-use crate::check::constrain::constraint::expected::{Expect, Expected};
-use crate::check::constrain::constraint::expected::Expect::{
-    Collection, ExpressionAny, Raises, Tuple, Type,
-};
+use crate::check::constrain::constraint::expected::Expect::{Collection, Raises, Tuple, Type};
+use crate::check::constrain::constraint::expected::Expected;
 use crate::check::constrain::constraint::iterator::Constraints;
 use crate::check::constrain::Unified;
 use crate::check::constrain::unify::expression::substitute::substitute;
 use crate::check::constrain::unify::link::unify_link;
 use crate::check::context::{Context, LookupClass};
-use crate::check::name::{ColType, Empty, IsSuperSet, Name};
+use crate::check::name::{Any, ColType, IsSuperSet, Name};
 use crate::check::name::name_variant::NameVariant;
 use crate::check::result::{TypeErr, TypeResult};
 use crate::common::position::Position;
@@ -26,26 +24,15 @@ pub fn unify_type(
     let count = if constraints.len() <= total { total - constraints.len() } else { 0 };
 
     match (&left.expect, &right.expect) {
-        (ExpressionAny, ty) | (ty, ExpressionAny) => match ty {
-            Type { name } => {
-                if Name::is_empty(name) {
-                    let msg = format!("Expected an expression, but was '{}'", name);
-                    Err(vec![TypeErr::new(left.pos, &msg)])
-                } else {
-                    unify_link(constraints, ctx, total)
-                }
-            }
-            _ => unify_link(constraints, ctx, total),
-        },
-
         (Type { name: l_ty }, Type { name: r_ty }) => {
             let left_is_super = (constraint.superset == ConstrVariant::Left)
-                && l_ty.is_superset_of(r_ty, ctx, left.pos)?;
+                && l_ty.is_superset_of(r_ty, ctx, left.pos)? || l_ty == &Name::any();
             let right_is_super = (constraint.superset == ConstrVariant::Right)
-                && r_ty.is_superset_of(l_ty, ctx, left.pos)?;
+                && r_ty.is_superset_of(l_ty, ctx, left.pos)? || r_ty == &Name::any();
             let either_is_super = (constraint.superset == ConstrVariant::Either)
                 && (l_ty.is_superset_of(r_ty, ctx, left.pos)?
-                || r_ty.is_superset_of(l_ty, ctx, left.pos)?);
+                || r_ty.is_superset_of(l_ty, ctx, left.pos)?)
+                || l_ty == &Name::any() || r_ty == &Name::any();
 
             if l_ty.is_temporary() {
                 let mut constr =
@@ -112,7 +99,7 @@ pub fn unify_type(
                         for pair in names.iter().cloned().zip_longest(elements.iter()) {
                             match &pair {
                                 Both(name, exp) => {
-                                    let expect = Expect::Type { name: name.clone() };
+                                    let expect = Type { name: name.clone() };
                                     let l_ty = Expected::new(left.pos, &expect);
                                     constraints.push("tuple", &l_ty, exp)
                                 }
@@ -162,7 +149,7 @@ pub fn unify_type(
         (l_exp, r_exp) => match (l_exp, r_exp) {
             (Collection { ty }, Type { name }) => {
                 if let Some(col_ty) = name.col_type(ctx, right.pos)? {
-                    let expect = Expect::Type { name: col_ty };
+                    let expect = Type { name: col_ty };
                     constraints.push("collection type", ty, &Expected::new(left.pos, &expect));
                     unify_link(constraints, ctx, total + 1)
                 } else {
@@ -172,7 +159,7 @@ pub fn unify_type(
             }
             (Type { name }, Collection { ty }) => {
                 if let Some(col_ty) = name.col_type(ctx, left.pos)? {
-                    let expect = Expect::Type { name: col_ty };
+                    let expect = Type { name: col_ty };
                     constraints.push("collection type", &Expected::new(left.pos, &expect), ty);
                     unify_link(constraints, ctx, total + 1)
                 } else {
@@ -201,7 +188,7 @@ fn substitute_ty(
     offset: usize,
     total: usize,
 ) -> TypeResult<Constraints> {
-    let new = Expected::new(new_pos, &Expect::Type { name: new.clone() });
-    let old = Expected::new(old_pos, &Expect::Type { name: old.clone() });
+    let new = Expected::new(new_pos, &Type { name: new.clone() });
+    let old = Expected::new(old_pos, &Type { name: old.clone() });
     substitute(&new, &old, constraints, offset, total)
 }

--- a/src/check/context/clss/generic.rs
+++ b/src/check/context/clss/generic.rs
@@ -4,13 +4,13 @@ use std::hash::{Hash, Hasher};
 use std::iter::FromIterator;
 use std::ops::Deref;
 
-use crate::check::context::arg;
+use crate::check::context::{arg, clss, function};
 use crate::check::context::arg::generic::{ClassArgument, GenericFunctionArg};
 use crate::check::context::field::generic::{GenericField, GenericFields};
 use crate::check::context::function::generic::GenericFunction;
 use crate::check::context::function::INIT;
 use crate::check::context::parent::generic::GenericParent;
-use crate::check::name::Name;
+use crate::check::name::{Any, Name};
 use crate::check::name::string_name::StringName;
 use crate::check::result::{TypeErr, TypeResult};
 use crate::common::position::Position;
@@ -44,6 +44,33 @@ impl GenericClass {
     pub fn all_pure(self, pure: bool) -> TypeResult<Self> {
         let functions = self.functions.iter().map(|f| f.clone().pure(pure)).collect();
         Ok(GenericClass { functions, ..self })
+    }
+}
+
+impl Any for GenericClass {
+    fn any() -> Self {
+        let mut functions = HashSet::new();
+        functions.insert(GenericFunction {
+            is_py_type: false,
+            name: StringName::new(function::STR, &[]),
+            pure: false,
+            pos: Default::default(),
+            arguments: vec![],
+            raises: Name { names: Default::default() },
+            in_class: None,
+            ret_ty: None,
+        });
+
+        GenericClass {
+            is_py_type: false,
+            name: StringName::new(clss::ANY, &[]),
+            pos: Default::default(),
+            concrete: true,
+            args: vec![],
+            fields: Default::default(),
+            functions,
+            parents: Default::default(),
+        }
     }
 }
 

--- a/src/check/context/clss/mod.rs
+++ b/src/check/context/clss/mod.rs
@@ -6,7 +6,7 @@ use std::hash::{Hash, Hasher};
 
 use itertools::{EitherOrBoth, enumerate, Itertools};
 
-use crate::check::context::{clss, Context, LookupClass};
+use crate::check::context::{Context, LookupClass};
 use crate::check::context::arg::FunctionArg;
 use crate::check::context::arg::generic::GenericFunctionArg;
 use crate::check::context::clss::generic::GenericClass;
@@ -36,6 +36,7 @@ pub const TUPLE: &str = "Tuple";
 
 pub const CALLABLE: &str = "Callable";
 
+pub const ANY: &str = "Any";
 pub const NONE: &str = "None";
 pub const EXCEPTION: &str = "Exception";
 
@@ -79,7 +80,7 @@ pub trait GetFun<T> {
 
 impl HasParent<&StringName> for Class {
     fn has_parent(&self, name: &StringName, ctx: &Context, pos: Position) -> TypeResult<bool> {
-        Ok(self.name.name == clss::COLLECTION && self.name.name == name.name
+        Ok(self.name.name == COLLECTION && self.name.name == name.name
             || &self.name == name
             || self
             .parents
@@ -135,7 +136,7 @@ impl LookupClass<&StringName, Class> for Context {
     fn class(&self, class: &StringName, pos: Position) -> TypeResult<Class> {
         if let Some(generic_class) = self.classes.iter().find(|c| c.name.name == class.name) {
             let mut generics = HashMap::new();
-            if class.name == clss::TUPLE || class.name == clss::COLLECTION {
+            if class.name == TUPLE || class.name == COLLECTION {
                 // Tuple and collection exception, variable generic count
                 let mut generic_keys: Vec<Name> = vec![];
                 for (i, gen) in enumerate(&class.generics) {

--- a/src/check/mod.rs
+++ b/src/check/mod.rs
@@ -72,7 +72,7 @@ pub fn check_all(asts: &[AST]) -> TypeResult<Vec<ASTTy>> {
 mod tests {
     use crate::check::ast::NodeTy;
     use crate::check::check_all;
-    use crate::check::name::Name;
+    use crate::check::name::{Name, Union};
     use crate::parse::parse;
 
     #[test]
@@ -105,5 +105,25 @@ mod tests {
         };
 
         assert_eq!(expr.ty, Some(Name::from("Int")));
+    }
+
+    #[test]
+    fn it_stmt_as_expression_int_and_str() {
+        let src = "def a := if True then 10 else \"asdf\"";
+        let ast = parse(src).unwrap();
+        let result = check_all(&[*ast]).unwrap();
+
+        let statements = if let NodeTy::Block { statements } = &result[0].node {
+            statements.clone()
+        } else {
+            panic!()
+        };
+
+        let expr = match &statements[0].node {
+            NodeTy::VariableDef { expr, .. } => expr.clone().unwrap(),
+            other => panic!("Expected variabledef: {:?}", other)
+        };
+
+        assert_eq!(expr.ty, Some(Name::from("Int").union(&Name::from("String"))));
     }
 }

--- a/src/check/mod.rs
+++ b/src/check/mod.rs
@@ -93,15 +93,12 @@ mod tests {
         let ast = parse(src).unwrap();
         let result = check_all(&[*ast]).unwrap();
 
-        let statements = if let NodeTy::Block { statements } = &result[0].node {
-            statements.clone()
-        } else {
+        let NodeTy::Block { statements } = &result[0].node else {
             panic!()
         };
 
-        let expr = match &statements[0].node {
-            NodeTy::VariableDef { expr, .. } => expr.clone().unwrap(),
-            other => panic!("Expected variabledef: {:?}", other)
+        let NodeTy::VariableDef { expr: Some(expr), .. } = &statements[0].node else {
+            panic!("Expected variabledef: {:?}", statements[0].node)
         };
 
         assert_eq!(expr.ty, Some(Name::from("Int")));
@@ -113,15 +110,12 @@ mod tests {
         let ast = parse(src).unwrap();
         let result = check_all(&[*ast]).unwrap();
 
-        let statements = if let NodeTy::Block { statements } = &result[0].node {
-            statements.clone()
-        } else {
+        let NodeTy::Block { statements } = &result[0].node else {
             panic!()
         };
 
-        let expr = match &statements[0].node {
-            NodeTy::VariableDef { expr, .. } => expr.clone().unwrap(),
-            other => panic!("Expected variabledef: {:?}", other)
+        let NodeTy::VariableDef { expr: Some(expr), .. } = &statements[0].node else {
+            panic!("Expected variabledef: {:?}", statements[0].node)
         };
 
         assert_eq!(expr.ty, Some(Name::from("Int").union(&Name::from("String"))));

--- a/src/check/name/mod.rs
+++ b/src/check/name/mod.rs
@@ -8,7 +8,7 @@ use std::iter::FromIterator;
 
 use itertools::Itertools;
 
-use crate::check::context::Context;
+use crate::check::context::{clss, Context};
 use crate::check::ident::Identifier;
 use crate::check::name::name_variant::NameVariant;
 use crate::check::name::string_name::StringName;
@@ -39,6 +39,10 @@ pub trait Empty {
     fn empty() -> Self;
 }
 
+pub trait Any {
+    fn any() -> Self;
+}
+
 pub trait Nullable {
     fn is_nullable(&self) -> bool;
     fn is_null(&self) -> bool;
@@ -62,6 +66,12 @@ pub struct Name {
     pub names: HashSet<TrueName>,
 }
 
+impl Any for Name {
+    fn any() -> Self {
+        Name::from(clss::ANY)
+    }
+}
+
 pub fn match_name(
     identifier: &Identifier,
     name: &Name,
@@ -74,7 +84,7 @@ pub fn match_name(
     for union in unions {
         for (id, (mutable, name)) in union {
             if let Some((current_mutable, current_name)) =
-            final_union.insert(id.clone(), (mutable, name.clone()))
+                final_union.insert(id.clone(), (mutable, name.clone()))
             {
                 final_union
                     .insert(id.clone(), (mutable && current_mutable, current_name.union(&name)));
@@ -327,8 +337,8 @@ mod tests {
 
     #[test]
     fn test_is_superset_slice_int() {
-        let name1 = Name::from(&HashSet::from([clss::INT, clss::SLICE]));
-        let name2 = Name::from(&HashSet::from([clss::INT]));
+        let name1 = Name::from(&HashSet::from([INT, clss::SLICE]));
+        let name2 = Name::from(&HashSet::from([INT]));
 
         let ctx = Context::default().into_with_primitives().unwrap();
         assert!(name1.is_superset_of(&name2, &ctx, Position::default()).unwrap());
@@ -390,7 +400,7 @@ mod tests {
     #[test]
     fn test_temp_name() {
         let name1 = Name::from("@something");
-        let name2 = Name::from(clss::INT);
+        let name2 = Name::from(INT);
 
         assert!(name1.is_temporary());
         assert!(!name2.is_temporary())
@@ -575,7 +585,7 @@ mod tests {
     #[test]
     fn range_has_collection_int_as_parent() -> TypeResult<()> {
         let range_name = Name::from(clss::RANGE);
-        let int_name = Name::from(clss::INT);
+        let int_name = Name::from(INT);
 
         let ctx = Context::default().into_with_primitives().unwrap();
         let collection_ty = range_name.col_type(&ctx, Position::default())?;
@@ -585,8 +595,8 @@ mod tests {
 
     #[test]
     fn float_parent_of_int() -> TypeResult<()> {
-        let float_name = Name::from(clss::FLOAT);
-        let int_name = StringName::from(clss::INT);
+        let float_name = Name::from(FLOAT);
+        let int_name = StringName::from(INT);
         let ctx = Context::default().into_with_primitives().unwrap();
 
         let clss = ctx.class(&int_name, Position::default())?;
@@ -596,8 +606,8 @@ mod tests {
 
     #[test]
     fn int_not_parent_of_float() -> TypeResult<()> {
-        let float_name = StringName::from(clss::FLOAT);
-        let int_name = Name::from(clss::INT);
+        let float_name = StringName::from(FLOAT);
+        let int_name = Name::from(INT);
         let ctx = Context::default().into_with_primitives().unwrap();
 
         let clss = ctx.class(&float_name, Position::default())?;
@@ -616,8 +626,8 @@ mod tests {
 
     #[test]
     fn name_fold() {
-        let int_name = Name::from(clss::INT);
-        let float_name = Name::from(clss::FLOAT);
+        let int_name = Name::from(INT);
+        let float_name = Name::from(FLOAT);
 
         let name1 = Name::from(&HashSet::from([int_name.clone(), float_name.clone()]));
         let name2 = [int_name, float_name].iter().fold(Name::empty(), |name, n| name.union(n));

--- a/src/check/name/mod.rs
+++ b/src/check/name/mod.rs
@@ -302,6 +302,11 @@ impl Substitute for Name {
 }
 
 impl Name {
+    pub fn trim_any(&self) -> Name {
+        let names = self.names.iter().filter(|n| **n != TrueName::any()).cloned().collect();
+        Name { names }
+    }
+
     pub fn as_direct(&self) -> HashSet<StringName> {
         self.names.iter().map(StringName::from).collect()
     }

--- a/src/check/name/mod.rs
+++ b/src/check/name/mod.rs
@@ -155,7 +155,24 @@ impl Mutable for Name {
 
 impl Union<Name> for Name {
     fn union(&self, name: &Name) -> Self {
-        Name { names: self.names.union(&name.names).cloned().collect() }
+        let nullable = name.names.contains(&TrueName::from(clss::NONE));
+        let names: HashSet<TrueName> = self.names.union(&name.names).cloned().collect();
+        let names = if nullable {
+            let names: HashSet<TrueName> = names
+                .iter()
+                .map(|name| if *name != TrueName::from(clss::NONE) { name.as_nullable() } else { name.clone() })
+                .collect();
+
+            if names.len() > 1 {
+                names.into_iter().filter(|name| *name != TrueName::from(clss::NONE)).collect()
+            } else {
+                names // In case None only name
+            }
+        } else {
+            names
+        };
+
+        Name { names }
     }
 }
 

--- a/src/check/name/true_name/mod.rs
+++ b/src/check/name/true_name/mod.rs
@@ -4,9 +4,9 @@ use std::fmt::{Display, Error, Formatter};
 use std::hash::Hash;
 use std::iter::FromIterator;
 
+use crate::check::context::{clss, Context};
 use crate::check::context::clss::NONE;
-use crate::check::context::Context;
-use crate::check::name::{ColType, Empty, IsSuperSet, Mutable, Name, Nullable, Substitute, Union};
+use crate::check::name::{Any, ColType, Empty, IsSuperSet, Mutable, Name, Nullable, Substitute, Union};
 use crate::check::name::name_variant::NameVariant;
 use crate::check::name::string_name::StringName;
 use crate::check::result::TypeResult;
@@ -33,6 +33,12 @@ impl PartialOrd<Self> for TrueName {
         } else {
             self.variant.partial_cmp(&other.variant)
         }
+    }
+}
+
+impl Any for TrueName {
+    fn any() -> Self {
+        TrueName::from(clss::ANY)
     }
 }
 

--- a/src/generate/convert/common.rs
+++ b/src/generate/convert/common.rs
@@ -25,7 +25,7 @@ pub fn convert_stmts(
             // only force the last node to be a return or expression if applicable
             result.push(convert_node(ast, imp, state, ctx)?)
         } else {
-            result.push(convert_node(ast, imp, &state.assign_to(None), ctx)?)
+            result.push(convert_node(ast, imp, &state.must_assign_to(None), ctx)?)
         }
     }
 

--- a/src/generate/convert/control_flow.rs
+++ b/src/generate/convert/control_flow.rs
@@ -7,33 +7,49 @@ use crate::generate::result::{GenResult, UnimplementedErr};
 
 pub fn convert_cntrl_flow(ast: &ASTTy, imp: &mut Imports, state: &State, ctx: &Context) -> GenResult {
     Ok(match &ast.node {
-        NodeTy::IfElse { cond, then, el } => match el {
-            Some(el) if ast.ty.is_some() => {
-                Core::Ternary {
-                    cond: Box::from(convert_node(cond, imp, &state.last_ret(false), ctx)?),
-                    then: Box::from(convert_node(then, imp, &state.last_ret(false), ctx)?),
-                    el: Box::from(convert_node(el, imp, &state.last_ret(false), ctx)?),
+        NodeTy::IfElse { cond, then, el } => {
+            let cond = Box::from(convert_node(cond, imp, &state.is_last_must_be_ret(false).must_assign_to(None), ctx)?);
+
+            match el {
+                Some(el) => match (&then.node, &el.node) {
+                    (NodeTy::Block { .. }, _) | (_, NodeTy::Block { .. }) => Core::IfElse {
+                        cond,
+                        then: Box::from(convert_node(then, imp, state, ctx)?),
+                        el: Box::from(convert_node(el, imp, state, ctx)?),
+                    },
+                    (..) if ast.ty.is_some() => {
+                        let state = state
+                            .is_last_must_be_ret(false)
+                            .remove_ret(true)
+                            .must_assign_to(None);
+
+                        Core::Ternary {
+                            cond,
+                            then: Box::from(convert_node(then, imp, &state, ctx)?),
+                            el: Box::from(convert_node(el, imp, &state, ctx)?),
+                        }
+                    }
+                    _ => Core::IfElse {
+                        cond,
+                        then: Box::from(convert_node(then, imp, state, ctx)?),
+                        el: Box::from(convert_node(el, imp, state, ctx)?),
+                    }
                 }
+                None => Core::If {
+                    cond,
+                    then: Box::from(convert_node(then, imp, state, ctx)?),
+                },
             }
-            Some(el) => Core::IfElse {
-                cond: Box::from(convert_node(cond, imp, &state.last_ret(false), ctx)?),
-                then: Box::from(convert_node(then, imp, state, ctx)?),
-                el: Box::from(convert_node(el, imp, state, ctx)?),
-            },
-            None => Core::If {
-                cond: Box::from(convert_node(cond, imp, state, ctx)?),
-                then: Box::from(convert_node(then, imp, state, ctx)?),
-            },
-        },
+        }
         NodeTy::Match { cond, cases: match_cases } => {
-            let expr = Box::from(convert_node(cond, imp, &state.last_ret(false), ctx)?);
+            let expr = Box::from(convert_node(cond, imp, &state.is_last_must_be_ret(false).must_assign_to(None), ctx)?);
 
             let mut cases = vec![];
             for case in match_cases {
                 if let NodeTy::Case { cond, body } = &case.node {
                     if let NodeTy::ExpressionType { expr, .. } = &cond.node {
                         cases.push(Core::Case {
-                            expr: Box::from(convert_node(expr.as_ref(), imp, &state.last_ret(false), ctx)?),
+                            expr: Box::from(convert_node(expr.as_ref(), imp, &state.is_last_must_be_ret(false).must_assign_to(None), ctx)?),
                             body: Box::from(convert_node(body.as_ref(), imp, state, ctx)?),
                         })
                     }

--- a/src/generate/convert/control_flow.rs
+++ b/src/generate/convert/control_flow.rs
@@ -8,10 +8,15 @@ use crate::generate::result::{GenResult, UnimplementedErr};
 pub fn convert_cntrl_flow(ast: &ASTTy, imp: &mut Imports, state: &State, ctx: &Context) -> GenResult {
     Ok(match &ast.node {
         NodeTy::IfElse { cond, then, el } => match el {
-            Some(el) => Core::IfElse {
+            Some(el) if ast.ty.is_none() => Core::IfElse {
                 cond: Box::from(convert_node(cond, imp, &state.last_ret(false), ctx)?),
                 then: Box::from(convert_node(then, imp, state, ctx)?),
                 el: Box::from(convert_node(el, imp, state, ctx)?),
+            },
+            Some(el) => Core::Ternary {
+                cond: Box::from(convert_node(cond, imp, &state.last_ret(false), ctx)?),
+                then: Box::from(convert_node(then, imp, &state.last_ret(false), ctx)?),
+                el: Box::from(convert_node(el, imp, &state.last_ret(false), ctx)?),
             },
             None => Core::If {
                 cond: Box::from(convert_node(cond, imp, state, ctx)?),

--- a/src/generate/convert/control_flow.rs
+++ b/src/generate/convert/control_flow.rs
@@ -9,7 +9,6 @@ pub fn convert_cntrl_flow(ast: &ASTTy, imp: &mut Imports, state: &State, ctx: &C
     Ok(match &ast.node {
         NodeTy::IfElse { cond, then, el } => match el {
             Some(el) if ast.ty.is_some() => {
-                println!("ast: {:?}, ty: {}", ast.node, ast.ty.clone().unwrap());
                 Core::Ternary {
                     cond: Box::from(convert_node(cond, imp, &state.last_ret(false), ctx)?),
                     then: Box::from(convert_node(then, imp, &state.last_ret(false), ctx)?),

--- a/src/generate/convert/control_flow.rs
+++ b/src/generate/convert/control_flow.rs
@@ -8,15 +8,18 @@ use crate::generate::result::{GenResult, UnimplementedErr};
 pub fn convert_cntrl_flow(ast: &ASTTy, imp: &mut Imports, state: &State, ctx: &Context) -> GenResult {
     Ok(match &ast.node {
         NodeTy::IfElse { cond, then, el } => match el {
-            Some(el) if ast.ty.is_none() => Core::IfElse {
+            Some(el) if ast.ty.is_some() => {
+                println!("ast: {:?}, ty: {}", ast.node, ast.ty.clone().unwrap());
+                Core::Ternary {
+                    cond: Box::from(convert_node(cond, imp, &state.last_ret(false), ctx)?),
+                    then: Box::from(convert_node(then, imp, &state.last_ret(false), ctx)?),
+                    el: Box::from(convert_node(el, imp, &state.last_ret(false), ctx)?),
+                }
+            }
+            Some(el) => Core::IfElse {
                 cond: Box::from(convert_node(cond, imp, &state.last_ret(false), ctx)?),
                 then: Box::from(convert_node(then, imp, state, ctx)?),
                 el: Box::from(convert_node(el, imp, state, ctx)?),
-            },
-            Some(el) => Core::Ternary {
-                cond: Box::from(convert_node(cond, imp, &state.last_ret(false), ctx)?),
-                then: Box::from(convert_node(then, imp, &state.last_ret(false), ctx)?),
-                el: Box::from(convert_node(el, imp, &state.last_ret(false), ctx)?),
             },
             None => Core::If {
                 cond: Box::from(convert_node(cond, imp, state, ctx)?),

--- a/src/generate/convert/handle.rs
+++ b/src/generate/convert/handle.rs
@@ -23,7 +23,7 @@ pub fn convert_handle(ast: &ASTTy, imp: &mut Imports, state: &State, ctx: &Conte
             } else {
                 (None, None)
             };
-            let assign_state = state.assign_to(var.as_deref());
+            let assign_state = state.must_assign_to(var.as_deref());
 
             Core::TryExcept {
                 setup: var.map(|var| Box::from(Core::VarDef { var, ty, expr: None })),

--- a/src/generate/convert/mod.rs
+++ b/src/generate/convert/mod.rs
@@ -271,7 +271,9 @@ pub fn convert_node(ast: &ASTTy, imp: &mut Imports, state: &State, ctx: &Context
                 op: CoreOp::Assign,
             },
         }
-    } else if last_ret {
+    } else { core };
+
+    let core = if last_ret {
         match core {
             Core::Block { ref statements } => if let Some(last) = statements.last() {
                 match last {
@@ -280,7 +282,7 @@ pub fn convert_node(ast: &ASTTy, imp: &mut Imports, state: &State, ctx: &Context
                         let mut new_stmts = statements.clone();
                         let last = if let Some(ref last) = new_stmts.pop() {
                             match last {
-                                core if skip_return(core) => last.clone(),
+                                last if skip_return(last) => last.clone(),
                                 _ => Core::Return { expr: Box::from(last.clone()) }
                             }
                         } else {
@@ -308,6 +310,7 @@ fn skip_return(core: &Core) -> bool {
     matches!(core,
         Core::Return { .. } |
         Core::IfElse { .. } |
+        Core::Ternary { .. } |
         Core::Match { .. } |
         Core::Raise { .. } |
         Core::TryExcept {..}

--- a/src/generate/convert/state.rs
+++ b/src/generate/convert/state.rs
@@ -7,15 +7,18 @@ use crate::generate::GenArguments;
 
 #[derive(Clone, Debug)]
 pub struct State {
-    pub tup: usize,
     pub interface: bool,
+
+    pub tup: usize,
     pub expand_ty: bool,
     pub def_as_fun_arg: bool,
-    pub tup_lit: bool,
-    pub last_return: bool,
-    pub assign_to: Option<Core>,
 
+    pub tup_lit: bool,
     pub annotate: bool,
+
+    pub is_last_must_be_ret: bool,
+    pub must_assign_to: Option<Core>,
+    pub is_remove_last_ret: bool,
 }
 
 impl From<&GenArguments> for State {
@@ -32,8 +35,9 @@ impl State {
             expand_ty: true,
             def_as_fun_arg: false,
             tup_lit: false,
-            last_return: false,
-            assign_to: None,
+            is_last_must_be_ret: false,
+            is_remove_last_ret: false,
+            must_assign_to: None,
             annotate: false,
         }
     }
@@ -54,14 +58,18 @@ impl State {
         State { expand_ty, ..self.clone() }
     }
 
-    pub fn last_ret(&self, last_return: bool) -> State { State { last_return, ..self.clone() } }
+    pub fn remove_ret(&self, remove_ret: bool) -> State {
+        State { is_remove_last_ret: remove_ret, ..self.clone() }
+    }
+
+    pub fn is_last_must_be_ret(&self, last_return: bool) -> State { State { is_last_must_be_ret: last_return, ..self.clone() } }
 
     pub fn def_as_fun_arg(&self, def_as_fun_arg: bool) -> State {
         State { def_as_fun_arg, ..self.clone() }
     }
 
-    pub fn assign_to(&self, assign_to: Option<&Core>) -> State {
-        State { assign_to: assign_to.cloned(), ..self.clone() }
+    pub fn must_assign_to(&self, assign_to: Option<&Core>) -> State {
+        State { must_assign_to: assign_to.cloned(), ..self.clone() }
     }
 }
 

--- a/src/parse/statement.rs
+++ b/src/parse/statement.rs
@@ -181,10 +181,9 @@ mod test {
         let asts = parse_direct(&source).expect("valid AST");
 
         assert_eq!(asts.len(), 1);
-        let reassignment = asts.first().expect("return");
-        let expr = match &reassignment.node {
-            Node::Return { expr } => (expr.clone()),
-            other => panic!("Expected reassignment, was {:?}", other),
+        let ret = asts.first().expect("return");
+        let Node::Return { expr } = &ret.node else {
+            panic!("Expected reassignment, was: {:?}", ret.node)
         };
 
         assert_eq!(expr.pos, Position::new(CaretPos::new(1, 7), CaretPos::new(1, 9)));

--- a/src/parse/statement.rs
+++ b/src/parse/statement.rs
@@ -170,9 +170,26 @@ pub fn is_start_statement(tp: &Token) -> bool {
 
 #[cfg(test)]
 mod test {
+    use crate::common::position::{CaretPos, Position};
     use crate::parse::ast::Node;
     use crate::parse::ast::node_op::NodeOp;
     use crate::parse::parse_direct;
+
+    #[test]
+    fn parse_return() {
+        let source = String::from("return 20");
+        let asts = parse_direct(&source).expect("valid AST");
+
+        assert_eq!(asts.len(), 1);
+        let reassignment = asts.first().expect("return");
+        let expr = match &reassignment.node {
+            Node::Return { expr } => (expr.clone()),
+            other => panic!("Expected reassignment, was {:?}", other),
+        };
+
+        assert_eq!(expr.pos, Position::new(CaretPos::new(1, 7), CaretPos::new(1, 9)));
+        assert_eq!(expr.node, Node::Int { lit: String::from("20") });
+    }
 
     #[test]
     fn parse_reassignment() {

--- a/tests/check/invalid/function.rs
+++ b/tests/check/invalid/function.rs
@@ -107,6 +107,7 @@ fn wrong_return_type() {
 }
 
 #[test]
+#[ignore] // See #366
 fn return_undefined() {
     let source = resource_content(false, &["type", "function"], "return_undefined.mamba");
     check_all(&[*parse(&source).unwrap()]).unwrap_err();

--- a/tests/resource/valid/control_flow/assign_if.mamba
+++ b/tests/resource/valid/control_flow/assign_if.mamba
@@ -1,0 +1,6 @@
+def my_var := if True then
+    print("then")
+    10
+else
+    print("else")
+    20

--- a/tests/resource/valid/control_flow/assign_if_check.py
+++ b/tests/resource/valid/control_flow/assign_if_check.py
@@ -1,0 +1,6 @@
+if True:
+    print("then")
+    my_var = 10
+else:
+    print("else")
+    my_var = 20

--- a/tests/resource/valid/control_flow/assign_match.mamba
+++ b/tests/resource/valid/control_flow/assign_match.mamba
@@ -1,0 +1,4 @@
+def c := True
+def my_var := match c
+    True => 10
+    False => 20

--- a/tests/resource/valid/control_flow/assign_match_check.py
+++ b/tests/resource/valid/control_flow/assign_match_check.py
@@ -1,0 +1,6 @@
+c: bool = True
+match c:
+    case True:
+        my_var = 10
+    case False:
+        my_var = 20

--- a/tests/resource/valid/control_flow/if_in_for_loop.mamba
+++ b/tests/resource/valid/control_flow/if_in_for_loop.mamba
@@ -1,0 +1,2 @@
+for i in if True then 0..= 2 else 0 .. 2 do
+    print("hello")

--- a/tests/resource/valid/control_flow/if_in_for_loop_check.py
+++ b/tests/resource/valid/control_flow/if_in_for_loop_check.py
@@ -1,0 +1,2 @@
+for i in range(0, 2, 1) if True else range(0, 1, 1):
+    print("hello")

--- a/tests/resource/valid/control_flow/if_in_if_cond.mamba
+++ b/tests/resource/valid/control_flow/if_in_if_cond.mamba
@@ -1,0 +1,6 @@
+def a := True
+def b := True
+def c := False
+
+def d := if a then b else c
+def e := if d then b else c

--- a/tests/resource/valid/control_flow/if_in_if_cond_check.py
+++ b/tests/resource/valid/control_flow/if_in_if_cond_check.py
@@ -1,0 +1,6 @@
+a = True
+b = True
+c = False
+
+d = b if a else c
+e = b if d else c

--- a/tests/resource/valid/control_flow/if_two_types.mamba
+++ b/tests/resource/valid/control_flow/if_two_types.mamba
@@ -1,0 +1,1 @@
+def a := if True then 10 else "asdf"

--- a/tests/resource/valid/control_flow/if_two_types_check.py
+++ b/tests/resource/valid/control_flow/if_two_types_check.py
@@ -1,3 +1,3 @@
 from typing import Union
 
-a: Union[str, int] = 10 if True else "asdf"
+a: Union[int, str] = 10 if True else "asdf"

--- a/tests/resource/valid/control_flow/if_two_types_check.py
+++ b/tests/resource/valid/control_flow/if_two_types_check.py
@@ -1,0 +1,3 @@
+from typing import Union
+
+a: Union[str, int] = 10 if True else "asdf"

--- a/tests/resource/valid/definition/ternary.mamba
+++ b/tests/resource/valid/definition/ternary.mamba
@@ -1,0 +1,6 @@
+if True then
+    print(10)
+else
+    print(20)
+
+def a := if False then 20 else 30

--- a/tests/resource/valid/definition/ternary_check.py
+++ b/tests/resource/valid/definition/ternary_check.py
@@ -1,0 +1,6 @@
+if True:
+    print(10)
+else:
+    print(20)
+
+a: int = 20 if False else 30

--- a/tests/resource/valid/function/definition_check.py
+++ b/tests/resource/valid/function/definition_check.py
@@ -7,10 +7,7 @@ def fun_a() -> Optional[int]:
     if False or True:
         print("world")
     a = None or 11
-    if True:
-        return 10
-    else:
-        return None
+    return 10 if True else None
 
 def fun_b(b: int): print(b)
 

--- a/tests/resource/valid/function/ternary_function_call.mamba
+++ b/tests/resource/valid/function/ternary_function_call.mamba
@@ -1,0 +1,3 @@
+def my_fun(x: Int) => print(x)
+
+my_fun(if True then 1 else 2)

--- a/tests/resource/valid/function/ternary_function_call_check.py
+++ b/tests/resource/valid/function/ternary_function_call_check.py
@@ -1,0 +1,4 @@
+def my_fun(x: int):
+    print(x)
+
+my_fun(1 if True else 2)

--- a/tests/resource/valid/operation/bitwise.mamba
+++ b/tests/resource/valid/operation/bitwise.mamba
@@ -9,6 +9,7 @@ def h := 80
 def i := 90
 def j := 100
 
+_not_ a
 a << b
 c >> d
 e _and_ f

--- a/tests/resource/valid/operation/bitwise_check.py
+++ b/tests/resource/valid/operation/bitwise_check.py
@@ -9,6 +9,7 @@ h: int = 80
 i: int = 90
 j: int = 100
 
+~a
 a << b
 c >> d
 e & f

--- a/tests/system/mod.rs
+++ b/tests/system/mod.rs
@@ -140,7 +140,7 @@ fn fallable(
         Err(OutTestErr(vec![msg]))
     } else if cmd2.status.code().unwrap() != 0 {
         let msg = format!(
-            "{}Running Python command on Mamba output.\n\
+            "{}\nRunning Python command on Mamba output.\n\
         Source:\n\
         ----------\n\
         {}\n\

--- a/tests/system/valid/control_flow.rs
+++ b/tests/system/valid/control_flow.rs
@@ -26,6 +26,11 @@ fn if_ast_verify() -> OutTestRet {
 }
 
 #[test]
+fn if_two_types() -> OutTestRet {
+    test_directory(true, &["control_flow"], &["control_flow", "target"], "if_two_types")
+}
+
+#[test]
 fn while_ast_verify() -> OutTestRet {
     test_directory(true, &["control_flow"], &["control_flow", "target"], "while")
 }

--- a/tests/system/valid/control_flow.rs
+++ b/tests/system/valid/control_flow.rs
@@ -1,6 +1,16 @@
 use crate::system::{OutTestRet, test_directory};
 
 #[test]
+fn assign_if() -> OutTestRet {
+    test_directory(true, &["control_flow"], &["control_flow", "target"], "assign_if")
+}
+
+#[test]
+fn assign_match() -> OutTestRet {
+    test_directory(true, &["control_flow"], &["control_flow", "target"], "assign_match")
+}
+
+#[test]
 fn for_statements() -> OutTestRet {
     test_directory(true, &["control_flow"], &["control_flow", "target"], "for_statements")
 }

--- a/tests/system/valid/control_flow.rs
+++ b/tests/system/valid/control_flow.rs
@@ -36,6 +36,18 @@ fn if_ast_verify() -> OutTestRet {
 }
 
 #[test]
+#[ignore] // See #367
+fn if_in_if_cond() -> OutTestRet {
+    test_directory(true, &["control_flow"], &["control_flow", "target"], "if_in_if_cond")
+}
+
+#[test]
+#[ignore] // See #367
+fn if_in_for_loop() -> OutTestRet {
+    test_directory(true, &["control_flow"], &["control_flow", "target"], "if_in_for_loop")
+}
+
+#[test]
 fn if_two_types() -> OutTestRet {
     test_directory(true, &["control_flow"], &["control_flow", "target"], "if_two_types")
 }
@@ -44,6 +56,7 @@ fn if_two_types() -> OutTestRet {
 fn while_ast_verify() -> OutTestRet {
     test_directory(true, &["control_flow"], &["control_flow", "target"], "while")
 }
+
 
 #[test]
 fn match_stmt_ast_verify() -> OutTestRet {

--- a/tests/system/valid/definition.rs
+++ b/tests/system/valid/definition.rs
@@ -16,6 +16,11 @@ fn function_ret_super_in_class() -> OutTestRet {
 }
 
 #[test]
+fn ternary() -> OutTestRet {
+    test_directory(true, &["definition"], &["definition", "target"], "ternary")
+}
+
+#[test]
 fn function_ret_super() -> OutTestRet {
     test_directory(true, &["definition"], &["definition", "target"], "function_ret_super")
 }

--- a/tests/system/valid/error.rs
+++ b/tests/system/valid/error.rs
@@ -11,6 +11,7 @@ fn exception() -> OutTestRet {
 }
 
 #[test]
+#[ignore] // see #365
 fn raise() -> OutTestRet {
     test_directory(true, &["error"], &["error", "target"], "raise")
 }

--- a/tests/system/valid/function.rs
+++ b/tests/system/valid/function.rs
@@ -24,3 +24,8 @@ fn match_function() -> OutTestRet {
 fn return_last_expression() -> OutTestRet {
     test_directory(true, &["function"], &["function", "target"], "return_last_expression")
 }
+
+#[test]
+fn ternary_function_call() -> OutTestRet {
+    test_directory(true, &["function"], &["function", "target"], "ternary_function_call")
+}


### PR DESCRIPTION
### Relevant issues

Closes #164
Should've been a separate issue but couldn't be bothered to create one.

Introduced bug highlighted in #366 .
Discovered bug highlighted in #367

### Summary

Treat if expressions as expressions where relevant by converting them to python ternary expressions.

- Remove `ExpressionAny`, which introduced a lot of unnecessary logic and complexity.
  Streamlining of logic made it easier to implement this new feature.
  Instead, just have a dedicated `Any` type and match this if needed.
  (Perhaps this introduced the bug in #366?).

### Added Tests

- *Happy* assign propagated into if
- *Happy* ... and match
- *Happy* If converted to ternary when used as function argument
