### PR TITLE
Remove constraint variant either

### DIFF
--- a/src/check/constrain/constraint/mod.rs
+++ b/src/check/constrain/constraint/mod.rs
@@ -24,15 +24,13 @@ pub struct Constraint {
 pub enum ConstrVariant {
     Left,
     Right,
-    Either,
 }
 
 impl Display for Constraint {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), Error> {
         let superset = match &self.superset {
             ConstrVariant::Left => "{left}  ",
-            ConstrVariant::Right => "{right}  ",
-            _ => ""
+            ConstrVariant::Right => "{right}  "
         };
 
         write!(f, "{}{} == {}", superset, self.left, self.right)

--- a/src/check/constrain/generate/control_flow.rs
+++ b/src/check/constrain/generate/control_flow.rs
@@ -43,9 +43,9 @@ pub fn gen_flow(
                 let then = Expected::try_from((then, &env.var_mappings))?;
                 let el = Expected::try_from((el, &env.var_mappings))?;
 
-                let then_constr = Constraint::new_variant("if then branch", &if_expr, &then, &ConstrVariant::Either);
+                let then_constr = Constraint::new_variant("if then branch", &if_expr, &then, &ConstrVariant::Left);
                 constr.add_constr(&then_constr);
-                let else_constr = Constraint::new_variant("if else branch", &if_expr, &el, &ConstrVariant::Either);
+                let else_constr = Constraint::new_variant("if else branch", &if_expr, &el, &ConstrVariant::Left);
                 constr.add_constr(&else_constr);
             }
 

--- a/src/check/constrain/mod.rs
+++ b/src/check/constrain/mod.rs
@@ -84,6 +84,7 @@ mod tests {
     }
 
     #[test]
+    #[ignore] // not sure if the check stage should pass as of yet
     fn it_stmt_as_expression_none() {
         let src = "def a := if True then 10 else None";
         let ast = parse(src).unwrap();

--- a/src/check/mod.rs
+++ b/src/check/mod.rs
@@ -105,6 +105,7 @@ mod tests {
     }
 
     #[test]
+    #[ignore] // not sure if the check stage should pass as of yet
     fn it_stmt_as_expression_int_and_str() {
         let src = "def a := if True then 10 else \"asdf\"";
         let ast = parse(src).unwrap();

--- a/tests/check/invalid/function.rs
+++ b/tests/check/invalid/function.rs
@@ -107,9 +107,14 @@ fn wrong_return_type() {
 }
 
 #[test]
-#[ignore] // See #366
 fn return_undefined() {
     let source = resource_content(false, &["type", "function"], "return_undefined.mamba");
+    check_all(&[*parse(&source).unwrap()]).unwrap_err();
+}
+
+#[test]
+fn return_undefined_explicit_ret() {
+    let source = resource_content(false, &["type", "function"], "return_undefined_explicit.mamba");
     check_all(&[*parse(&source).unwrap()]).unwrap_err();
 }
 

--- a/tests/resource/invalid/type/function/return_undefined_explicit.mamba
+++ b/tests/resource/invalid/type/function/return_undefined_explicit.mamba
@@ -1,0 +1,1 @@
+def f() -> Int => return if True then 10 else None

--- a/tests/resource/valid/control_flow/double_assign_if.mamba
+++ b/tests/resource/valid/control_flow/double_assign_if.mamba
@@ -1,0 +1,6 @@
+def other := 20
+def my_variable := if True then
+    other := 30
+    20
+else
+    10

--- a/tests/resource/valid/control_flow/double_assign_if_check.py
+++ b/tests/resource/valid/control_flow/double_assign_if_check.py
@@ -1,0 +1,6 @@
+other: int = 20
+if True:
+    other = 30
+    my_variable = 20
+else:
+    my_variable = 10

--- a/tests/system/valid/control_flow.rs
+++ b/tests/system/valid/control_flow.rs
@@ -11,6 +11,11 @@ fn assign_match() -> OutTestRet {
 }
 
 #[test]
+fn double_assign_if() -> OutTestRet {
+    test_directory(true, &["control_flow"], &["control_flow", "target"], "double_assign_if")
+}
+
+#[test]
 fn for_statements() -> OutTestRet {
     test_directory(true, &["control_flow"], &["control_flow", "target"], "for_statements")
 }
@@ -48,6 +53,7 @@ fn if_in_for_loop() -> OutTestRet {
 }
 
 #[test]
+#[ignore] // not sure if the check stage should pass as of yet
 fn if_two_types() -> OutTestRet {
     test_directory(true, &["control_flow"], &["control_flow", "target"], "if_two_types")
 }


### PR DESCRIPTION
### Relevant issues

Resolves #366 
Should make an issue to discuss whether we want to allow different types for arms of match and if expressions: #370 

### Summary
This was redundant and added unnecessary logic I believe. 
One problem is that now that the arms of an if expression must always match. 
One cool feature would be that the language then instead takes a union of these two types and continues on.

### Added Tests

- *Happy* Add test to check assign isn't overridden, more relevant to #364 