### PR TITLE
Scan top-level imports and create dummy classes

### DIFF
--- a/src/check/context/clss/generic.rs
+++ b/src/check/context/clss/generic.rs
@@ -41,6 +41,24 @@ impl Hash for GenericClass {
 }
 
 impl GenericClass {
+    pub fn try_from_id(id: &AST) -> TypeResult<GenericClass> {
+        match &id.node {
+            Node::Id { lit } => {
+                Ok(GenericClass {
+                    is_py_type: false,
+                    name: StringName::from(lit.as_str()),
+                    pos: id.pos,
+                    concrete: true, // assume concrete for now
+                    args: vec![],
+                    fields: Default::default(),
+                    functions: Default::default(),
+                    parents: Default::default(),
+                })
+            }
+            _ => Err(vec![TypeErr::new(id.pos, "Expected class name")]),
+        }
+    }
+
     pub fn all_pure(self, pure: bool) -> TypeResult<Self> {
         let functions = self.functions.iter().map(|f| f.clone().pure(pure)).collect();
         Ok(GenericClass { functions, ..self })

--- a/src/check/context/mod.rs
+++ b/src/check/context/mod.rs
@@ -84,6 +84,7 @@ mod tests {
     use crate::check::name::string_name::StringName;
     use crate::check::result::TypeResult;
     use crate::common::position::Position;
+    use crate::parse::parse;
 
     #[test]
     pub fn lookup_custom_list_type() -> TypeResult<()> {
@@ -155,5 +156,37 @@ mod tests {
         context.class(&StringName::from("Range"), Position::default()).unwrap();
         context.class(&StringName::from("None"), Position::default()).unwrap();
         context.class(&StringName::from("Exception"), Position::default()).unwrap();
+    }
+
+    #[test]
+    pub fn test_import_parse() {
+        let file = parse("import IPv4Address").unwrap();
+        let context = Context::try_from(vec![*file.clone()].as_slice()).unwrap();
+
+        context.class(&StringName::from("IPv4Address"), Position::default()).unwrap();
+    }
+
+    #[test]
+    pub fn test_import_as_parse() {
+        let file = parse("import IPv4Address as Other").unwrap();
+        let context = Context::try_from(vec![*file.clone()].as_slice()).unwrap();
+
+        context.class(&StringName::from("Other"), Position::default()).unwrap();
+    }
+
+    #[test]
+    pub fn test_from_import_parse() {
+        let file = parse("from ipaddress import IPv4Address").unwrap();
+        let context = Context::try_from(vec![*file.clone()].as_slice()).unwrap();
+
+        context.class(&StringName::from("IPv4Address"), Position::default()).unwrap();
+    }
+
+    #[test]
+    pub fn test_from_import_as_parse() {
+        let file = parse("from ipaddress import IPv4Address as Other").unwrap();
+        let context = Context::try_from(vec![*file.clone()].as_slice()).unwrap();
+
+        context.class(&StringName::from("Other"), Position::default()).unwrap();
     }
 }

--- a/src/check/context/mod.rs
+++ b/src/check/context/mod.rs
@@ -175,6 +175,12 @@ mod tests {
     }
 
     #[test]
+    pub fn test_import_as_too_many_parse() {
+        let file = parse("import IPv4Address as Other, Other2").unwrap();
+        Context::try_from(vec![*file.clone()].as_slice()).unwrap_err();
+    }
+
+    #[test]
     pub fn test_from_import_parse() {
         let file = parse("from ipaddress import IPv4Address").unwrap();
         let context = Context::try_from(vec![*file.clone()].as_slice()).unwrap();


### PR DESCRIPTION
### Relevant issues

First part of #174 

### Summary

In future we will need a system to get the actual signature of these classes as well.
This is a future milestone.

### Added Tests

*Happy*
- parse import
- parse import alias
- parse from import
- parse from import alias

*Sad*
- parse import with one too many alias