### PR TITLE
Generate identifiers from conditions of match arms

### DIFF
--- a/src/check/constrain/generate/mod.rs
+++ b/src/check/constrain/generate/mod.rs
@@ -59,7 +59,7 @@ pub fn generate(
         TypeFun { .. } => gen_ty(ast, env, ctx, constr),
         QuestionOp { .. } => gen_ty(ast, env, ctx, constr),
 
-        Id { .. } | Question { .. } => gen_expr(ast, env, ctx, constr),
+        ExpressionType { .. } | Id { .. } | Question { .. } => gen_expr(ast, env, ctx, constr),
         AnonFun { .. } => gen_expr(ast, env, ctx, constr),
         Pass => gen_expr(ast, env, ctx, constr),
 
@@ -101,7 +101,6 @@ pub fn generate(
         Import { .. }
         | Generic { .. }
         | Parent { .. }
-        | ExpressionType { .. }
         | DocStr { .. }
         | Underscore
         | Comment { .. } => Ok((constr.clone(), env.clone())),

--- a/tests/check/invalid/control_flow.rs
+++ b/tests/check/invalid/control_flow.rs
@@ -50,3 +50,9 @@ fn or_float() {
     let source = resource_content(false, &["type", "control_flow"], "or_float.mamba");
     check_all(&[*parse(&source).unwrap()]).unwrap_err();
 }
+
+#[test]
+fn undefined_var_in_match_arm() {
+    let source = resource_content(false, &["type", "control_flow"], "undefined_var_in_match_arm.mamba");
+    check_all(&[*parse(&source).unwrap()]).unwrap_err();
+}

--- a/tests/check/invalid/control_flow.rs
+++ b/tests/check/invalid/control_flow.rs
@@ -4,6 +4,12 @@ use mamba::parse::parse;
 use crate::common::resource_content;
 
 #[test]
+fn access_match_arms_variable() {
+    let source = resource_content(false, &["type", "control_flow"], "access_match_arms_variable.mamba");
+    check_all(&[*parse(&source).unwrap()]).unwrap_err();
+}
+
+#[test]
 fn float_and() {
     let source = resource_content(false, &["type", "control_flow"], "float_and.mamba");
     check_all(&[*parse(&source).unwrap()]).unwrap_err();

--- a/tests/resource/invalid/type/control_flow/access_match_arms_variable.mamba
+++ b/tests/resource/invalid/type/control_flow/access_match_arms_variable.mamba
@@ -1,0 +1,5 @@
+match 10
+    n =>
+        print("10")
+
+print(n)

--- a/tests/resource/invalid/type/control_flow/undefined_var_in_match_arm.mamba
+++ b/tests/resource/invalid/type/control_flow/undefined_var_in_match_arm.mamba
@@ -1,0 +1,3 @@
+match 10
+    n =>
+        print(x)

--- a/tests/resource/valid/control_flow/match_dont_remove_shadowed.mamba
+++ b/tests/resource/valid/control_flow/match_dont_remove_shadowed.mamba
@@ -1,0 +1,7 @@
+def n := 10
+
+match 10
+    n =>
+        print("10")
+
+print(n)

--- a/tests/resource/valid/control_flow/match_dont_remove_shadowed_check.py
+++ b/tests/resource/valid/control_flow/match_dont_remove_shadowed_check.py
@@ -1,0 +1,7 @@
+n: int = 10
+
+match 10:
+    case n:
+        print("10")
+
+print(n)

--- a/tests/system/valid/control_flow.rs
+++ b/tests/system/valid/control_flow.rs
@@ -59,10 +59,14 @@ fn if_two_types() -> OutTestRet {
 }
 
 #[test]
+fn match_dont_remove_shadowed() -> OutTestRet {
+    test_directory(true, &["control_flow"], &["control_flow", "target"], "match_dont_remove_shadowed")
+}
+
+#[test]
 fn while_ast_verify() -> OutTestRet {
     test_directory(true, &["control_flow"], &["control_flow", "target"], "while")
 }
-
 
 #[test]
 fn match_stmt_ast_verify() -> OutTestRet {


### PR DESCRIPTION
### Summary

Match arms treated same way as if arms:
- For each new arm create new constraint set
- Use similar logic to for loop variable initialisation.

In future should have way to have some sort of union between constraints, much like env.
This allows us to type check all possible execution paths.

When we implementing pattern matching this system will need to be extended.

### Added Tests

*Happy*
- Variable only declared in condition of match arm usable in arm body.

*Sad*
- Shadow system does not delete outer variables of match.
  Started writing this while creating system of environment unions between match body arms.
  However, I don't think that we actually want this behaviour.
