### PR TITLE
Filter comments when parsing

### DIFF
--- a/src/check/ast/mod.rs
+++ b/src/check/ast/mod.rs
@@ -127,7 +127,6 @@ pub enum NodeTy {
     Pass,
     Question { left: Box<ASTTy>, right: Box<ASTTy> },
     QuestionOp { expr: Box<ASTTy> },
-    Comment { comment: String },
 }
 
 #[cfg(test)]

--- a/src/check/ast/node.rs
+++ b/src/check/ast/node.rs
@@ -320,8 +320,7 @@ impl From<&Node> for NodeTy {
             Node::ReturnEmpty => NodeTy::ReturnEmpty,
             Node::Underscore => NodeTy::Underscore,
             Node::Undefined => NodeTy::Undefined,
-            Node::Pass => NodeTy::Pass,
-            Node::Comment { comment } => NodeTy::Comment { comment: comment.clone() },
+            Node::Pass => NodeTy::Pass
         }
     }
 }

--- a/src/check/constrain/generate/mod.rs
+++ b/src/check/constrain/generate/mod.rs
@@ -103,8 +103,7 @@ pub fn generate(
         | Parent { .. }
         | ExpressionType { .. }
         | DocStr { .. }
-        | Underscore
-        | Comment { .. } => Ok((constr.clone(), env.clone())),
+        | Underscore => Ok((constr.clone(), env.clone())),
     }
 }
 

--- a/src/check/context/clss/generic.rs
+++ b/src/check/context/clss/generic.rs
@@ -288,7 +288,7 @@ fn get_fields_and_functions(
 
                 fields = fields.union(&stmt_fields).cloned().collect();
             }
-            Node::Comment { .. } | Node::DocStr { .. } => {}
+            Node::DocStr { .. } => {}
             _ => {
                 let msg = "Expected function or variable definition";
                 return Err(vec![TypeErr::new(statement.pos, msg)]);

--- a/src/generate/ast/mod.rs
+++ b/src/generate/ast/mod.rs
@@ -281,7 +281,6 @@ fn to_py(core: &Core, ind: usize) -> String {
         Core::Pass => String::from("pass"),
         Core::None => String::from("None"),
         Core::Empty => String::new(),
-        Core::Comment { comment } => format!("#{}", comment),
 
         Core::With { resource, expr } => {
             format!("with {}: {}", to_py(resource, ind), newline_if_body(expr, ind))

--- a/src/generate/ast/node.rs
+++ b/src/generate/ast/node.rs
@@ -78,7 +78,6 @@ pub enum Core {
     Pass,
     None,
     Empty,
-    Comment { comment: String },
     TryExcept { setup: Option<Box<Core>>, attempt: Box<Core>, except: Vec<Core> },
     Except { id: Box<Core>, class: Option<Box<Core>>, body: Box<Core> },
     Raise { error: Box<Core> },

--- a/src/generate/convert/mod.rs
+++ b/src/generate/convert/mod.rs
@@ -243,9 +243,6 @@ pub fn convert_node(ast: &ASTTy, imp: &mut Imports, state: &State, ctx: &Context
 
         NodeTy::Condition { .. } => return Err(UnimplementedErr::new(ast, "condition")),
 
-        NodeTy::Comment { comment } => Core::Comment { comment: comment.clone() },
-        NodeTy::Pass => Core::Pass,
-
         NodeTy::With { resource, alias: Some((alias, ..)), expr } => Core::WithAs {
             resource: Box::from(convert_node(resource, imp, state, ctx)?),
             alias: Box::from(convert_node(alias, imp, &state.expand_ty(false), ctx)?),
@@ -260,6 +257,7 @@ pub fn convert_node(ast: &ASTTy, imp: &mut Imports, state: &State, ctx: &Context
             convert_handle(ast, imp, state, ctx)?
         }
 
+        NodeTy::Pass => Core::Pass,
         _ => Core::Empty,
     };
 

--- a/src/parse/ast/mod.rs
+++ b/src/parse/ast/mod.rs
@@ -117,7 +117,6 @@ pub enum Node {
     Pass,
     Question { left: Box<AST>, right: Box<AST> },
     QuestionOp { expr: Box<AST> },
-    Comment { comment: String },
 }
 
 impl Node {

--- a/src/parse/ast/node.rs
+++ b/src/parse/ast/node.rs
@@ -119,8 +119,7 @@ impl Display for Node {
             Node::Undefined => format!("{}", Token::Undefined),
             Node::Pass => format!("{}", Token::Pass),
             Node::Question { .. } => String::from("ternary operator"),
-            Node::QuestionOp { .. } => String::from("unsafe operator"),
-            Node::Comment { .. } => String::from("comment"),
+            Node::QuestionOp { .. } => String::from("unsafe operator")
         };
 
         write!(f, "{}", name)
@@ -653,7 +652,6 @@ impl Node {
             (Node::QuestionOp { expr: left }, Node::QuestionOp { expr: right }) => {
                 left.same_value(right)
             }
-            (Node::Comment { .. }, Node::Comment { .. }) => true,
 
             (left, right) if **left == **right => true,
             _ => false,
@@ -1222,19 +1220,6 @@ mod test {
             left: Box::from(AST::new(Position::default(), Node::Continue)),
             right: Box::from(AST::new(Position::default(), Node::Break))
         });
-    }
-
-    #[test]
-    fn comment_op_equal_value() {
-        two_ast!(Node::Comment { comment: String::from("cca") });
-    }
-
-    #[test]
-    fn comment_op_equal_value_different_string() {
-        two_ast!(
-            Node::Comment { comment: String::from("cca") },
-            Node::Comment { comment: String::from("aaa") }
-        );
     }
 
     #[test]

--- a/src/parse/block.rs
+++ b/src/parse/block.rs
@@ -37,12 +37,10 @@ pub fn parse_statements(it: &mut LexIterator) -> ParseResult<Vec<AST>> {
             }
             _ => {
                 statements.push(*it.parse(&parse_expr_or_stmt, "statements", start)?);
-                match it.peek_next().map(|l| l.token) {
-                    Some(Token::NL) | Some(Token::Dedent) | Some(Token::Eof) => Ok(()),
-                    _ => {
-                        let exp = [Token::NL, Token::Dedent, Token::Eof];
-                        Err(expected_one_of(&exp, lex, "end of statement"))
-                    }
+                if it.peek_if(&|lex| lex.token != Token::NL && lex.token != Token::Dedent && lex.token != Token::Eof) {
+                    Err(expected_one_of(&[Token::NL, Token::Dedent, Token::Eof], lex, "end of statement"))
+                } else {
+                    Ok(())
                 }
             }
         },

--- a/src/parse/block.rs
+++ b/src/parse/block.rs
@@ -28,7 +28,6 @@ pub fn parse_statements(it: &mut LexIterator) -> ParseResult<Vec<AST>> {
                 statements.push(*it.parse(&parse_class, "file", start)?);
                 Ok(())
             }
-            Token::Comment(str) => it.eat(&Token::Comment(str.clone()), "statements").map(|_| ()),
             Token::DocStr(doc_str) => {
                 let end = it.eat(&Token::DocStr(doc_str.clone()), "statements")?;
                 let node = Node::DocStr { lit: doc_str.clone() };

--- a/src/parse/expr_or_stmt.rs
+++ b/src/parse/expr_or_stmt.rs
@@ -162,6 +162,32 @@ mod test {
     }
 
     #[test]
+    fn return_stmt_with_comment_verify() {
+        let source = String::from("return some_value # comment");
+        let statements = parse_direct(&source).unwrap();
+
+        let expr = match &statements.first().expect("script empty.").node {
+            Node::Return { expr } => expr.clone(),
+            _ => panic!("first element script was not reassign.")
+        };
+
+        assert_eq!(expr.node, Node::Id { lit: String::from("some_value") });
+    }
+
+    #[test]
+    fn literal_expr_with_comment_verify() {
+        let source = String::from("10 # comment");
+        let statements = parse_direct(&source).unwrap();
+
+        let lit = match &statements.first().expect("script empty.").node {
+            Node::Int { lit } => lit.clone(),
+            _ => panic!("first element script was not reassign.")
+        };
+
+        assert_eq!(lit, String::from("10"));
+    }
+
+    #[test]
     fn underscore_verify() {
         let source = String::from("_");
         let statements = parse_direct(&source).unwrap();

--- a/src/parse/expression.rs
+++ b/src/parse/expression.rs
@@ -44,6 +44,7 @@ pub fn parse_inner_expression(it: &mut LexIterator) -> ParseResult {
         Token::Undefined,
         Token::BOneCmpl,
         Token::BSlash,
+        Token::Comment(String::new())
     ];
 
     let result = it.peek_or_err(
@@ -52,6 +53,10 @@ pub fn parse_inner_expression(it: &mut LexIterator) -> ParseResult {
             Token::LRBrack | Token::LSBrack | Token::LCBrack => parse_collection(it),
             Token::Underscore => parse_underscore(it),
 
+            Token::Comment(str) => {
+                let end = it.eat(&Token::Comment(str.clone()), "identifier")?;
+                Ok(Box::from(AST::new(end, Node::Comment { comment: str.clone() })))
+            }
             Token::Id(_) => parse_id(it),
             Token::_Self => parse_id(it),
             Token::Real(real) => literal!(it, real.to_string(), Real),

--- a/src/parse/expression.rs
+++ b/src/parse/expression.rs
@@ -43,8 +43,7 @@ pub fn parse_inner_expression(it: &mut LexIterator) -> ParseResult {
         Token::Sub,
         Token::Undefined,
         Token::BOneCmpl,
-        Token::BSlash,
-        Token::Comment(String::new())
+        Token::BSlash
     ];
 
     let result = it.peek_or_err(
@@ -52,11 +51,6 @@ pub fn parse_inner_expression(it: &mut LexIterator) -> ParseResult {
             Token::If | Token::Match => parse_cntrl_flow_expr(it),
             Token::LRBrack | Token::LSBrack | Token::LCBrack => parse_collection(it),
             Token::Underscore => parse_underscore(it),
-
-            Token::Comment(str) => {
-                let end = it.eat(&Token::Comment(str.clone()), "identifier")?;
-                Ok(Box::from(AST::new(end, Node::Comment { comment: str.clone() })))
-            }
             Token::Id(_) => parse_id(it),
             Token::_Self => parse_id(it),
             Token::Real(real) => literal!(it, real.to_string(), Real),


### PR DESCRIPTION
### Summary

This greatly simplifies (potential) parse logic as we needn't deal with possible comment locations.
We now accept that comments are not preserved in the output, however.


