### PR TITLE
Fix Readme examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,17 +92,21 @@ class MyServer(def ip_address: IPv4Address)
     def is_connected: Bool     := False
     def _last_message: String? := None
 
-    def last_sent(fin self) -> String raise ServerError => if self._last_message /= None 
-        then self._last_message
-        else raise ServerError("No last message!")
+    def last_sent(fin self) -> String raise [ServerError] =>
+        if self._last_message != None then
+            self._last_message
+        else
+            raise ServerError("No last message!")
 
     def connect(self) =>
         self.is_connected := True
         print(always_the_same_message)
 
-    def send(self, message: String) raise ServerError => if self.is_connected 
-        then self._last_message := message
-        else raise ServerError("Not connected!")
+    def send(self, message: String) raise [ServerError] =>
+        if self.is_connected then
+            self._last_message := message
+        else
+            raise ServerError("Not connected!")
 
     def disconnect(self) => self.is_connected := False
 ```
@@ -151,9 +155,11 @@ class MyServer(self: DisConnMyServer, def ip_address: IPv4Address): Server
     def is_connected: Bool     := False
     def _last_message: String? := None
 
-    def last_sent(self) -> String raise ServerErr => if self.last_message /= None 
-        then self._last_message
-        else raise ServerError("No last message!")
+    def last_sent(self) -> String raise ServerErr => 
+        if self.last_message != None then 
+            self._last_message
+        else
+            raise ServerError("No last message!")
 
     def connect(self: DisConnMyServer) => self.is_connected := True
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ def factorial(x: Int) -> Int => match x
 
 def num := input("Compute factorial: ")
 if num.is_digit() then
-    def result := factorial(int(num))
+    def result := factorial(Int(num))
     print("Factorial {num} is: {result}.")
 else
     print("Input was not an integer.")
@@ -279,15 +279,18 @@ This also prevents us from wrapping large code blocks in a `try`, where it might
 This is shown below:
 
 ```mamba
-def a := function_may_throw_err() handle
-    err: MyErr => 
-        print("We have a problem: {err.message}.")
-        return  # we return, halting execution
-    err: MyOtherErr => 
-        print("We have another problem: {err.message}.")
-        0  # ... or we assign default value 0 to a
-        
-print("a has value {a}.")
+def g() =>
+    def a := function_may_throw_err() handle
+        err: MyErr =>
+            print("We have a problem: {err.message}.")
+            return  # we return, halting execution
+        err: MyOtherErr =>
+            print("We have another problem: {err.message}.")
+            0  # ... or we assign default value 0 to a
+
+    print("a has value {a}.")
+
+g()
 ```
 
 If we don't want to use a `handle`, we can simply use `raise` after a statement or exception to show that its execution might result in an exception, but we don't want to handle that here.

--- a/README.md
+++ b/README.md
@@ -16,11 +16,10 @@
     <a href="https://github.com/JSAbrahams/mamba/blob/main/LICENSE">
     <img src="https://img.shields.io/github/license/JSAbrahams/mamba.svg?style=for-the-badge" alt="License"/>
     </a>
-    <img src="https://img.shields.io/badge/Built%20with-%E2%99%A5-red.svg?style=for-the-badge" alt="Built with Love"/>
-    <br/>
     <a href="https://github.com/JSAbrahams/mamba/milestones">
     <img src="https://img.shields.io/github/milestones/open/JSAbrahams/mamba?style=for-the-badge" alt="Active milestones"/>
     </a>
+    <img src="https://img.shields.io/badge/Built%20with-%E2%99%A5-red.svg?style=for-the-badge" alt="Built with Love"/>
 </p>
 
 <h1 align="center">Mamba</h1>

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ print("last message sent before disconnect: \"{my_server.last_sent()}\".")
 my_server.disconnect()
 ```
 
-### 🗃 Type refinement (🇻 0.6+)
+### 🗃 Type refinement (🇻 0.4.1+)
 
 As shown above Mamba has a type system.
 Mamba however also has type refinement features to assign additional properties to types.
@@ -213,7 +213,7 @@ Type refinement allows us to do some additional things:
   that certain conditions hold. We can simply ask whether a given object is a certain state by checking whether it is a
   certain type.
 
-### 🔒 Pure functions (🇻 0.4.1)
+### 🔒 Pure functions (🇻 0.4.1+)
 
 Mamba has features to ensure that functions are pure, meaning that if `x = y`, for any `f`, `f(x) = f(y)`.
 (Except if the output of the function is say `None` or `NaN`.)
@@ -247,7 +247,7 @@ def pure sin(x: Int) =>
     ans
 ```
 
-### ⚠ Error handling (🇻 0.5+)
+### ⚠ Error handling
 
 Unlike Python, Mamba does not have `try` `except` and `finally` (or `try` `catch` as it is sometimes known).
 Instead, we aim to directly handle errors on-site so the origin of errors is more tracable.
@@ -289,8 +289,6 @@ def g() =>
             0  # ... or we assign default value 0 to a
 
     print("a has value {a}.")
-
-g()
 ```
 
 If we don't want to use a `handle`, we can simply use `raise` after a statement or exception to show that its execution might result in an exception, but we don't want to handle that here.

--- a/src/check/resource/primitive/bool.py
+++ b/src/check/resource/primitive/bool.py
@@ -1,5 +1,5 @@
 class bool:
-    def __init__(self, arg: bool) -> bool: pass
+    def __init__(self, arg: Union[int, str, bool]) -> bool: pass
 
     def __bool__(self) -> bool: pass
     def __str__(self) -> str: pass

--- a/tests/resource/valid/readme_example/error_handling.mamba
+++ b/tests/resource/valid/readme_example/error_handling.mamba
@@ -1,8 +1,10 @@
 from ipaddress import IPv4Address
 
+class ServerErr: Exception
 class MyServer(def ip_address: IPv4Address):
-    def send(self) =>
+    def send(self, message: String) =>
         pass
+    def disconnect() => pass
 
 class ConnectedMyServer: MyServer
 

--- a/tests/resource/valid/readme_example/error_handling.mamba
+++ b/tests/resource/valid/readme_example/error_handling.mamba
@@ -1,0 +1,12 @@
+from ipaddress import IPv4Address
+
+class MyServer(def ip_address: IPv4Address)
+
+def fin some_ip := ipaddress.ip_address("151.101.193.140")
+def my_server   := MyServer(some_ip)
+
+def message := "Hello World!"
+my_server.send(message) handle
+    err: ServerErr => print("Error while sending message: \"{message}\": {err}")
+
+if my_server isa ConnectedMyServer then my_server.disconnect()

--- a/tests/resource/valid/readme_example/error_handling.mamba
+++ b/tests/resource/valid/readme_example/error_handling.mamba
@@ -1,6 +1,10 @@
 from ipaddress import IPv4Address
 
-class MyServer(def ip_address: IPv4Address)
+class MyServer(def ip_address: IPv4Address):
+    def send(self) =>
+        pass
+
+class ConnectedMyServer: MyServer
 
 def fin some_ip := ipaddress.ip_address("151.101.193.140")
 def my_server   := MyServer(some_ip)

--- a/tests/resource/valid/readme_example/error_handling_check.py
+++ b/tests/resource/valid/readme_example/error_handling_check.py
@@ -1,0 +1,18 @@
+from ipaddress import IPv4Address
+from server import MyServer
+
+class MyServer:
+    def __init__(self, ip_address: IPv4Address):
+        self.ip_address = ip_address
+
+fin some_ip = ipaddress.ip_address("151.101.193.140")
+my_server = MyServer(some_ip)
+
+def message = "Hello World!"
+try:
+    my_server.send(message)
+except ServerErr as err:
+    print(f"Error while sending message: \"{message}\": {err}")
+
+if isinstance(my_server, ConnectedMyServer):
+    my_server.disconnect()

--- a/tests/resource/valid/readme_example/factorial_dynamic.mamba
+++ b/tests/resource/valid/readme_example/factorial_dynamic.mamba
@@ -1,0 +1,6 @@
+def factorial(x: Int) -> Int => match x
+    0 => 1
+    n =>
+        def ans := 1
+        for i in 1 ..= n do ans := ans * i
+        ans

--- a/tests/resource/valid/readme_example/factorial_dynamic_check.py
+++ b/tests/resource/valid/readme_example/factorial_dynamic_check.py
@@ -1,5 +1,5 @@
 def factorial(x: int) -> int:
-    match x
+    match x:
         case 0:
             return 1
         case n:

--- a/tests/resource/valid/readme_example/fatorial_dynamic_check.py
+++ b/tests/resource/valid/readme_example/fatorial_dynamic_check.py
@@ -1,0 +1,9 @@
+def factorial(x: int) -> int:
+    match x
+        case 0:
+            return 1
+        case n:
+            ans = 1
+            for i in range(1, n, 1):
+                ans = ans * i
+            return ans

--- a/tests/resource/valid/readme_example/handle.mamba
+++ b/tests/resource/valid/readme_example/handle.mamba
@@ -1,14 +1,17 @@
-class MyErr(message: String): Exception
-class MyOtherErr(message: String): Exception
+class MyErr(def message: String): Exception
+class MyOtherErr(def message: String): Exception
 
-def function_may_throw_err() raise [MyErr] => pass
+def function_may_throw_err() -> Int raise [MyErr] => 10
 
-def a := function_may_throw_err() handle
-    err: MyErr =>
-        print("We have a problem: {err.message}.")
-        return  # we return, halting execution
-    err: MyOtherErr =>
-        print("We have another problem: {err.message}.")
-        0  # ... or we assign default value 0 to a
+def g() =>
+    def a := function_may_throw_err() handle
+        err: MyErr =>
+            print("We have a problem: {err.message}.")
+            return  # we return, halting execution
+        err: MyOtherErr =>
+            print("We have another problem: {err.message}.")
+            0  # ... or we assign default value 0 to a
 
-print("a has value {a}.")
+    print("a has value {a}.")
+
+g()

--- a/tests/resource/valid/readme_example/handle.mamba
+++ b/tests/resource/valid/readme_example/handle.mamba
@@ -1,3 +1,8 @@
+class MyErr(message: String): Exception
+class MyOtherErr(message: String): Exception
+
+def function_may_throw_err() raise [MyErr] => pass
+
 def a := function_may_throw_err() handle
     err: MyErr =>
         print("We have a problem: {err.message}.")

--- a/tests/resource/valid/readme_example/handle.mamba
+++ b/tests/resource/valid/readme_example/handle.mamba
@@ -1,0 +1,9 @@
+def a := function_may_throw_err() handle
+    err: MyErr =>
+        print("We have a problem: {err.message}.")
+        return  # we return, halting execution
+    err: MyOtherErr =>
+        print("We have another problem: {err.message}.")
+        0  # ... or we assign default value 0 to a
+
+print("a has value {a}.")

--- a/tests/resource/valid/readme_example/handle_check.py
+++ b/tests/resource/valid/readme_example/handle_check.py
@@ -1,0 +1,27 @@
+class MyErr(Exception):
+    def __init__(self, message: str):
+        Exception.__init__(self)
+        self.message = message
+
+class MyOtherErr(Exception):
+    def __init__(self, message: str):
+        Exception.__init__(self)
+        self.message = message
+
+def function_may_throw_err() -> int:
+    return 10
+
+def g():
+    a = None
+    try:
+        a: int = function_may_throw_err()
+    except MyErr as err:
+        print(f"We have a problem: {err.message}.")
+        return None
+    except MyOtherErr as err:
+        print(f"We have another problem: {err.message}.")
+        a = 0
+
+    print(f"a has value {a}.")
+
+g()

--- a/tests/resource/valid/readme_example/pos_int.mamba
+++ b/tests/resource/valid/readme_example/pos_int.mamba
@@ -1,0 +1,6 @@
+type PosInt: Int when
+    self >= 0 else "Must be greater than 0"
+
+def factorial(x: PosInt) -> PosInt => match x
+    0 => 1
+    n => n * factorial(n - 1)

--- a/tests/resource/valid/readme_example/pure_functions.mamba
+++ b/tests/resource/valid/readme_example/pure_functions.mamba
@@ -1,0 +1,9 @@
+# taylor is immutable, its value does not change during execution
+def fin taylor := 7
+
+# the sin function is pure, its output depends solely on the input
+def pure sin(x: Int) =>
+    def ans := x
+    for i in 1 ..= taylor .. 2 do
+        ans := ans + (x ^ (i + 2)) / (factorial (i + 2))
+    ans

--- a/tests/resource/valid/readme_example/server_class.mamba
+++ b/tests/resource/valid/readme_example/server_class.mamba
@@ -1,0 +1,27 @@
+from ipaddress import IPv4Address
+
+class ServerError(def message: String): Exception(message)
+
+def fin always_the_same_message := "Connected!"
+
+class MyServer(def ip_address: IPv4Address)
+    def is_connected: Bool     := False
+    def _last_message: String? := None
+
+    def last_sent(fin self) -> String raise [ServerError] =>
+        if self._last_message != None then
+            self._last_message
+        else
+            raise ServerError("No last message!")
+
+    def connect(self) =>
+        self.is_connected := True
+        print(always_the_same_message)
+
+    def send(self, message: String) raise [ServerError] =>
+        if self.is_connected then
+            self._last_message := message
+        else
+            raise ServerError("Not connected!")
+
+    def disconnect(self) => self.is_connected := False

--- a/tests/resource/valid/readme_example/server_class_check.py
+++ b/tests/resource/valid/readme_example/server_class_check.py
@@ -1,0 +1,34 @@
+from ipaddress import IPv4Address
+from typing import Option
+
+class ServerError(Exception)
+    def __init__(self, message:str):
+        Exception.__init__(message)
+
+always_the_same_message = "Connected!"
+
+class MyServer(def ip_address: IPv4Address)
+    def is_connected: bool = False
+    def _last_message: Option[str] = None
+
+    def __init__(ip_address: IPv4Address):
+        self.ip_address = ip_address
+
+    def last_sent(self) -> str:
+        if self._last_message != None:
+            return self._last_message
+        else:
+            raise ServerError("No last message!")
+
+    def connect(self):
+        self.is_connected = True
+        print(always_the_same_message)
+
+    def send(self, message: str):
+        if self.is_connected:
+            self._last_message = message
+        else:
+            raise ServerError("Not connected!")
+
+    def disconnect(self):
+        self.is_connected = False

--- a/tests/resource/valid/readme_example/type_refinement.mamba
+++ b/tests/resource/valid/readme_example/type_refinement.mamba
@@ -1,0 +1,27 @@
+from ipaddress import IPv4Address
+
+type Server
+    def ip_address: IPv4Address
+
+    def connect()    -> () raise ServerErr
+    def send(String) -> () raise ServerErr
+    def disconnect() -> ()
+
+type ConnMyServer: MyServer when self.is_connected
+type DisConnMyServer: MyServer when not self.is_connected
+
+class ServerErr(def message: String): Exception(message)
+
+class MyServer(self: DisConnMyServer, def ip_address: IPv4Address): Server
+    def is_connected: Bool     := False
+    def _last_message: String? := None
+
+    def last_sent(self) -> String raise ServerErr => if self.last_message /= None
+        then self._last_message
+        else raise ServerError("No last message!")
+
+    def connect(self: DisConnMyServer) => self.is_connected := True
+
+    def send(self: ConnMyServer, message: String) => self._last_message := message
+
+    def disconnect(self: ConnMyServer) => self.is_connected := False

--- a/tests/resource/valid/readme_example/type_refinement_use.mamba
+++ b/tests/resource/valid/readme_example/type_refinement_use.mamba
@@ -1,0 +1,16 @@
+import ipaddress
+from server import MyServer
+
+def fin some_ip := ipaddress.ip_address("151.101.193.140")
+def my_server   := MyServer(some_ip)
+
+# The default state of http_server is DisconnectedHTTPServer, so we don't need to check that here
+http_server.connect()
+
+# We check the state
+if my_server isa ConnMyServer then
+    # http_server is a Connected Server if the above is true
+    my_server.send("Hello World!")
+
+print("last message sent before disconnect: \"{my_server.last_sent}\".")
+if my_server isa ConnectedMyServer then my_server.disconnect()

--- a/tests/resource/valid/readme_example/use_server.mamba
+++ b/tests/resource/valid/readme_example/use_server.mamba
@@ -1,0 +1,14 @@
+from ipaddress import IPv4Address
+
+class MyServer(def ip_address: IPv4Address)
+
+def fin some_ip := ipaddress.ip_address("151.101.193.140")
+def my_server   := MyServer(some_ip)
+
+http_server.connect()
+if my_server.is_connected then http_server.send("Hello World!")
+
+# This statement may raise an error, but for now de simply leave it as-is
+# See the error handling section for more detail
+print("last message sent before disconnect: \"{my_server.last_sent()}\".")
+my_server.disconnect()

--- a/tests/resource/valid/readme_example/use_server.mamba
+++ b/tests/resource/valid/readme_example/use_server.mamba
@@ -1,6 +1,8 @@
 from ipaddress import IPv4Address
 
-class MyServer(def ip_address: IPv4Address)
+class MyServer(def ip_address: IPv4Address):
+    def is_connected: Bool := True
+    def last_sent() -> String => "dummy"
 
 def fin some_ip := ipaddress.ip_address("151.101.193.140")
 def my_server   := MyServer(some_ip)

--- a/tests/resource/valid/readme_example/use_server_check.py
+++ b/tests/resource/valid/readme_example/use_server_check.py
@@ -2,8 +2,13 @@ from ipaddress import IPv4Address
 from server import MyServer
 
 class MyServer:
+    is_connected: bool = true
+
     def __init__(self, ip_address: IPv4Address):
         self.ip_address = ip_address
+
+    def last_sent() -> str:
+        "dummy"
 
 some_ip = ipaddress.ip_address("151.101.193.140")
 my_server = MyServer(some_ip)

--- a/tests/resource/valid/readme_example/use_server_check.py
+++ b/tests/resource/valid/readme_example/use_server_check.py
@@ -1,0 +1,18 @@
+from ipaddress import IPv4Address
+from server import MyServer
+
+class MyServer:
+    def __init__(self, ip_address: IPv4Address):
+        self.ip_address = ip_address
+
+some_ip = ipaddress.ip_address("151.101.193.140")
+my_server = MyServer(some_ip)
+
+http_server.connect()
+if my_server.is_connected:
+    http_server.send("Hello World!")
+
+# This statement may raise an error, but for now de simply leave it as-is
+# See the error handling section for more detail
+print(f"last message sent before disconnect: \"{my_server.last_sent()}\".")
+my_server.disconnect()

--- a/tests/system/valid/readme_examples.rs
+++ b/tests/system/valid/readme_examples.rs
@@ -34,6 +34,7 @@ fn pure_functions() -> OutTestRet {
 }
 
 #[test]
+#[ignore] // milestone 0.4.2 (Type refinement)
 fn server_class() -> OutTestRet {
     test_directory(true, &["readme_example"], &["readme_example", "target"], "server_class")
 }

--- a/tests/system/valid/readme_examples.rs
+++ b/tests/system/valid/readme_examples.rs
@@ -1,6 +1,55 @@
 use crate::system::{OutTestRet, test_directory};
 
 #[test]
+fn error_handling() -> OutTestRet {
+    test_directory(true, &["readme_example"], &["readme_example", "target"], "error_handling")
+}
+
+#[test]
 fn factorial() -> OutTestRet {
     test_directory(true, &["readme_example"], &["readme_example", "target"], "factorial")
+}
+
+#[test]
+fn factorial_dynamic() -> OutTestRet {
+    test_directory(true, &["readme_example"], &["readme_example", "target"], "factorial_dynamic")
+}
+
+#[test]
+fn handle() -> OutTestRet {
+    test_directory(true, &["readme_example"], &["readme_example", "target"], "handle")
+}
+
+#[test]
+#[ignore] // milestone 0.6 (type refinement)
+fn pos_int() -> OutTestRet {
+    test_directory(true, &["readme_example"], &["readme_example", "target"], "pos_int")
+}
+
+#[test]
+#[ignore] // milestone 0.4.1
+fn pure_functions() -> OutTestRet {
+    test_directory(true, &["readme_example"], &["readme_example", "target"], "pure_functions")
+}
+
+#[test]
+fn server_class() -> OutTestRet {
+    test_directory(true, &["readme_example"], &["readme_example", "target"], "server_class")
+}
+
+#[test]
+#[ignore] // milestone 0.6
+fn type_refinement() -> OutTestRet {
+    test_directory(true, &["readme_example"], &["readme_example", "target"], "type_refinement")
+}
+
+#[test]
+#[ignore] // milestone 0.6
+fn type_refinement_use() -> OutTestRet {
+    test_directory(true, &["readme_example"], &["readme_example", "target"], "type_refinement_use")
+}
+
+#[test]
+fn use_server() -> OutTestRet {
+    test_directory(true, &["readme_example"], &["readme_example", "target"], "use_server")
 }

--- a/tests/system/valid/readme_examples.rs
+++ b/tests/system/valid/readme_examples.rs
@@ -1,6 +1,7 @@
 use crate::system::{OutTestRet, test_directory};
 
 #[test]
+#[ignore] // milestone 0.5
 fn error_handling() -> OutTestRet {
     test_directory(true, &["readme_example"], &["readme_example", "target"], "error_handling")
 }
@@ -50,6 +51,7 @@ fn type_refinement_use() -> OutTestRet {
 }
 
 #[test]
+#[ignore] // milestone 0.5
 fn use_server() -> OutTestRet {
     test_directory(true, &["readme_example"], &["readme_example", "target"], "use_server")
 }


### PR DESCRIPTION
### Summary

Update README examples

We also (accidentally here) update the bool primitive constructor so that it accepts either a `Bool`, `Int`, or `String`.

### Added Tests

*Happy*
- README examples

