### PR TITLE
Fix nullablility rules for field access

### DIFF
--- a/src/check/constrain/constraint/builder.rs
+++ b/src/check/constrain/constraint/builder.rs
@@ -1,4 +1,4 @@
-use crate::check::constrain::constraint::Constraint;
+use crate::check::constrain::constraint::{Constraint, ConstrVariant};
 use crate::check::constrain::constraint::expected::Expected;
 use crate::check::constrain::constraint::iterator::Constraints;
 use crate::check::name::string_name::StringName;
@@ -73,8 +73,12 @@ impl ConstrBuilder {
         self.add_constr(&Constraint::new(msg, parent, child));
     }
 
+    pub fn add_var(&mut self, msg: &str, parent: &Expected, child: &Expected, var: ConstrVariant) {
+        self.add_constr(&Constraint::new_variant(msg, parent, child, var));
+    }
+
     pub fn add_constr(&mut self, constraint: &Constraint) {
-        trace!("Constr: {} == {}, {}: {}", constraint.left.pos, constraint.right.pos, self.level, constraint);
+        trace!("Constr[{}]: {} == {}, {}: {}", self.level, constraint.left.pos, constraint.right.pos, constraint.msg, constraint);
         self.constraints[self.level].1.push(constraint.clone())
     }
 

--- a/src/check/constrain/constraint/iterator.rs
+++ b/src/check/constrain/constraint/iterator.rs
@@ -36,12 +36,6 @@ impl Constraints {
         self.constraints.push_front(constraint)
     }
 
-    /// Append in_class and constraints of constraints to self
-    pub fn append(&mut self, constraints: &mut Constraints) {
-        self.in_class.append(&mut constraints.in_class);
-        self.constraints.append(&mut constraints.constraints);
-    }
-
     pub fn push_constr(&mut self, constr: &Constraint) {
         self.constraints.push_back(constr.clone())
     }

--- a/src/check/constrain/constraint/mod.rs
+++ b/src/check/constrain/constraint/mod.rs
@@ -1,5 +1,4 @@
 use std::fmt::{Display, Error, Formatter};
-use std::ops::Not;
 
 use crate::check::constrain::constraint::expected::Expect::{Access, Function, Type};
 use crate::check::constrain::constraint::expected::Expected;
@@ -21,7 +20,7 @@ pub struct Constraint {
     pub superset: ConstrVariant,
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub enum ConstrVariant {
     Left,
     Right,
@@ -33,25 +32,14 @@ impl Default for ConstrVariant {
     }
 }
 
-impl Not for ConstrVariant {
-    type Output = Self;
-
-    fn not(self) -> Self::Output {
-        match self {
-            ConstrVariant::Left => ConstrVariant::Right,
-            ConstrVariant::Right => ConstrVariant::Left
-        }
-    }
-}
-
 impl Display for Constraint {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), Error> {
         let superset = match &self.superset {
-            ConstrVariant::Left => "{left}  ",
-            ConstrVariant::Right => "{right}  "
+            ConstrVariant::Left => ">=",
+            ConstrVariant::Right => "<="
         };
 
-        write!(f, "{}{} == {}", superset, self.left, self.right)
+        write!(f, "{} {superset} {}", self.left, self.right)
     }
 }
 
@@ -60,10 +48,10 @@ impl Constraint {
     ///
     /// By default, the left side is assumed to be the superset of the right side.
     pub fn new(msg: &str, parent: &Expected, child: &Expected) -> Constraint {
-        Constraint::new_variant(msg, parent, child, &ConstrVariant::default())
+        Constraint::new_variant(msg, parent, child, ConstrVariant::default())
     }
 
-    pub fn new_variant(msg: &str, parent: &Expected, child: &Expected, superset: &ConstrVariant)
+    pub fn new_variant(msg: &str, parent: &Expected, child: &Expected, superset: ConstrVariant)
                        -> Constraint {
         Constraint {
             left: parent.clone(),

--- a/src/check/constrain/generate/call.rs
+++ b/src/check/constrain/generate/call.rs
@@ -48,8 +48,8 @@ pub fn gen_call(
 
                 constr.add(
                     "reassign",
-                    &Expected::try_from((left, &env_assigned_to.var_mappings))?,
-                    &Expected::try_from((right, &env_assigned_to.var_mappings))?,
+                    &Expected::try_from((left, &env.var_mappings))?,
+                    &Expected::try_from((right, &env.var_mappings))?,
                 );
                 generate(right, &env_assigned_to, ctx, constr)?;
                 generate(left, &env_assigned_to, ctx, constr)?;

--- a/src/check/constrain/generate/call.rs
+++ b/src/check/constrain/generate/call.rs
@@ -103,7 +103,7 @@ pub fn gen_call(
                     &fun_ret_exp,
                 );
 
-                check_raises_caught(&constr, &fun.raises.names, env, ctx, ast.pos)?;
+                check_raises_caught(constr, &fun.raises.names, env, ctx, ast.pos)?;
                 env.clone()
             })
         }

--- a/src/check/constrain/generate/class.rs
+++ b/src/check/constrain/generate/class.rs
@@ -31,7 +31,7 @@ pub fn gen_class(
         Node::TypeAlias { conditions, isa, .. } => constrain_class_body(conditions, isa, env, ctx, constr),
         Node::Condition { cond, el: Some(el) } => {
             generate(cond, env, ctx, constr)?;
-            generate(el, &env, ctx, constr)
+            generate(el, env, ctx, constr)
         }
         Node::Condition { cond, .. } => generate(cond, env, ctx, constr),
 

--- a/src/check/constrain/generate/class.rs
+++ b/src/check/constrain/generate/class.rs
@@ -82,13 +82,13 @@ pub fn property_from_field(
     let field_ty = Expected::new(pos, &Type { name: field.ty.clone() });
 
     let env = env.insert_var(field.mutable, &field.name, &field_ty);
-    constr.add("field property", &field_ty, &property_call);
+    constr.add("class field type", &field_ty, &property_call);
 
     let access = Expected::new(pos, &Access {
         entity: Box::new(Expected::new(pos, &Type { name: Name::from(class) })),
         name: Box::new(Expected::new(pos, &Field { name: field.name.clone() })),
     });
 
-    constr.add("field property", &property_call, &access);
+    constr.add("class field access", &property_call, &access);
     Ok(env)
 }

--- a/src/check/constrain/generate/control_flow.rs
+++ b/src/check/constrain/generate/control_flow.rs
@@ -60,10 +60,8 @@ pub fn gen_flow(
                 let then = Expected::try_from((then, &then_env.var_mappings))?;
                 let el = Expected::try_from((el, &else_env.var_mappings))?;
 
-                let then_constr = Constraint::new_variant("if then branch", &if_expr, &then, &ConstrVariant::Left);
-                constr.add_constr(&then_constr);
-                let else_constr = Constraint::new_variant("if else branch", &if_expr, &el, &ConstrVariant::Left);
-                constr.add_constr(&else_constr);
+                constr.add_var("if then branch", &if_expr, &then, ConstrVariant::default());
+                constr.add_var("if else branch", &if_expr, &el, ConstrVariant::default());
             }
 
             constr.exit_set(ast.pos)?;

--- a/src/check/constrain/generate/definition.rs
+++ b/src/check/constrain/generate/definition.rs
@@ -195,7 +195,7 @@ pub fn identifier_from_var(
 
     let var_expect = Expected::try_from((var, &env_with_var.var_mappings))?;
     if let Some(ty) = ty {
-        let ty_exp = Expected::new(ty.pos, &Type { name: Name::try_from(ty.deref())? });
+        let ty_exp = Expected::new(var.pos, &Type { name: Name::try_from(ty.deref())? });
         constr.add("variable and type", &ty_exp, &var_expect);
     }
     if let Some(expr) = expr {

--- a/src/check/constrain/unify/expression/mod.rs
+++ b/src/check/constrain/unify/expression/mod.rs
@@ -21,14 +21,13 @@ pub fn unify_expression(constraint: &Constraint, constraints: &mut Constraints, 
         // Not sure if necessary, but exception made for tuple
         (Tuple { elements }, Expression { ast: AST { node: Node::Tuple { elements: ast_elements }, .. } }) |
         (Expression { ast: AST { node: Node::Tuple { elements: ast_elements }, .. } }, Tuple { elements }) => {
-            let mut constraints = substitute(left, right, constraints, count, total)?;
+            substitute(constraints, left, right, count, total)?;
 
             for pair in ast_elements.iter().cloned().zip_longest(elements.iter()) {
                 match &pair {
                     Both(ast, exp) => {
                         let expect = Expression { ast: ast.clone() };
-                        let l_ty = Expected::new(left.pos, &expect);
-                        constraints.push("tuple", &l_ty, exp)
+                        constraints.push("tuple", &Expected::new(left.pos, &expect), exp)
                     }
                     _ => {
                         let msg = format!("Expected tuple with {} elements, was {}", elements.len(), ast_elements.len());
@@ -37,16 +36,16 @@ pub fn unify_expression(constraint: &Constraint, constraints: &mut Constraints, 
                 }
             }
 
-            unify_link(&mut constraints, finished, ctx, total)
+            unify_link(constraints, finished, ctx, total)
         }
 
         (Expression { .. }, _) if constraint.superset == ConstrVariant::Left => {
-            let mut constraints = substitute(right, left, constraints, count, total)?;
-            unify_link(&mut constraints, finished, ctx, total)
+            substitute(constraints, right, left, count, total)?;
+            unify_link(constraints, finished, ctx, total)
         }
         _ => {
-            let mut constraints = substitute(left, right, constraints, count, total)?;
-            unify_link(&mut constraints, finished, ctx, total)
+            substitute(constraints, left, right, count, total)?;
+            unify_link(constraints, finished, ctx, total)
         }
     }
 }

--- a/src/check/constrain/unify/expression/mod.rs
+++ b/src/check/constrain/unify/expression/mod.rs
@@ -35,17 +35,12 @@ pub fn unify_expression(constraint: &Constraint, constraints: &mut Constraints, 
                     }
                 }
             }
-
-            unify_link(constraints, finished, ctx, total)
         }
 
-        (Expression { .. }, _) if constraint.superset == ConstrVariant::Left => {
-            substitute(constraints, right, left, count, total)?;
-            unify_link(constraints, finished, ctx, total)
-        }
-        _ => {
-            substitute(constraints, left, right, count, total)?;
-            unify_link(constraints, finished, ctx, total)
-        }
+        (Expression { .. }, _) if constraint.superset == ConstrVariant::Left =>
+            substitute(constraints, right, left, count, total)?,
+        _ => substitute(constraints, left, right, count, total)?
     }
+
+    unify_link(constraints, finished, ctx, total)
 }

--- a/src/check/constrain/unify/expression/substitute.rs
+++ b/src/check/constrain/unify/expression/substitute.rs
@@ -1,6 +1,6 @@
 use crate::check::constrain::constraint::expected::{Expect, Expected};
 use crate::check::constrain::constraint::iterator::Constraints;
-use crate::check::result::TypeResult;
+use crate::check::constrain::Unified;
 
 /// Substitute old expression with new.
 ///
@@ -18,7 +18,7 @@ pub fn substitute(
     old: &Expected,
     offset: usize,
     total: usize,
-) -> TypeResult<()> {
+) -> Unified<()> {
     let mut constraint_pos = offset;
     trace!("{:width$} [subbing {}\\{}]  {}  <=  {}", "", offset, total, old, new, width = 30);
 

--- a/src/check/constrain/unify/function.rs
+++ b/src/check/constrain/unify/function.rs
@@ -80,6 +80,7 @@ pub fn unify_function(
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 fn access(
     constraints: &mut Constraints,
     finished: &mut Finished,

--- a/src/check/constrain/unify/function.rs
+++ b/src/check/constrain/unify/function.rs
@@ -188,7 +188,11 @@ fn unify_fun_arg(
                     })
                     .collect::<Result<Vec<Name>, _>>()?;
 
-                let name = names.iter().fold(Name::empty(), |name, f_name| name.union(f_name));
+                // Constraint should pass if just one is superset of function arg
+                let name = names
+                    .iter()
+                    .fold(Name::empty(), |name, f_name| name.union(f_name))
+                    .as_any();
                 let ctx_arg_ty = Expected::new(expected.pos, &Type { name });
                 constr.push("function argument", &ctx_arg_ty, expected);
                 added += 1;

--- a/src/check/constrain/unify/function.rs
+++ b/src/check/constrain/unify/function.rs
@@ -37,7 +37,7 @@ pub fn unify_function(
                 .map(|n| match n.variant {
                     NameVariant::Fun(arguments, _) => Ok(arguments),
                     other => {
-                        let msg = format!("A '{}' does not take arguments", other);
+                        let msg = format!("A '{other}' does not take arguments");
                         Err(vec![TypeErr::new(right.pos, &msg)])
                     }
                 })
@@ -68,68 +68,51 @@ pub fn unify_function(
             unify_link(constraints, finished, ctx, total + count)
         }
 
-        (Access { entity, name }, _) => {
-            if let Type { name: entity_name } = &entity.expect {
-                match &name.expect {
-                    Field { name } => {
-                        field_access(constraints, finished, ctx, entity_name, name, left, right, total)
-                    }
-                    Function { name, args } => function_access(
-                        constraints,
-                        finished,
-                        ctx,
-                        entity_name,
-                        name,
-                        args,
-                        left,
-                        right,
-                        total,
-                    ),
-                    _ => {
-                        let mut constr = reinsert(constraints, constraint, total)?;
-                        unify_link(&mut constr, finished, ctx, total)
-                    }
-                }
-            } else {
-                let mut constr = reinsert(constraints, constraint, total)?;
-                unify_link(&mut constr, finished, ctx, total)
-            }
-        }
-        (_, Access { entity, name }) => {
-            if let Type { name: entity_name } = &entity.expect {
-                match &name.expect {
-                    Field { name } => {
-                        field_access(constraints, finished, ctx, entity_name, name, right, left, total)
-                    }
-                    Function { name, args } => function_access(
-                        constraints,
-                        finished,
-                        ctx,
-                        entity_name,
-                        name,
-                        args,
-                        right,
-                        left,
-                        total,
-                    ),
-                    _ => {
-                        let mut constr = reinsert(constraints, constraint, total)?;
-                        unify_link(&mut constr, finished, ctx, total)
-                    }
-                }
-            } else {
-                let mut constr = reinsert(constraints, constraint, total)?;
-                unify_link(&mut constr, finished, ctx, total)
-            }
-        }
+        (Access { entity, name }, _) =>
+            access(constraints, finished, ctx, constraint, entity, name, true, total),
+        (_, Access { entity, name }) =>
+            access(constraints, finished, ctx, constraint, entity, name, false, total),
 
         (l_exp, r_exp) => {
-            let msg = format!("Unifying function: Expected a '{}', was a '{}'", l_exp, r_exp);
+            let msg = format!("Unifying function: Expected a '{l_exp}', was a '{r_exp}'");
             Err(vec![TypeErr::new(left.pos, &msg)])
         }
     }
 }
 
+fn access(
+    constraints: &mut Constraints,
+    finished: &mut Finished,
+    ctx: &Context,
+    constraint: &Constraint,
+    entity: &Expected,
+    name: &Box<Expected>,
+    access_left: bool,
+    total: usize,
+) -> Unified {
+    let (left, right) = (&constraint.left, &constraint.right);
+    let (left, right) = if access_left { (left, right) } else { (right, left) };
+
+    if let Type { name: entity_name } = &entity.expect {
+        match &name.expect {
+            Field { name } => {
+                field_access(constraints, finished, ctx, entity_name, name, left, right, total)
+            }
+            Function { name, args } => {
+                function_access(constraints, finished, ctx, entity_name, name, args, left, right, total)
+            }
+            _ => {
+                reinsert(constraints, constraint, total)?;
+                unify_link(constraints, finished, ctx, total)
+            }
+        }
+    } else {
+        reinsert(constraints, constraint, total)?;
+        unify_link(constraints, finished, ctx, total)
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
 fn field_access(
     constraints: &mut Constraints,
     finished: &mut Finished,
@@ -144,7 +127,7 @@ fn field_access(
     let fields = ctx.class(entity_name, accessed.pos)?.field(name, ctx, accessed.pos)?;
     for field in fields.union {
         let field_ty_exp = Expected::new(accessed.pos, &Type { name: field.ty });
-        constraints.push("field access", &field_ty_exp, other);
+        constraints.push("field access", other, &field_ty_exp);
         pushed += 1;
     }
 
@@ -201,8 +184,7 @@ fn unify_fun_arg(
                     .iter()
                     .map(|f_arg| {
                         f_arg.ty.clone().ok_or({
-                            let msg = format!("Argument '{}' has no type", f_arg);
-                            vec![TypeErr::new(pos, &msg)]
+                            vec![TypeErr::new(pos, &format!("Argument '{f_arg}' has no type"))]
                         })
                     })
                     .collect::<Result<Vec<Name>, _>>()?;

--- a/src/check/constrain/unify/function.rs
+++ b/src/check/constrain/unify/function.rs
@@ -144,7 +144,7 @@ fn field_access(
     let fields = ctx.class(entity_name, accessed.pos)?.field(name, ctx, accessed.pos)?;
     for field in fields.union {
         let field_ty_exp = Expected::new(accessed.pos, &Type { name: field.ty });
-        constraints.push("field access", other, &field_ty_exp);
+        constraints.push("field access", &field_ty_exp, other);
         pushed += 1;
     }
 

--- a/src/check/constrain/unify/function.rs
+++ b/src/check/constrain/unify/function.rs
@@ -127,7 +127,7 @@ fn field_access(
     let fields = ctx.class(entity_name, accessed.pos)?.field(name, ctx, accessed.pos)?;
     for field in fields.union {
         let field_ty_exp = Expected::new(accessed.pos, &Type { name: field.ty });
-        constraints.push("field access", other, &field_ty_exp);
+        constraints.push("field access", &field_ty_exp, other);
         pushed += 1;
     }
 
@@ -164,17 +164,16 @@ fn function_access(
         }
     }
 
-    let (mut constr, added) = unify_fun_arg(&possible_args, args, constraints, accessed.pos)?;
-    unify_link(&mut constr, finished, ctx, total + added + pushed)
+    let added = unify_fun_arg(&possible_args, args, constraints, accessed.pos)?;
+    unify_link(constraints, finished, ctx, total + added + pushed)
 }
 
 fn unify_fun_arg(
     ctx_f_args: &[HashSet<FunctionArg>],
     args: &[Expected],
-    constr: &Constraints,
+    constr: &mut Constraints,
     pos: Position,
-) -> Unified<(Constraints, usize)> {
-    let mut constr = constr.clone();
+) -> Unified<usize> {
     let mut added = 0;
 
     for either_or_both in ctx_f_args.iter().zip_longest(args.iter()) {
@@ -206,5 +205,5 @@ fn unify_fun_arg(
         }
     }
 
-    Ok((constr, added))
+    Ok(added)
 }

--- a/src/check/constrain/unify/function.rs
+++ b/src/check/constrain/unify/function.rs
@@ -217,7 +217,7 @@ fn unify_fun_arg(
                 return Err(vec![TypeErr::new(pos, &msg)]);
             }
             EitherOrBoth::Right(_) => {
-                let msg = format!("Function takes only {} arguments", f_args.len());
+                let msg = format!("Function takes only {} {}", f_args.len(), if f_args.len() == 1 { "argument" } else { "arguments" });
                 return Err(vec![TypeErr::new(pos, &msg)]);
             }
             _ => {}

--- a/src/check/constrain/unify/function.rs
+++ b/src/check/constrain/unify/function.rs
@@ -186,7 +186,7 @@ fn function_access(
 }
 
 fn unify_fun_arg(
-    f_args: &[HashSet<FunctionArg>],
+    ctx_f_args: &[HashSet<FunctionArg>],
     args: &[Expected],
     constr: &Constraints,
     pos: Position,
@@ -194,10 +194,10 @@ fn unify_fun_arg(
     let mut constr = constr.clone();
     let mut added = 0;
 
-    for either_or_both in f_args.iter().zip_longest(args.iter()) {
+    for either_or_both in ctx_f_args.iter().zip_longest(args.iter()) {
         match either_or_both {
-            EitherOrBoth::Both(fun_arg, expected) => {
-                let names = fun_arg
+            EitherOrBoth::Both(ctx_f_arg, expected) => {
+                let names = ctx_f_arg
                     .iter()
                     .map(|f_arg| {
                         f_arg.ty.clone().ok_or({
@@ -208,8 +208,8 @@ fn unify_fun_arg(
                     .collect::<Result<Vec<Name>, _>>()?;
 
                 let name = names.iter().fold(Name::empty(), |name, f_name| name.union(f_name));
-                let ty = Expected::new(expected.pos, &Type { name });
-                constr.push("function argument", &ty, expected);
+                let ctx_arg_ty = Expected::new(expected.pos, &Type { name });
+                constr.push("function argument", &ctx_arg_ty, expected);
                 added += 1;
             }
             EitherOrBoth::Left(fun_arg) if !fun_arg.iter().any(|a| !a.has_default) => {
@@ -217,7 +217,7 @@ fn unify_fun_arg(
                 return Err(vec![TypeErr::new(pos, &msg)]);
             }
             EitherOrBoth::Right(_) => {
-                let msg = format!("Function takes only {} {}", f_args.len(), if f_args.len() == 1 { "argument" } else { "arguments" });
+                let msg = format!("Function takes only {} {}", ctx_f_args.len(), if ctx_f_args.len() == 1 { "argument" } else { "arguments" });
                 return Err(vec![TypeErr::new(pos, &msg)]);
             }
             _ => {}

--- a/src/check/constrain/unify/link.rs
+++ b/src/check/constrain/unify/link.rs
@@ -21,7 +21,7 @@ pub fn unify_link(constraints: &mut Constraints, finished: &mut Finished, ctx: &
 
         let pos = format!("{}={} ", left.pos, right.pos);
         let count = if constraints.len() <= total { total - constraints.len() } else { 0 };
-        let unify = format!("{}\\{}", count, total);
+        let unify = format!("{count}\\{total}");
         let msg =
             if constraint.msg.is_empty() { String::new() } else { format!(" {}", constraint.msg) };
 

--- a/src/check/constrain/unify/link.rs
+++ b/src/check/constrain/unify/link.rs
@@ -56,8 +56,8 @@ pub fn unify_link(constraints: &mut Constraints, finished: &mut Finished, ctx: &
             }
 
             _ => {
-                let mut constr = reinsert(constraints, constraint, total)?;
-                unify_link(&mut constr, finished, ctx, total + 1)
+                reinsert(constraints, constraint, total)?;
+                unify_link(constraints, finished, ctx, total + 1)
             }
         }
     } else {
@@ -69,11 +69,11 @@ pub fn unify_link(constraints: &mut Constraints, finished: &mut Finished, ctx: &
 ///
 /// The amount of attempts is a counter which states how often we allow
 /// reinserts.
-pub fn reinsert(constr: &mut Constraints, constraint: &Constraint, total: usize) -> Unified<Constraints> {
+pub fn reinsert(constr: &mut Constraints, constraint: &Constraint, total: usize) -> Unified<()> {
     let pos = format!("({}={}) ", constraint.left.pos.start, constraint.right.pos.start);
     let count = format!("[reinserting {}\\{}] ", total - constr.len(), total);
     trace!("{:width$}{}{}", pos, count, constraint, width = 17);
 
     constr.reinsert(constraint)?;
-    Ok(constr.clone())
+    Ok(())
 }

--- a/src/check/constrain/unify/mod.rs
+++ b/src/check/constrain/unify/mod.rs
@@ -15,7 +15,7 @@ mod expression;
 mod function;
 mod ty;
 
-pub fn unify(all_constraints: &[Constraints], ctx: &Context) -> Unified<Finished> {
+pub fn unify(all_constraints: &[Constraints], ctx: &Context) -> Unified {
     let mut count = 1;
     let mut finished = Finished::new();
     let (_, errs): (Vec<_>, Vec<_>) = all_constraints

--- a/src/check/constrain/unify/mod.rs
+++ b/src/check/constrain/unify/mod.rs
@@ -40,7 +40,7 @@ pub fn unify(all_constraints: &[Constraints], ctx: &Context) -> Unified {
                     newline_delimited(e.clone().into_iter().map(|e| format!(
                         "{}{}",
                         if let Some(pos) = e.position {
-                            format!(" at {}: ", pos)
+                            format!(" at {pos}: ")
                         } else {
                             String::new()
                         },

--- a/src/check/constrain/unify/ty.rs
+++ b/src/check/constrain/unify/ty.rs
@@ -48,10 +48,10 @@ pub fn unify_type(
                 finished.push_ty(right.pos, &l_ty.union(r_ty));
                 unify_link(constraints, finished, ctx, total)
             } else if constraint.superset == ConstrVariant::Left {
-                let msg = format!("Unifying two types: Expected {}, was {}", left, right);
+                let msg = format!("Unifying two types within {}: Expected {left}, was {right}", constraint.msg);
                 Err(vec![TypeErr::new(left.pos, &msg)])
             } else {
-                let msg = format!("Unifying two types: Expected {}, was {}", right, left);
+                let msg = format!("Unifying two types within {}: Expected {right}, was {left}", constraint.msg);
                 Err(vec![TypeErr::new(right.pos, &msg)])
             }
         }

--- a/src/check/context/clss/generic.rs
+++ b/src/check/context/clss/generic.rs
@@ -10,7 +10,7 @@ use crate::check::context::field::generic::{GenericField, GenericFields};
 use crate::check::context::function::generic::GenericFunction;
 use crate::check::context::function::INIT;
 use crate::check::context::parent::generic::GenericParent;
-use crate::check::name::{Any, Name};
+use crate::check::name::{Any, Empty, Name};
 use crate::check::name::string_name::StringName;
 use crate::check::result::{TypeErr, TypeResult};
 use crate::common::position::Position;
@@ -74,7 +74,7 @@ impl Any for GenericClass {
             pure: false,
             pos: Default::default(),
             arguments: vec![],
-            raises: Name { names: Default::default() },
+            raises: Name::empty(),
             in_class: None,
             ret_ty: None,
         });

--- a/src/check/name/generic.rs
+++ b/src/check/name/generic.rs
@@ -22,7 +22,7 @@ impl TryFrom<&AST> for Name {
         } else {
             vec![TrueName::try_from(ast)?].into_iter().collect::<HashSet<_>>()
         };
-        Ok(Name { names })
+        Ok(Name { names, any: false })
     }
 }
 

--- a/src/check/name/mod.rs
+++ b/src/check/name/mod.rs
@@ -108,7 +108,7 @@ pub fn match_type_direct(
                 mapping.insert(id.clone().object(pos)?, (*mutable, Name::from(name)));
                 Ok(mapping)
             } else {
-                let msg = format!("Cannot match {} with a '{}'", identifier, name);
+                let msg = format!("Cannot match {identifier} with a '{name}'");
                 Err(vec![TypeErr::new(pos, &msg)])
             }
         }
@@ -230,7 +230,7 @@ impl Display for Name {
             if self.names.len() > 1 {
                 write!(f, "{{{}}}", comma_delm(&self.names))
             } else {
-                write!(f, "{}", first)
+                write!(f, "{first}")
             }
         } else {
             write!(f, "()")

--- a/src/check/name/mod.rs
+++ b/src/check/name/mod.rs
@@ -64,6 +64,7 @@ pub trait ColType {
 #[derive(Debug, Clone, Eq)]
 pub struct Name {
     pub names: HashSet<TrueName>,
+    pub any: bool,
 }
 
 impl Any for Name {
@@ -149,7 +150,7 @@ impl Ord for Name {
 
 impl Mutable for Name {
     fn as_mutable(&self) -> Self {
-        Name { names: self.names.iter().map(|n| n.as_mutable()).collect() }
+        Name { names: self.names.iter().map(|n| n.as_mutable()).collect(), ..self.clone() }
     }
 }
 
@@ -172,7 +173,7 @@ impl Union<Name> for Name {
             names
         };
 
-        Name { names }
+        Name { names, any: self.any || name.any }
     }
 }
 
@@ -240,7 +241,7 @@ impl Display for Name {
 impl From<&TrueName> for Name {
     fn from(name: &TrueName) -> Self {
         let names: HashSet<TrueName> = HashSet::from_iter(vec![name.clone()]);
-        Name { names }
+        Name { names, any: false }
     }
 }
 
@@ -260,8 +261,11 @@ impl IsSuperSet<Name> for Name {
             let is_superset = |s_name: &TrueName| s_name.is_superset_of(name, ctx, pos);
             let any_superset: Vec<bool> =
                 self.names.iter().map(is_superset).collect::<Result<_, _>>()?;
-            if !any_superset.iter().any(|b| *b) {
+
+            if !any_superset.clone().iter().any(|b| *b) && !other.any {
                 return Ok(false);
+            } else if any_superset.clone().iter().any(|b| *b) && other.any {
+                return Ok(true);
             }
         }
 
@@ -279,7 +283,7 @@ impl Nullable for Name {
     }
 
     fn as_nullable(&self) -> Self {
-        Name { names: self.names.iter().map(|n| n.as_nullable()).collect() }
+        Name { names: self.names.iter().map(|n| n.as_nullable()).collect(), ..self.clone() }
     }
 }
 
@@ -289,7 +293,7 @@ impl Empty for Name {
     }
 
     fn empty() -> Name {
-        Name { names: HashSet::new() }
+        Name { names: HashSet::new(), any: false }
     }
 }
 
@@ -297,18 +301,24 @@ impl Substitute for Name {
     fn substitute(&self, generics: &HashMap<Name, Name>, pos: Position) -> TypeResult<Name> {
         let names =
             self.names.iter().map(|n| n.substitute(generics, pos)).collect::<Result<_, _>>()?;
-        Ok(Name { names })
+        Ok(Name { names, any: self.any })
     }
 }
 
 impl Name {
-    pub fn trim_any(&self) -> Name {
+    pub fn trim_any(&self) -> Self {
         let names = self.names.iter().filter(|n| **n != TrueName::any()).cloned().collect();
-        Name { names }
+        Name { names, ..self.clone() }
     }
 
     pub fn as_direct(&self) -> HashSet<StringName> {
         self.names.iter().map(StringName::from).collect()
+    }
+
+    /// Any means that if one check if another [is_superset_of] self, then it will be true if it is
+    /// just a superset of one.
+    pub fn as_any(&self) -> Self {
+        Name { any: true, ..self.clone() }
     }
 
     pub fn contains(&self, item: &TrueName) -> bool {
@@ -383,6 +393,24 @@ mod tests {
 
         let ctx = Context::default().into_with_primitives().unwrap();
         assert!(union_1.is_superset_of(&union_2, &ctx, Position::default()).unwrap())
+    }
+
+    #[test]
+    fn is_superset_any_only_one() {
+        let union_1 = Name::from(&vec![TrueName::from(BOOL), TrueName::from(INT)]).as_any();
+        let union_2 = Name::from(BOOL);
+
+        let ctx = Context::default().into_with_primitives().unwrap();
+        assert!(union_2.is_superset_of(&union_1, &ctx, Position::default()).unwrap())
+    }
+
+    #[test]
+    fn is_superset_any_no_one() {
+        let union_1 = Name::from(&vec![TrueName::from(BOOL), TrueName::from(INT)]).as_any();
+        let union_2 = Name::from(FLOAT);
+
+        let ctx = Context::default().into_with_primitives().unwrap();
+        assert!(union_2.is_superset_of(&union_1, &ctx, Position::default()).unwrap())
     }
 
     #[test]

--- a/src/check/name/string_name/mod.rs
+++ b/src/check/name/string_name/mod.rs
@@ -105,20 +105,15 @@ impl ColType for StringName {
                         fun.union.iter().fold(Name::empty(), |name, i| name.union(&i.ret_ty));
                     Ok(Some(ret_name))
                 } else {
-                    let msg = format!(
-                        "Cannot find iterator '{}' for iterable type '{}'",
-                        iter_name, self
-                    );
+                    let msg = format!("Cannot find iterator '{iter_name}' for iterable type '{self}'");
                     Err(vec![TypeErr::new(pos, &msg)])
                 }
             } else {
-                let msg =
-                    format!("Type '{}' is not iterable, it does not define an iterator.", self);
+                let msg = format!("Type '{self}' is not iterable, it does not define an iterator.");
                 Err(vec![TypeErr::new(pos, &msg)])
             }
         } else {
-            let msg = format!("'{}' is undefined", self);
-            Err(vec![TypeErr::new(pos, &msg)])
+            Err(vec![TypeErr::new(pos, &format!("'{self}' is undefined"))])
         }
     }
 }
@@ -171,7 +166,7 @@ impl Substitute for StringName {
         if let Some(name) = generics.get(&Name::from(self)) {
             let string_names = name.as_direct();
             if string_names.len() > 1 {
-                let msg = format!("Cannot substitute type union {}", name);
+                let msg = format!("Cannot substitute type union {name}");
                 return Err(vec![TypeErr::new(pos, &msg)]);
             }
 
@@ -179,8 +174,7 @@ impl Substitute for StringName {
                 return Ok(string_name.clone());
             }
 
-            let msg = format!("{} incorrect name", name);
-            Err(vec![TypeErr::new(pos, &msg)])
+            Err(vec![TypeErr::new(pos, &format!("{name} incorrect name"))])
         } else {
             Ok(StringName {
                 name: self.name.clone(),

--- a/src/check/name/string_name/mod.rs
+++ b/src/check/name/string_name/mod.rs
@@ -39,7 +39,7 @@ impl PartialEq for StringName {
 
 impl Name {
     fn full_name(&self) -> Self {
-        Name { names: self.names.iter().map(TrueName::full_name).collect() }
+        Name { names: self.names.iter().map(TrueName::full_name).collect(), ..self.clone() }
     }
 }
 
@@ -144,7 +144,7 @@ impl IsSuperSet<StringName> for StringName {
 
 impl From<&StringName> for Name {
     fn from(name: &StringName) -> Self {
-        Name { names: HashSet::from_iter(vec![TrueName::from(name)]) }
+        Name { names: HashSet::from_iter(vec![TrueName::from(name)]), any: false }
     }
 }
 
@@ -152,7 +152,7 @@ impl Union<StringName> for Name {
     fn union(&self, name: &StringName) -> Self {
         let mut names = self.names.clone();
         names.insert(TrueName::from(name));
-        Name { names }
+        Name { names, ..self.clone() }
     }
 }
 

--- a/src/check/name/true_name/mod.rs
+++ b/src/check/name/true_name/mod.rs
@@ -121,7 +121,7 @@ impl Union<TrueName> for Name {
     fn union(&self, name: &TrueName) -> Self {
         let mut names = self.names.clone();
         names.insert(name.clone());
-        Name { names }
+        Name { names, ..self.clone() }
     }
 }
 
@@ -167,7 +167,7 @@ impl From<&TrueName> for StringName {
 impl From<&Vec<TrueName>> for Name {
     fn from(names: &Vec<TrueName>) -> Self {
         let names: HashSet<TrueName> = HashSet::from_iter(names.iter().cloned());
-        Name { names }
+        Name { names, any: false }
     }
 }
 

--- a/src/common/position.rs
+++ b/src/common/position.rs
@@ -12,6 +12,8 @@ impl Display for Position {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), Error> {
         if self.start == self.end {
             write!(f, "({})", self.start)
+        } else if self.start.line == self.end.line {
+            write!(f, "({}-{})", self.start, self.end.pos)
         } else {
             write!(f, "({}-{})", self.start, self.end)
         }

--- a/tests/check/invalid/definition.rs
+++ b/tests/check/invalid/definition.rs
@@ -89,7 +89,6 @@ fn nested_non_mut_field() {
 }
 
 #[test]
-#[ignore] // Ignore mutability for now
 fn reassign_non_mut() {
     let source = resource_content(false, &["type", "definition"], "reassign_non_mut.mamba");
     check_all(&[*parse(&source).unwrap()]).unwrap_err();

--- a/tests/check/valid/definition.rs
+++ b/tests/check/valid/definition.rs
@@ -9,7 +9,6 @@ fn all_mutable_in_call_chain() -> CheckTestRet {
 }
 
 #[test]
-#[ignore]
 fn nested_mut_field() -> CheckTestRet {
     let source = resource_content(true, &["definition"], "nested_mut_field.mamba");
     check_test(&source)
@@ -30,14 +29,12 @@ fn nested_function() -> CheckTestRet {
 }
 
 #[test]
-#[ignore] // Ignore tuples for now
 fn tuple_modify_mut() -> CheckTestRet {
     let source = resource_content(true, &["definition"], "tuple_modify_mut.mamba");
     check_test(&source)
 }
 
 #[test]
-#[ignore] // Ignore tuples for now
 fn tuple_modify_outer_mut() -> CheckTestRet {
     let source = resource_content(true, &["definition"], "tuple_modify_outer_mut.mamba");
     check_test(&source)

--- a/tests/resource/valid/class/assign_to_nullable_field.mamba
+++ b/tests/resource/valid/class/assign_to_nullable_field.mamba
@@ -1,0 +1,5 @@
+class MyServer()
+    def _message: String? := None
+
+    def send(self, message: String) =>
+        self._message := message

--- a/tests/resource/valid/class/assign_to_nullable_field.mamba
+++ b/tests/resource/valid/class/assign_to_nullable_field.mamba
@@ -1,5 +1,5 @@
 class MyServer()
     def _message: String? := None
 
-    def send(self, message: String) =>
-        self._message := message
+    def send(self, x: String) =>
+        self._message := x

--- a/tests/resource/valid/class/assign_to_nullable_field_check.py
+++ b/tests/resource/valid/class/assign_to_nullable_field_check.py
@@ -3,5 +3,5 @@ from typing import Optional
 class MyServer:
     _message: Optional[str] = None
 
-    def send(self, message: str):
-        self._message = message
+    def send(self, x: str):
+        self._message = x

--- a/tests/resource/valid/class/assign_to_nullable_field_check.py
+++ b/tests/resource/valid/class/assign_to_nullable_field_check.py
@@ -1,0 +1,7 @@
+from typing import Option
+
+class MyServer:
+    _message: Option[str] = None
+
+    def send(self, message: str):
+        self._message := message

--- a/tests/resource/valid/class/assign_to_nullable_field_check.py
+++ b/tests/resource/valid/class/assign_to_nullable_field_check.py
@@ -1,7 +1,7 @@
-from typing import Option
+from typing import Optional
 
 class MyServer:
-    _message: Option[str] = None
+    _message: Optional[str] = None
 
     def send(self, message: str):
-        self._message := message
+        self._message = message

--- a/tests/resource/valid/definition/assign_to_nullable_in_function.mamba
+++ b/tests/resource/valid/definition/assign_to_nullable_in_function.mamba
@@ -1,0 +1,3 @@
+def send(message: String) =>
+    def _message: String? := None
+    _message := message

--- a/tests/resource/valid/definition/assign_to_nullable_in_function_check.py
+++ b/tests/resource/valid/definition/assign_to_nullable_in_function_check.py
@@ -1,0 +1,5 @@
+from typing import Optional
+
+def send(message: str):
+    _message: Optional[str] = None
+    _message = message

--- a/tests/resource/valid/operation/greater_than_int.mamba
+++ b/tests/resource/valid/operation/greater_than_int.mamba
@@ -1,0 +1,6 @@
+class MyClass(def a: Int)
+    def f(self) -> Bool => self.a > 10
+
+def a := MyClass(10)
+
+a.f()

--- a/tests/resource/valid/operation/greater_than_int_check.py
+++ b/tests/resource/valid/operation/greater_than_int_check.py
@@ -1,0 +1,9 @@
+class MyClass:
+    def __init__(self, a: int):
+        self.a = a
+
+    def f(self) -> bool:
+        return self.a > 10
+
+a: MyClass = MyClass(10)
+a.f()

--- a/tests/resource/valid/operation/greater_than_int_check.py
+++ b/tests/resource/valid/operation/greater_than_int_check.py
@@ -6,4 +6,5 @@ class MyClass:
         return self.a > 10
 
 a: MyClass = MyClass(10)
+
 a.f()

--- a/tests/resource/valid/operation/greater_than_other_int.mamba
+++ b/tests/resource/valid/operation/greater_than_other_int.mamba
@@ -1,0 +1,7 @@
+class MyClass(def a: Int)
+    def f(self, other: MyClass) -> Bool => self.a > other.a
+
+def a := MyClass(10)
+def b := MyClass(20)
+
+a.f(b)

--- a/tests/resource/valid/operation/greater_than_other_int_check.py
+++ b/tests/resource/valid/operation/greater_than_other_int_check.py
@@ -1,0 +1,11 @@
+class MyClass:
+    def __init__(self, a: int):
+        self.a = a
+
+    def f(self, other: MyClass) -> bool:
+        return self.a > other.a
+
+a: MyClass = MyClass(10)
+b: MyClass = MyClass(20)
+
+a.f(b)

--- a/tests/resource/valid/operation/multiply_other_int.mamba
+++ b/tests/resource/valid/operation/multiply_other_int.mamba
@@ -1,0 +1,7 @@
+class MyClass(def a: Int)
+    def f(self, other: MyClass) -> Int => self.a * other.a
+
+def a := MyClass(10)
+def b := MyClass(20)
+
+a.f(b)

--- a/tests/resource/valid/operation/multiply_other_int_check.py
+++ b/tests/resource/valid/operation/multiply_other_int_check.py
@@ -1,0 +1,11 @@
+class MyClass:
+    def __init__(self, a: int):
+        self.a = a
+
+    def f(self, other: MyClass) -> int:
+        return self.a * other.a
+
+a: MyClass = MyClass(10)
+b: MyClass = MyClass(20)
+
+a.f(b)

--- a/tests/system/valid/class.rs
+++ b/tests/system/valid/class.rs
@@ -25,7 +25,6 @@ fn assign_types_double_nested() -> OutTestRet {
     test_directory(true, &["class"], &["class", "target"], "assign_types_double_nested")
 }
 
-
 #[test]
 fn print_types_double_nested() -> OutTestRet {
     test_directory(true, &["class"], &["class", "target"], "print_types_double_nested")

--- a/tests/system/valid/class.rs
+++ b/tests/system/valid/class.rs
@@ -1,6 +1,11 @@
 use crate::system::{OutTestRet, test_directory};
 
 #[test]
+fn assign_to_nullable_field() -> OutTestRet {
+    test_directory(true, &["class"], &["class", "target"], "assign_to_nullable_field")
+}
+
+#[test]
 fn generics() -> OutTestRet {
     test_directory(true, &["class"], &["class", "target"], "generics")
 }
@@ -19,6 +24,7 @@ fn class_super_one_line_init() -> OutTestRet {
 fn assign_types_double_nested() -> OutTestRet {
     test_directory(true, &["class"], &["class", "target"], "assign_types_double_nested")
 }
+
 
 #[test]
 fn print_types_double_nested() -> OutTestRet {

--- a/tests/system/valid/definition.rs
+++ b/tests/system/valid/definition.rs
@@ -11,6 +11,11 @@ fn assign_tuples() -> OutTestRet {
 }
 
 #[test]
+fn assign_to_nullable_in_function() -> OutTestRet {
+    test_directory(true, &["definition"], &["definition", "target"], "assign_to_nullable_in_function")
+}
+
+#[test]
 fn assign_with_if() -> OutTestRet {
     test_directory(true, &["definition"], &["definition", "target"], "assign_with_if")
 }

--- a/tests/system/valid/operation.rs
+++ b/tests/system/valid/operation.rs
@@ -22,6 +22,21 @@ fn assign_types_nested() -> OutTestRet {
 }
 
 #[test]
+fn greater_than_int() -> OutTestRet {
+    test_directory(true, &["operation"], &["operation", "target"], "greater_than_int")
+}
+
+#[test]
+fn greater_than_other_int() -> OutTestRet {
+    test_directory(true, &["operation"], &["operation", "target"], "greater_than_other_int")
+}
+
+#[test]
+fn multiply_other_int() -> OutTestRet {
+    test_directory(true, &["operation"], &["operation", "target"], "multiply_other_int")
+}
+
+#[test]
 fn primitives_ast_verify() -> OutTestRet {
     test_directory(true, &["operation"], &["operation", "target"], "primitives")
 }


### PR DESCRIPTION
### Summary

- Fix bug where incorrect constraints were generated in the unify stage for function arguments in calls

Now, the expression at the site must be the super of any of the types mentioned in the union of types of the argument.
We do this by introducing a boolean `any` in the `Name` struct.
This then changes the behavior when set to true of `is_superset_of`, where if `other`'s `any` is true, then self will the super of the other if just one `TrueName` in the union is a super of the other.
Not sure if this logic is completely right.
Perhaps it should be that for each `TrueName` in self, it should be the super of at least one.
But I'm leaving it as-is for now.
 
### Added Tests

*Happy*
- Assign to nullable class field
- Assign to null variable in function body

*Sad*
- Random test uncommented where we assign to a non-mutable field

