### PR TITLE
Fix return token width

### DIFF
--- a/src/parse/lex/token.rs
+++ b/src/parse/lex/token.rs
@@ -214,7 +214,7 @@ impl Token {
             Token::Do => 2,
             Token::Continue => 8,
             Token::Break => 5,
-            Token::Ret => 5,
+            Token::Ret => 6,
             Token::With => 4,
             Token::Question => 1,
             Token::Handle => 5,

--- a/src/parse/statement.rs
+++ b/src/parse/statement.rs
@@ -186,7 +186,7 @@ mod test {
             panic!("Expected reassignment, was: {:?}", ret.node)
         };
 
-        assert_eq!(expr.pos, Position::new(CaretPos::new(1, 7), CaretPos::new(1, 9)));
+        assert_eq!(expr.pos, Position::new(CaretPos::new(1, 8), CaretPos::new(1, 10)));
         assert_eq!(expr.node, Node::Int { lit: String::from("20") });
     }
 


### PR DESCRIPTION
### Summary

Noticed that the error messages looked weird.
Turns out return token is 6 wide not 5.

### Added Tests

- Modified test where we pare `return`