### PR TITLE
Generate constr for match expression and arm conds

### DIFF
--- a/src/check/constrain/constraint/iterator.rs
+++ b/src/check/constrain/constraint/iterator.rs
@@ -44,8 +44,8 @@ impl Constraints {
         if constraint.is_flag {
             // Can only reinsert constraint once
             let msg = format!(
-                "Cannot infer type. Expected a {}, was {}",
-                &constraint.left.expect, &constraint.right.expect
+                "Cannot infer type within {}. Expected a {}, was {}",
+                constraint.msg, &constraint.left.expect, &constraint.right.expect
             );
             return Err(vec![TypeErr::new(constraint.left.pos, &msg)]);
         }

--- a/src/check/constrain/generate/control_flow.rs
+++ b/src/check/constrain/generate/control_flow.rs
@@ -38,7 +38,7 @@ pub fn gen_flow(
             let outer_env = generate(expr_or_stmt, &env.raises_caught(&raises), ctx, constr)?
                 .raises_caught(&raises_before);
 
-            constrain_cases(ast, cases, &outer_env, ctx, constr)?;
+            constrain_cases(ast, expr_or_stmt, cases, &outer_env, ctx, constr)?;
             Ok(outer_env.clone())
         }
 
@@ -83,7 +83,7 @@ pub fn gen_flow(
         Node::Case { .. } => Err(vec![TypeErr::new(ast.pos, "Case cannot be top level")]),
         Node::Match { cond, cases } => {
             let outer_env = generate(cond, env, ctx, constr)?;
-            constrain_cases(ast, cases, &outer_env, ctx, constr)?;
+            constrain_cases(ast, cond, cases, &outer_env, ctx, constr)?;
             Ok(env.clone())
         }
 
@@ -116,7 +116,7 @@ pub fn gen_flow(
     }
 }
 
-fn constrain_cases(ast: &AST, cases: &Vec<AST>, env: &Environment, ctx: &Context, constr: &mut ConstrBuilder) -> Constrained<()> {
+fn constrain_cases(ast: &AST, expr: &AST, cases: &Vec<AST>, env: &Environment, ctx: &Context, constr: &mut ConstrBuilder) -> Constrained<()> {
     let is_define_mode = env.is_def_mode;
     let exp_ast = Expected::try_from((ast, &env.var_mappings))?;
 
@@ -128,8 +128,15 @@ fn constrain_cases(ast: &AST, cases: &Vec<AST>, env: &Environment, ctx: &Context
                 let cond_env = generate(cond, &env.is_def_mode(true), ctx, constr)?;
                 generate(body, &cond_env.is_def_mode(is_define_mode), ctx, constr)?;
 
+                if let Node::ExpressionType { expr: ref cond, .. } = cond.node {
+                    constr.add("match expression and arm condition",
+                               &Expected::try_from((expr, &env.var_mappings))?,
+                               &Expected::try_from((cond, &env.var_mappings))?,
+                    );
+                }
+
                 let exp_body = Expected::try_from((body, &cond_env.var_mappings))?;
-                constr.add("handle arm body", &exp_body, &exp_ast);
+                constr.add("match arm body", &exp_body, &exp_ast);
                 constr.exit_set(case.pos)?;
             }
             _ => return Err(vec![TypeErr::new(case.pos, "Expected case")])

--- a/src/check/resource/std/input
+++ b/src/check/resource/std/input
@@ -1,0 +1,1 @@
+def input(in: str) -> str: pass

--- a/tests/resource/valid/readme_example/factorial.mamba
+++ b/tests/resource/valid/readme_example/factorial.mamba
@@ -1,0 +1,10 @@
+def factorial(x: Int) -> Int => match x
+    0 => 1
+    n => n * factorial(n - 1)
+
+def num := input("Compute factorial: ")
+if num.is_digit() then
+    def result := factorial(Int(num))
+    print("Factorial {num} is: {result}.")
+else
+    print("Input was not an integer.")

--- a/tests/resource/valid/readme_example/factorial_check.py
+++ b/tests/resource/valid/readme_example/factorial_check.py
@@ -1,0 +1,15 @@
+from typing import Union
+def factorial(x: int) -> int:
+    match x:
+        case 0:
+            return 1
+        case n:
+            return n * factorial(n - 1)
+
+num: Union[flot, int, str] = input("Compute factorial: ")
+
+if num.is_digit():
+    result = factorial(int(num))
+    print(f"Factorial {num} is: {result}.")
+else:
+    print("Input was not an integer.")

--- a/tests/system/valid/mod.rs
+++ b/tests/system/valid/mod.rs
@@ -9,6 +9,7 @@ pub mod definition;
 pub mod error;
 pub mod function;
 pub mod operation;
+pub mod readme_examples;
 
 #[test]
 fn empty_file() -> OutTestRet {

--- a/tests/system/valid/readme_examples.rs
+++ b/tests/system/valid/readme_examples.rs
@@ -1,0 +1,6 @@
+use crate::system::{OutTestRet, test_directory};
+
+#[test]
+fn factorial() -> OutTestRet {
+    test_directory(true, &["readme_example"], &["readme_example", "target"], "factorial")
+}


### PR DESCRIPTION
### Summary

This is because as we continue in the match arm body, the condition has the same type as the outer expr.
Noticed when testing the factorial example in the README.

### Added Tests

*Happy*
- Recursive function call within match arm
