### PR TITLE
Don't generate access for equality check

### DIFF
--- a/src/check/constrain/constraint/builder.rs
+++ b/src/check/constrain/constraint/builder.rs
@@ -29,7 +29,7 @@ impl ConstrBuilder {
     pub fn is_top_level(&self) -> bool { self.level == 0 }
 
     pub fn new_set_in_class(&mut self, inherit_class: bool, class: &StringName) {
-        self.new_set(false);
+        self.new_set(true);
         if self.level > 0 && inherit_class {
             let mut previous = self.constraints[self.level - 1].0.clone();
             self.constraints[self.level].0.append(&mut previous);

--- a/tests/resource/valid/class/var_from_outside_class.mamba
+++ b/tests/resource/valid/class/var_from_outside_class.mamba
@@ -1,0 +1,5 @@
+def message := "may be mutable, for now"
+
+class MyClass
+    def f(self) =>
+        print(message)

--- a/tests/resource/valid/class/var_from_outside_class_check.py
+++ b/tests/resource/valid/class/var_from_outside_class_check.py
@@ -1,0 +1,5 @@
+message: str = "may be mutable, for now"
+
+class MyClass:
+    def f(self):
+        print(message)

--- a/tests/resource/valid/function/print_string.mamba
+++ b/tests/resource/valid/function/print_string.mamba
@@ -1,0 +1,3 @@
+def my_string := "asdf"
+
+print(my_string)

--- a/tests/resource/valid/function/print_string_check.py
+++ b/tests/resource/valid/function/print_string_check.py
@@ -1,0 +1,3 @@
+my_string: str = "asdf"
+
+print(my_string)

--- a/tests/resource/valid/operation/equality_different_types.mamba
+++ b/tests/resource/valid/operation/equality_different_types.mamba
@@ -1,0 +1,8 @@
+class MyClass
+class MyOtherClass
+
+def a := MyClass()
+def b := MyOtherClass()
+
+a = b
+a != b

--- a/tests/resource/valid/operation/equality_different_types_check.py
+++ b/tests/resource/valid/operation/equality_different_types_check.py
@@ -1,0 +1,10 @@
+class MyClass:
+    pass
+class MyOtherClass:
+    pass
+
+a: MyClass = MyClass()
+b: MyOtherClass = MyOtherClass()
+
+a == b
+a != b

--- a/tests/system/valid/class.rs
+++ b/tests/system/valid/class.rs
@@ -84,3 +84,8 @@ fn tuple_as_class() -> OutTestRet {
 fn unassigned_tuple_second_nullable() -> OutTestRet {
     test_directory(true, &["class"], &["class", "target"], "unassigned_tuple_second_nullable")
 }
+
+#[test]
+fn var_from_outside_class() -> OutTestRet {
+    test_directory(true, &["class"], &["class", "target"], "var_from_outside_class")
+}

--- a/tests/system/valid/function.rs
+++ b/tests/system/valid/function.rs
@@ -26,6 +26,11 @@ fn match_function() -> OutTestRet {
 }
 
 #[test]
+fn print_string() -> OutTestRet {
+    test_directory(true, &["function"], &["function", "target"], "print_string")
+}
+
+#[test]
 fn return_last_expression() -> OutTestRet {
     test_directory(true, &["function"], &["function", "target"], "return_last_expression")
 }

--- a/tests/system/valid/operation.rs
+++ b/tests/system/valid/operation.rs
@@ -52,6 +52,11 @@ fn boolean_ast_verify() -> OutTestRet {
 }
 
 #[test]
+fn equality_different_types() -> OutTestRet {
+    test_directory(true, &["operation"], &["operation", "target"], "equality_different_types")
+}
+
+#[test]
 #[ignore] // investigate whether this should in fact, pass
 fn type_alias_primitive() -> OutTestRet {
     test_directory(true, &["operation"], &["operation", "target"], "type_alias_primitive")


### PR DESCRIPTION
### Summary

Also inherit constraints when entering class.
Useful if you have defined variables you use within the class outside the class.

- Also allow equality check between two items which are not strictly the same type

### Added Tests

- Variable from outside class used within class.
- Equality between two types not the same
