### PR TITLE
Store ParseErr on heap

### DIFF
--- a/src/common/position.rs
+++ b/src/common/position.rs
@@ -73,13 +73,13 @@ impl Position {
     /// the source code.
     ///
     /// Width is always 1 or greater.
-    pub fn get_width(&self) -> i32 {
+    pub fn get_width(&self) -> usize {
         max(
             1,
             max(
                 self.end.pos as i32 - self.start.pos as i32,
                 self.start.pos as i32 - self.end.pos as i32,
-            ),
+            ) as usize,
         )
     }
 

--- a/src/parse/block.rs
+++ b/src/parse/block.rs
@@ -37,7 +37,7 @@ pub fn parse_statements(it: &mut LexIterator) -> ParseResult<Vec<AST>> {
             _ => {
                 statements.push(*it.parse(&parse_expr_or_stmt, "statements", start)?);
                 if it.peek_if(&|lex| lex.token != Token::NL && lex.token != Token::Dedent && lex.token != Token::Eof) {
-                    Err(expected_one_of(&[Token::NL, Token::Dedent, Token::Eof], lex, "end of statement"))
+                    Err(Box::from(expected_one_of(&[Token::NL, Token::Dedent, Token::Eof], lex, "end of statement")))
                 } else {
                     Ok(())
                 }

--- a/src/parse/call.rs
+++ b/src/parse/call.rs
@@ -44,7 +44,7 @@ pub fn parse_call(pre: &AST, it: &mut LexIterator) -> ParseResult {
                 let node = Node::FunctionCall { name: Box::from(pre.clone()), args };
                 Ok(Box::from(AST::new(pre.pos.union(end), node)))
             }
-            _ => Err(expected_one_of(&[Token::Point, Token::LRBrack], ast, "function call")),
+            _ => Err(Box::from(expected_one_of(&[Token::Point, Token::LRBrack], ast, "function call"))),
         },
         &[Token::Point, Token::LRBrack],
         "function call",

--- a/src/parse/class.rs
+++ b/src/parse/class.rs
@@ -40,7 +40,7 @@ pub fn parse_class(it: &mut LexIterator) -> ParseResult {
                 it.eat_if(&Token::Comma);
                 Ok(())
             }
-            _ => Err(expected(&Token::Id(String::new()), &lex.clone(), "parents"))
+            _ => Err(Box::from(expected(&Token::Id(String::new()), &lex.clone(), "parents")))
         })?;
     }
 
@@ -72,7 +72,7 @@ pub fn parse_parent(it: &mut LexIterator) -> ParseResult {
                 it.eat_if(&Token::Comma);
                 Ok(())
             }
-            _ => Err(expected_one_of(
+            _ => Err(Box::from(expected_one_of(
                 &[
                     Token::Id(String::new()),
                     Token::Str(String::new(), vec![]),
@@ -84,7 +84,7 @@ pub fn parse_parent(it: &mut LexIterator) -> ParseResult {
                 ],
                 lex,
                 "parent arguments",
-            ))
+            )))
         })?;
         it.eat(&Token::RRBrack, "parent arguments")?
     } else {

--- a/src/parse/collection.rs
+++ b/src/parse/collection.rs
@@ -13,11 +13,11 @@ pub fn parse_collection(it: &mut LexIterator) -> ParseResult {
             Token::LRBrack => parse_tuple(it),
             Token::LSBrack => parse_list(it),
             Token::LCBrack => parse_set(it),
-            _ => Err(expected_one_of(
+            _ => Err(Box::from(expected_one_of(
                 &[Token::LRBrack, Token::LSBrack, Token::LCBrack],
                 lex,
                 "collection",
-            ))
+            )))
         },
         &[Token::LRBrack, Token::LSBrack, Token::LCBrack],
         "collection",

--- a/src/parse/control_flow_expr.rs
+++ b/src/parse/control_flow_expr.rs
@@ -13,7 +13,7 @@ pub fn parse_cntrl_flow_expr(it: &mut LexIterator) -> ParseResult {
         &|it, lex| match lex.token {
             Token::If => parse_if(it),
             Token::Match => parse_match(it),
-            _ => Err(expected_one_of(&[Token::If, Token::Match], lex, "control flow expression"))
+            _ => Err(Box::from(expected_one_of(&[Token::If, Token::Match], lex, "control flow expression")))
         },
         &[Token::If, Token::Match],
         "control flow expression",
@@ -93,7 +93,7 @@ fn parse_expression_maybe_type(it: &mut LexIterator) -> ParseResult {
 mod test {
     use crate::parse::{parse, parse_direct};
     use crate::parse::ast::{AST, Node};
-    use crate::parse::result::ParseErr;
+    use crate::parse::result::ParseResult;
     use crate::test_util::resource_content;
 
     #[test]
@@ -145,7 +145,7 @@ mod test {
     }
 
     #[test]
-    fn if_expression() -> Result<(), ParseErr> {
+    fn if_expression() -> ParseResult<()> {
         let source = String::from("if a then\n    b\n");
         let ast = parse_direct(&source)?;
 
@@ -166,7 +166,7 @@ mod test {
     }
 
     #[test]
-    fn if_else_expression() -> Result<(), ParseErr> {
+    fn if_else_expression() -> ParseResult<()> {
         let source = String::from("if a then\n    b\nelse\n    c");
         let ast = parse_direct(&source)?;
 

--- a/src/parse/control_flow_stmt.rs
+++ b/src/parse/control_flow_stmt.rs
@@ -21,11 +21,11 @@ pub fn parse_cntrl_flow_stmt(it: &mut LexIterator) -> ParseResult {
                 let end = it.eat(&Token::Continue, "control flow statement")?;
                 Ok(Box::from(AST::new(lex.pos.union(end), Node::Continue)))
             }
-            _ => Err(expected_one_of(
+            _ => Err(Box::from(expected_one_of(
                 &[Token::While, Token::For, Token::Break, Token::Continue],
                 lex,
                 "control flow statement",
-            ))
+            )))
         },
         &[Token::While, Token::For, Token::Break, Token::Continue],
         "control flow statement",

--- a/src/parse/definition.rs
+++ b/src/parse/definition.rs
@@ -79,7 +79,7 @@ fn parse_var_or_fun_def(it: &mut LexIterator, pure: bool) -> ParseResult {
                 _ if !pure => parse_variable_def_id(&id, it),
                 _ => {
                     let msg = format!("Definition cannot have {} identifier", Token::Pure);
-                    Err(custom(&msg, id.pos))
+                    Err(Box::from(custom(&msg, id.pos)))
                 }
             },
             {
@@ -93,7 +93,7 @@ fn parse_var_or_fun_def(it: &mut LexIterator, pure: bool) -> ParseResult {
                 Ok(Box::from(AST::new(id.pos.union(id.pos), node)))
             },
         ),
-        _ => Err(custom("definition must start with id type", id.pos)),
+        _ => Err(Box::from(custom("definition must start with id type", id.pos))),
     }
 }
 
@@ -104,11 +104,11 @@ fn parse_fun_def(id: &AST, pure: bool, it: &mut LexIterator) -> ParseResult {
     let id = match &id.node {
         Node::ExpressionType { expr, mutable, ty } => match (mutable, ty) {
             (_, None) => expr.clone(),
-            (_, Some(_)) => return Err(custom("Function identifier cannot have type", expr.pos)),
+            (_, Some(_)) => return Err(Box::from(custom("Function identifier cannot have type", expr.pos))),
         },
         Node::Id { .. } => Box::from(id.clone()),
 
-        _ => return Err(custom("Function definition not given id or operator", id.pos)),
+        _ => return Err(Box::from(custom("Function definition not given id or operator", id.pos))),
     };
 
     let ret_ty = it.parse_if(&Token::To, &parse_type, "function return type", start)?;
@@ -159,7 +159,7 @@ pub fn parse_fun_arg(it: &mut LexIterator) -> ParseResult {
     let (mutable, var, ty) = match &expression_type.node {
         Node::ExpressionType { expr, mutable, ty } => (*mutable, expr.clone(), ty.clone()),
         _ => {
-            return Err(custom("Expected expression type in function argument", expression_type.pos));
+            return Err(Box::from(custom("Expected expression type in function argument", expression_type.pos)));
         }
     };
     let default =
@@ -187,7 +187,7 @@ fn parse_variable_def_id(id: &AST, it: &mut LexIterator) -> ParseResult {
     let forward = it.parse_vec_if(&Token::Forward, &parse_forward, "definition raises", id.pos)?;
     let (mutable, var, ty) = match &id.node {
         Node::ExpressionType { expr, mutable, ty } => (*mutable, expr.clone(), ty.clone()),
-        _ => return Err(custom("Expected expression type in variable definition", id.pos)),
+        _ => return Err(Box::from(custom("Expected expression type in variable definition", id.pos))),
     };
 
     let end = match (&expression, &forward.last()) {

--- a/src/parse/definition.rs
+++ b/src/parse/definition.rs
@@ -73,7 +73,7 @@ fn parse_var_or_fun_def(it: &mut LexIterator, pure: bool) -> ParseResult {
         Node::ExpressionType { ty: Some(_), .. } | Node::TypeTup { .. } if !pure => {
             parse_variable_def_id(&id, it)
         }
-        Node::ExpressionType { expr, ty, mutable } if *ty == None => it.peek(
+        Node::ExpressionType { expr, ty, mutable } if ty.is_none() => it.peek(
             &|it, lex| match lex.token {
                 Token::LRBrack => parse_fun_def(&id, pure, it),
                 _ if !pure => parse_variable_def_id(&id, it),

--- a/src/parse/expression.rs
+++ b/src/parse/expression.rs
@@ -85,7 +85,7 @@ pub fn parse_inner_expression(it: &mut LexIterator) -> ParseResult {
 
             Token::BSlash => parse_anon_fun(it),
 
-            _ => Err(expected_one_of(&expected, lex, "expression")),
+            _ => Err(Box::from(expected_one_of(&expected, lex, "expression"))),
         },
         &expected,
         "expression",

--- a/src/parse/iterator.rs
+++ b/src/parse/iterator.rs
@@ -51,8 +51,8 @@ impl<'a> LexIterator<'a> {
     pub fn eat(&mut self, token: &Token, err_msg: &str) -> ParseResult<Position> {
         match self.it.next() {
             Some(Lex { token: actual, pos }) if Token::same_type(actual, token) => Ok(*pos),
-            Some(lex) => Err(expected(token, lex, err_msg)),
-            None => Err(eof_expected_one_of(&[token.clone()], err_msg))
+            Some(lex) => Err(Box::from(expected(token, lex, err_msg))),
+            None => Err(Box::from(eof_expected_one_of(&[token.clone()], err_msg)))
         }
     }
 
@@ -85,7 +85,7 @@ impl<'a> LexIterator<'a> {
         cause: &str,
         start: Position,
     ) -> ParseResult<Box<AST>> {
-        parse_fun(self).map_err(|err| err.clone_with_cause(cause, start))
+        parse_fun(self).map_err(|err| Box::from(err.clone_with_cause(cause, start)))
     }
 
     pub fn parse_vec(
@@ -94,7 +94,7 @@ impl<'a> LexIterator<'a> {
         cause: &str,
         start: Position,
     ) -> ParseResult<Vec<AST>> {
-        parse_fun(self).map_err(|err| err.clone_with_cause(cause, start))
+        parse_fun(self).map_err(|err| Box::from(err.clone_with_cause(cause, start)))
     }
 
     pub fn parse_if(
@@ -136,7 +136,7 @@ impl<'a> LexIterator<'a> {
         eof_err_msg: &str,
     ) -> ParseResult {
         match self.it.peek().cloned() {
-            None => Err(eof_expected_one_of(eof_expected, eof_err_msg)),
+            None => Err(Box::from(eof_expected_one_of(eof_expected, eof_err_msg))),
             Some(lex) => match_fun(self, lex)
         }
     }
@@ -195,7 +195,7 @@ impl<'a> LexIterator<'a> {
     pub fn start_pos(&mut self, msg: &str) -> ParseResult<Position> {
         match self.it.peek() {
             Some(Lex { pos, .. }) => Ok(*pos),
-            None => Err(eof_expected_one_of(&[], &format!("start of a {}", msg)))
+            None => Err(Box::from(eof_expected_one_of(&[], &format!("start of a {}", msg))))
         }
     }
 }

--- a/src/parse/iterator.rs
+++ b/src/parse/iterator.rs
@@ -195,7 +195,7 @@ impl<'a> LexIterator<'a> {
     pub fn start_pos(&mut self, msg: &str) -> ParseResult<Position> {
         match self.it.peek() {
             Some(Lex { pos, .. }) => Ok(*pos),
-            None => Err(Box::from(eof_expected_one_of(&[], &format!("start of a {}", msg))))
+            None => Err(Box::from(eof_expected_one_of(&[], &format!("start of a {msg}"))))
         }
     }
 }

--- a/src/parse/mod.rs
+++ b/src/parse/mod.rs
@@ -28,10 +28,7 @@ mod ty;
 /// Parse input, which is a string.
 pub fn parse(input: &str) -> ParseResult {
     let tokens: Vec<Lex> = tokenize(input)
-        .map(|tokens| tokens.into_iter().filter(|t| match t.token {
-            Token::Comment(_) => false,
-            _ => true
-        }).collect())
+        .map(|tokens| tokens.into_iter().filter(|t| !matches!(t.token, Token::Comment(_))).collect())
         .map_err(ParseErr::from)?;
 
     let mut iterator = LexIterator::new(tokens.iter().peekable());

--- a/src/parse/mod.rs
+++ b/src/parse/mod.rs
@@ -38,7 +38,7 @@ pub fn parse(input: &str) -> ParseResult {
     let statements = block::parse_statements(&mut iterator)?;
     if iterator.peek_if(&|lex| lex.token != Token::Eof) {
         if let Some(lex) = iterator.peek_next() {
-            return Err(expected(&Token::Eof, &lex, "end of file"));
+            return Err(Box::from(expected(&Token::Eof, &lex, "end of file")));
         }
     }
 

--- a/src/parse/result.rs
+++ b/src/parse/result.rs
@@ -13,7 +13,7 @@ use crate::parse::lex::token::Token;
 
 const SYNTAX_ERR_MAX_DEPTH: usize = 1;
 
-pub type ParseResult<T = Box<AST>> = Result<T, ParseErr>;
+pub type ParseResult<T = Box<AST>> = Result<T, Box<ParseErr>>;
 
 #[derive(Debug, Clone)]
 pub struct ParseErr {

--- a/src/parse/result.rs
+++ b/src/parse/result.rs
@@ -157,7 +157,7 @@ impl Display for ParseErr {
                 let source_line = match &self.source {
                     Some(source) => source
                         .lines()
-                        .nth(cause.position.start.line as usize - 1)
+                        .nth(cause.position.start.line - 1)
                         .unwrap_or("<unknown>"),
                     None => "<unknown>",
                 };
@@ -176,7 +176,7 @@ impl Display for ParseErr {
         let path = self.path.as_ref().map_or("<unknown>", |path| path.to_str().unwrap_or_default());
         let source_line = match &self.source {
             Some(source) => {
-                source.lines().nth(self.position.start.line as usize - 1).unwrap_or("<unknown>")
+                source.lines().nth(self.position.start.line - 1).unwrap_or("<unknown>")
             }
             None => "<unknown>",
         };
@@ -190,8 +190,8 @@ impl Display for ParseErr {
             self.position.start.pos,
             self.position.start.line,
             source_line,
-            String::from_utf8(vec![b' '; self.position.start.pos as usize]).unwrap(),
-            String::from_utf8(vec![b'^'; self.position.get_width() as usize]).unwrap(),
+            String::from_utf8(vec![b' '; self.position.start.pos]).unwrap(),
+            String::from_utf8(vec![b'^'; self.position.get_width()]).unwrap(),
             cause_formatter,
         )
     }

--- a/src/parse/result.rs
+++ b/src/parse/result.rs
@@ -166,7 +166,7 @@ impl Display for ParseErr {
                     "{:3}  |- {}\n     | {}^ in {} ({}:{})\n",
                     cause.position.start.line,
                     source_line,
-                    String::from_utf8(vec![b' '; cause.position.start.pos as usize]).unwrap(),
+                    String::from_utf8(vec![b' '; cause.position.start.pos]).unwrap(),
                     cause.cause,
                     cause.position.start.line,
                     cause.position.start.pos,

--- a/src/parse/statement.rs
+++ b/src/parse/statement.rs
@@ -28,11 +28,11 @@ pub fn parse_statement(it: &mut LexIterator) -> ParseResult {
             Token::With => parse_with(it),
             Token::For | Token::While => parse_cntrl_flow_stmt(it),
             Token::Ret => parse_return(it),
-            _ => Err(expected_one_of(
+            _ => Err(Box::from(expected_one_of(
                 &[Token::Pass, Token::Raise, Token::Def, Token::With, Token::For, Token::While, Token::Ret],
                 lex,
                 "statement",
-            )),
+            ))),
         },
         &[Token::Pass, Token::Raise, Token::Def, Token::With, Token::For, Token::While, Token::Ret],
         "statement",
@@ -63,7 +63,7 @@ pub fn parse_import(it: &mut LexIterator) -> ParseResult {
                 it.eat_if(&Token::Comma);
                 Ok(())
             }
-            _ => Err(expected(&Token::Id(String::new()), lex, "as")),
+            _ => Err(Box::from(expected(&Token::Id(String::new()), lex, "as"))),
         })?;
         alias
     } else {
@@ -102,11 +102,11 @@ pub fn parse_reassignment(pre: &AST, it: &mut LexIterator) -> ParseResult {
             Lex { token: Token::BLShiftAssign, .. } => (Token::BLShiftAssign, NodeOp::BLShift),
             Lex { token: Token::BRShiftAssign, .. } => (Token::BRShiftAssign, NodeOp::BRShift),
             lex => {
-                return Err(expected_one_of(&expect, lex, "reassignment"));
+                return Err(Box::from(expected_one_of(&expect, lex, "reassignment")));
             }
         }
     } else {
-        return Err(eof_expected_one_of(&expect, "reassignment"));
+        return Err(Box::from(eof_expected_one_of(&expect, "reassignment")));
     };
     it.eat(&token, "reassignment")?;
 
@@ -125,7 +125,7 @@ pub fn parse_with(it: &mut LexIterator) -> ParseResult {
     let alias = if let Some(alias) = &alias {
         match alias.node.clone() {
             Node::ExpressionType { expr, mutable, ty } => Some((expr, mutable, ty)),
-            _ => return Err(custom("Expected expression type", alias.pos)),
+            _ => return Err(Box::from(custom("Expected expression type", alias.pos))),
         }
     } else {
         None

--- a/src/parse/ty.rs
+++ b/src/parse/ty.rs
@@ -35,11 +35,11 @@ pub fn parse_id(it: &mut LexIterator) -> ParseResult {
                 let end = it.eat(&Token::RRBrack, "identifier tuple")?;
                 Ok(Box::from(AST::new(end, Node::Tuple { elements })))
             }
-            _ => Err(expected_one_of(
+            _ => Err(Box::from(expected_one_of(
                 &[Token::_Self, Token::Init, Token::Id(String::new()), Token::LRBrack],
                 lex,
                 "identifier",
-            ))
+            )))
         },
         &[Token::_Self, Token::Init, Token::Id(String::new())],
         "identifier",
@@ -87,11 +87,11 @@ pub fn parse_type(it: &mut LexIterator) -> ParseResult {
             }
             Token::LRBrack => it.parse(&parse_type_tuple, "type", start),
             Token::LCBrack => it.parse(&parse_type_set, "type", start),
-            _ => Err(expected_one_of(
+            _ => Err(Box::from(expected_one_of(
                 &[Token::Id(String::new()), Token::LRBrack, Token::LCBrack],
                 &lex.clone(),
                 "type",
-            ))
+            )))
         },
         &[Token::Id(String::new()), Token::LRBrack],
         "type",
@@ -192,7 +192,7 @@ pub fn parse_expr_no_type(it: &mut LexIterator) -> ParseResult {
     let start = it.start_pos("expression no type")?;
     let expr = it.parse(&parse_id, "expression no type", start)?;
     if let Some(annotation_pos) = it.eat_if(&Token::DoublePoint) {
-        Err(custom("Type annotation not allowed here", annotation_pos))
+        Err(Box::from(custom("Type annotation not allowed here", annotation_pos)))
     } else {
         Ok(expr)
     }


### PR DESCRIPTION
### Relevant issues

- Partially resolves #396 

### Summary

This is because ParseErr is relatively large.
Now it is stored on the heap, and the compiler also doesn't have to create extra space for the `Ok` value.

