### PR TITLE
Propagate outward if else constraint

### DIFF
--- a/src/check/constrain/constraint/builder.rs
+++ b/src/check/constrain/constraint/builder.rs
@@ -1,4 +1,4 @@
-use crate::check::constrain::constraint::{Constraint, ConstrVariant};
+use crate::check::constrain::constraint::Constraint;
 use crate::check::constrain::constraint::expected::Expected;
 use crate::check::constrain::constraint::iterator::Constraints;
 use crate::check::name::string_name::StringName;
@@ -71,10 +71,6 @@ impl ConstrBuilder {
     /// Add new constraint to constraint builder with a message.
     pub fn add(&mut self, msg: &str, parent: &Expected, child: &Expected) {
         self.add_constr(&Constraint::new(msg, parent, child));
-    }
-
-    pub fn add_var(&mut self, msg: &str, parent: &Expected, child: &Expected, var: ConstrVariant) {
-        self.add_constr(&Constraint::new_variant(msg, parent, child, var));
     }
 
     pub fn add_constr(&mut self, constraint: &Constraint) {

--- a/src/check/constrain/generate/definition.rs
+++ b/src/check/constrain/generate/definition.rs
@@ -244,31 +244,3 @@ fn identifier_to_tuple(
         }
     }
 }
-
-#[cfg(test)]
-mod tests {
-    use std::collections::HashSet;
-
-    use crate::check::constrain::constraint::builder::ConstrBuilder;
-    use crate::check::constrain::generate::env::Environment;
-    use crate::check::constrain::generate::generate;
-    use crate::check::context::Context;
-    use crate::parse::parse;
-
-    #[test]
-    fn if_else_as_expr() {
-        let src = "def a := if True then 10 else 20";
-        let ast = parse(src).unwrap();
-        let mut builder = ConstrBuilder::new();
-        generate(&ast, &Environment::default(), &Context::default(), &mut builder).unwrap();
-
-        // Ignore then and else branches
-        let mut constraints = builder.all_constr()[2].clone();
-
-        let mut popped = HashSet::new();
-        while let Some(pop) = constraints.pop_constr() {
-            popped.insert(pop);
-        }
-        assert_eq!(popped.len(), 3);
-    }
-}

--- a/src/check/constrain/mod.rs
+++ b/src/check/constrain/mod.rs
@@ -47,7 +47,7 @@ mod tests {
         let ast = parse(src).unwrap();
         let finished = constraints(&ast, &Context::default().into_with_primitives().unwrap()).unwrap().pos_to_name;
 
-        assert_eq!(finished.len(), 4);
+        assert_eq!(finished.len(), 5);
         let pos_20 = Position::new(CaretPos::new(1, 31), CaretPos::new(1, 33));
         assert_eq!(finished[&pos_20], Name::from("Int"));
         let pos_10 = Position::new(CaretPos::new(1, 23), CaretPos::new(1, 25));
@@ -57,6 +57,9 @@ mod tests {
 
         let pos_if = Position::new(CaretPos::new(1, 10), CaretPos::new(1, 33));
         assert_eq!(finished[&pos_if], Name::from("Int"));
+
+        let pos_var = Position::new(CaretPos::new(1, 5), CaretPos::new(1, 6));
+        assert_eq!(finished[&pos_var], Name::from("Int"));
     }
 
     #[test]

--- a/tests/resource/valid/control_flow/if_in_if_cond_check.py
+++ b/tests/resource/valid/control_flow/if_in_if_cond_check.py
@@ -1,6 +1,6 @@
-a = True
-b = True
-c = False
+a: bool = True
+b: bool = True
+c: bool = False
 
-d = b if a else c
-e = b if d else c
+d: bool = b if a else c
+e: bool = b if d else c

--- a/tests/system/valid/control_flow.rs
+++ b/tests/system/valid/control_flow.rs
@@ -41,7 +41,6 @@ fn if_ast_verify() -> OutTestRet {
 }
 
 #[test]
-#[ignore] // See #367
 fn if_in_if_cond() -> OutTestRet {
     test_directory(true, &["control_flow"], &["control_flow", "target"], "if_in_if_cond")
 }


### PR DESCRIPTION
### Relevant issues

- Closes #367 

### Summary

Remove unnecessary creation of further sets in the builder in:
- if else
- if

This means that a proper constraint is generated for a whole if statement in the outer set (in which the if is defined).
Before, a new set was created meaning that this information was lost when exiting the set right after the if.

### Added Tests

*Happy*
- Re-add test of nested ifs (see #367 )
- Remove test of if_else in generate stage which was too granular.