### PR TITLE
Don't generate ternary if contains raises

### DIFF
--- a/src/generate/convert/control_flow.rs
+++ b/src/generate/convert/control_flow.rs
@@ -70,7 +70,7 @@ pub fn convert_cntrl_flow(ast: &ASTTy, imp: &mut Imports, state: &State, ctx: &C
     })
 }
 
-fn is_valid_in_ternary(then: &Box<ASTTy>, el: &Box<ASTTy>) -> bool {
+fn is_valid_in_ternary(then: &ASTTy, el: &ASTTy) -> bool {
     !matches!(then.node, NodeTy::Block { .. } | NodeTy::Raise { ..  })
         && !matches!(el.node, NodeTy::Block { .. } | NodeTy::Raise { ..  })
 }

--- a/src/generate/convert/control_flow.rs
+++ b/src/generate/convert/control_flow.rs
@@ -11,25 +11,19 @@ pub fn convert_cntrl_flow(ast: &ASTTy, imp: &mut Imports, state: &State, ctx: &C
             let cond = Box::from(convert_node(cond, imp, &state.is_last_must_be_ret(false).must_assign_to(None), ctx)?);
 
             match el {
-                Some(el) => match (&then.node, &el.node) {
-                    (NodeTy::Block { .. }, _) | (_, NodeTy::Block { .. }) => Core::IfElse {
-                        cond,
-                        then: Box::from(convert_node(then, imp, state, ctx)?),
-                        el: Box::from(convert_node(el, imp, state, ctx)?),
-                    },
-                    (..) if ast.ty.is_some() => {
-                        let state = state
-                            .is_last_must_be_ret(false)
-                            .remove_ret(true)
-                            .must_assign_to(None);
+                Some(el) => if ast.ty.is_some() && is_valid_in_ternary(then, el) {
+                    let state = state
+                        .is_last_must_be_ret(false)
+                        .remove_ret(true)
+                        .must_assign_to(None);
 
-                        Core::Ternary {
-                            cond,
-                            then: Box::from(convert_node(then, imp, &state, ctx)?),
-                            el: Box::from(convert_node(el, imp, &state, ctx)?),
-                        }
+                    Core::Ternary {
+                        cond,
+                        then: Box::from(convert_node(then, imp, &state, ctx)?),
+                        el: Box::from(convert_node(el, imp, &state, ctx)?),
                     }
-                    _ => Core::IfElse {
+                } else {
+                    Core::IfElse {
                         cond,
                         then: Box::from(convert_node(then, imp, state, ctx)?),
                         el: Box::from(convert_node(el, imp, state, ctx)?),
@@ -67,7 +61,6 @@ pub fn convert_cntrl_flow(ast: &ASTTy, imp: &mut Imports, state: &State, ctx: &C
             col: Box::from(convert_node(col, imp, state, ctx)?),
             body: Box::from(convert_node(body, imp, state, ctx)?),
         },
-
         NodeTy::Break => Core::Break,
         NodeTy::Continue => Core::Continue,
         other => {
@@ -75,6 +68,11 @@ pub fn convert_cntrl_flow(ast: &ASTTy, imp: &mut Imports, state: &State, ctx: &C
             return Err(Box::from(UnimplementedErr::new(ast, &msg)));
         }
     })
+}
+
+fn is_valid_in_ternary(then: &Box<ASTTy>, el: &Box<ASTTy>) -> bool {
+    !matches!(then.node, NodeTy::Block { .. } | NodeTy::Raise { ..  })
+        && !matches!(el.node, NodeTy::Block { .. } | NodeTy::Raise { ..  })
 }
 
 #[cfg(test)]

--- a/tests/resource/valid/control_flow/handle_in_if.mamba
+++ b/tests/resource/valid/control_flow/handle_in_if.mamba
@@ -1,0 +1,8 @@
+def f() -> Int raise [Exception] => 10
+
+def x:= if True then
+    f() handle
+        err: Exception => 3
+else
+    f() handle
+        err: Exception => 3

--- a/tests/resource/valid/control_flow/handle_in_if_check.py
+++ b/tests/resource/valid/control_flow/handle_in_if_check.py
@@ -1,0 +1,13 @@
+def f() -> int:
+    return 10
+
+if True:
+    try:
+        x = f()
+    except Exception as err:
+        x = 3
+else:
+    try:
+        x = f()
+    except Exception as err:
+        x = 3

--- a/tests/resource/valid/control_flow/matches_in_if.mamba
+++ b/tests/resource/valid/control_flow/matches_in_if.mamba
@@ -1,0 +1,7 @@
+def x:= if True then
+    match 10
+        2 => 3
+        _ => 4
+else
+    match 20
+        _ => 2

--- a/tests/resource/valid/control_flow/matches_in_if_check.py
+++ b/tests/resource/valid/control_flow/matches_in_if_check.py
@@ -1,0 +1,10 @@
+if True:
+    match 10:
+        case 2:
+            x = 3
+        case _:
+            x = 4
+else:
+    match 20:
+        case _:
+            x = 2

--- a/tests/system/valid/control_flow.rs
+++ b/tests/system/valid/control_flow.rs
@@ -21,6 +21,11 @@ fn for_statements() -> OutTestRet {
 }
 
 #[test]
+fn handle_in_if() -> OutTestRet {
+    test_directory(true, &["control_flow"], &["control_flow", "target"], "handle_in_if")
+}
+
+#[test]
 fn for_over_collection_of_tuple() -> OutTestRet {
     test_directory(true, &["control_flow"], &["control_flow", "target"], "for_over_collection_of_tuple")
 }
@@ -60,6 +65,11 @@ fn if_two_types() -> OutTestRet {
 #[test]
 fn match_dont_remove_shadowed() -> OutTestRet {
     test_directory(true, &["control_flow"], &["control_flow", "target"], "match_dont_remove_shadowed")
+}
+
+#[test]
+fn matches_in_if() -> OutTestRet {
+    test_directory(true, &["control_flow"], &["control_flow", "target"], "matches_in_if")
 }
 
 #[test]

--- a/tests/system/valid/error.rs
+++ b/tests/system/valid/error.rs
@@ -31,7 +31,6 @@ fn nested_exception() -> OutTestRet {
 }
 
 #[test]
-#[ignore] // see #365
 fn raise() -> OutTestRet {
     test_directory(true, &["error"], &["error", "target"], "raise")
 }


### PR DESCRIPTION
### Relevant issues

- Resolves #365 

### Summary

Do a check before generating a ternary if one of the branches does not contain a node which would generate invalid Python output.
We verify that both then and else branch don't contain:
- A code block.
- A raise statement.

### Added Tests

*Happy*
- Re-add raise in one line if, verify generate Python if not ternary
- Added handle test to verify separate handle parse rule.
