### PR TITLE
Use if let else in unit tests in parse

### DIFF
--- a/src/parse/call.rs
+++ b/src/parse/call.rs
@@ -96,9 +96,8 @@ mod test {
         let source = String::from("\\ => c");
         let statements = parse_direct(&source).unwrap();
 
-        let (args, body) = match &statements.first().expect("script empty.").node {
-            Node::AnonFun { args, body } => (args.clone(), body.clone()),
-            _ => panic!("first element script was anon fun."),
+        let Node::AnonFun { args, body } = &statements.first().expect("script empty.").node else {
+            panic!("first element script was anon fun.")
         };
 
         assert_eq!(args.len(), 0);
@@ -110,9 +109,8 @@ mod test {
         let source = String::from("\\a,b => c");
         let statements = parse_direct(&source).unwrap();
 
-        let (args, body) = match &statements.first().expect("script empty.").node {
-            Node::AnonFun { args, body } => (args.clone(), body.clone()),
-            _ => panic!("first element script was anon fun."),
+        let Node::AnonFun { args, body } = &statements.first().expect("script empty.").node else {
+            panic!("first element script was anon fun.")
         };
 
         assert_eq!(args.len(), 2);
@@ -135,9 +133,8 @@ mod test {
         let source = String::from("a(b, c)");
         let statements = parse_direct(&source).unwrap();
 
-        let (name, args) = match &statements.first().expect("script empty.").node {
-            Node::FunctionCall { name, args } => (name.clone(), args.clone()),
-            _ => panic!("first element script was anon fun."),
+        let Node::FunctionCall { name, args } = &statements.first().expect("script empty.").node else {
+            panic!("first element script was anon fun.")
         };
 
         assert_eq!(name.node, Node::Id { lit: String::from("a") });

--- a/src/parse/collection.rs
+++ b/src/parse/collection.rs
@@ -109,10 +109,8 @@ mod test {
     fn tuple_empty_verify() {
         let source = String::from("()");
         let statements = parse_direct(&source).unwrap();
-
-        let elements = match &statements.first().expect("script empty.").node {
-            Node::Tuple { elements } => elements,
-            _ => panic!("first element script was not tuple.")
+        let Node::Tuple { elements } = &statements.first().expect("script empty.").node else {
+            panic!("first element script was not tuple.")
         };
 
         assert_eq!(elements.len(), 0);
@@ -122,10 +120,8 @@ mod test {
     fn tuple_single_is_expr_verify() {
         let source = String::from("(a)");
         let statements = parse_direct(&source).unwrap();
-
-        let lit = match &statements.first().expect("script empty.").node {
-            Node::Id { lit } => lit,
-            _ => panic!("first element script was not tuple.")
+        let Node::Id { lit } = &statements.first().expect("script empty.").node else {
+            panic!("first element script was not tuple.")
         };
 
         assert_eq!(lit.as_str(), "a");
@@ -135,10 +131,8 @@ mod test {
     fn tuple_multiple_verify() {
         let source = String::from("(d, c)");
         let statements = parse_direct(&source).unwrap();
-
-        let elements = match &statements.first().expect("script empty.").node {
-            Node::Tuple { elements } => elements,
-            _ => panic!("first element script was not tuple.")
+        let Node::Tuple { elements } = &statements.first().expect("script empty.").node else {
+            panic!("first element script was not tuple.")
         };
 
         assert_eq!(elements.len(), 2);
@@ -151,9 +145,8 @@ mod test {
         let source = String::from("{a, b}");
         let statements = parse_direct(&source).unwrap();
 
-        let elements = match &statements.first().expect("script empty.").node {
-            Node::Set { elements } => elements,
-            _ => panic!("first element script was not set.")
+        let Node::Set { elements } = &statements.first().expect("script empty.").node else {
+            panic!("first element script was not set.")
         };
 
         assert_eq!(elements[0].node, Node::Id { lit: String::from("a") });
@@ -165,12 +158,11 @@ mod test {
         let source = String::from("{a | c, d}");
         let statements = parse_direct(&source).unwrap();
 
-        let (items, conditions) = match &statements.first().expect("script empty.").node {
-            Node::SetBuilder { item, conditions } => (item.clone(), conditions.clone()),
-            _ => panic!("first element script was not set builder.")
+        let Node::SetBuilder { item, conditions } = &statements.first().expect("script empty.").node else {
+            panic!("first element script was not set builder.")
         };
 
-        assert_eq!(items.node, Node::Id { lit: String::from("a") });
+        assert_eq!(item.node, Node::Id { lit: String::from("a") });
 
         assert_eq!(conditions.len(), 2);
         assert_eq!(conditions[0].node, Node::Id { lit: String::from("c") });
@@ -182,9 +174,8 @@ mod test {
         let source = String::from("[a, b]");
         let statements = parse_direct(&source).unwrap();
 
-        let elements = match &statements.first().expect("script empty.").node {
-            Node::List { elements } => elements,
-            _ => panic!("first element script was not list.")
+        let Node::List { elements } = &statements.first().expect("script empty.").node else {
+            panic!("first element script was not list.")
         };
 
         assert_eq!(elements[0].node, Node::Id { lit: String::from("a") });
@@ -195,13 +186,11 @@ mod test {
     fn list_builder_verify() {
         let source = String::from("[a | c, d]");
         let statements = parse_direct(&source).unwrap();
-
-        let (items, conditions) = match &statements.first().expect("script empty.").node {
-            Node::ListBuilder { item, conditions } => (item.clone(), conditions.clone()),
-            _ => panic!("first element script was not list builder.")
+        let Node::ListBuilder { item, conditions } = &statements.first().expect("script empty.").node else {
+            panic!("first element script was not list builder.")
         };
 
-        assert_eq!(items.node, Node::Id { lit: String::from("a") });
+        assert_eq!(item.node, Node::Id { lit: String::from("a") });
 
         assert_eq!(conditions.len(), 2);
         assert_eq!(conditions[0].node, Node::Id { lit: String::from("c") });

--- a/src/parse/control_flow_expr.rs
+++ b/src/parse/control_flow_expr.rs
@@ -101,9 +101,8 @@ mod test {
         let source = String::from("if a then c else d");
         let statements = parse_direct(&source).unwrap();
 
-        let (cond, then, el) = match &statements.first().expect("script empty.").node {
-            Node::IfElse { cond, then, el } => (cond, then, el),
-            _ => panic!("first element script was not if.")
+        let Node::IfElse { cond, then, el } = &statements.first().expect("script empty.").node else {
+            panic!("first element script was not if.")
         };
 
         assert_eq!(cond.node, Node::Id { lit: String::from("a") });
@@ -116,9 +115,8 @@ mod test {
         let source = String::from("match a\n    a => b\n    c => d");
         let statements = parse_direct(&source).unwrap();
 
-        let (cond, cases) = match &statements.first().expect("script empty.").node {
-            Node::Match { cond, cases } => (cond.clone(), cases.clone()),
-            _ => panic!("first element script was not match.")
+        let Node::Match { cond, cases } = &statements.first().expect("script empty.").node else {
+            panic!("first element script was not match.")
         };
 
         assert_eq!(cond.node, Node::Id { lit: String::from("a") });
@@ -149,9 +147,8 @@ mod test {
         let source = String::from("if a then\n    b\n");
         let ast = parse_direct(&source)?;
 
-        let (cond, then, el) = match ast.first().map(|a| &a.node) {
-            Some(Node::IfElse { cond, then, el }) => (cond, then, el.clone()),
-            _ => panic!("Expected if, got {:?}", ast)
+        let Some(Node::IfElse { cond, then, el }) = ast.first().map(|a| &a.node) else {
+            panic!("Expected if, got {:?}", ast)
         };
 
         assert_eq!(cond.node, Node::Id { lit: String::from("a") });
@@ -170,9 +167,8 @@ mod test {
         let source = String::from("if a then\n    b\nelse\n    c");
         let ast = parse_direct(&source)?;
 
-        let (cond, then, el) = match ast.first().map(|a| &a.node) {
-            Some(Node::IfElse { cond, then, el }) => (cond, then, el.clone()),
-            _ => panic!("Expected if, got {:?}", ast)
+        let Some(Node::IfElse { cond, then, el }) = ast.first().map(|a| &a.node) else {
+            panic!("Expected if, got {:?}", ast)
         };
 
         assert_eq!(cond.node, Node::Id { lit: String::from("a") });
@@ -182,7 +178,7 @@ mod test {
         };
         assert_eq!(then.node, Node::Id { lit: String::from("b") });
 
-        let el = match &el.unwrap().node {
+        let el = match el.clone().unwrap().node {
             Node::Block { statements } => statements[0].clone(),
             _ => panic!("Expected then block, got {:?}", then)
         };

--- a/src/parse/expr_or_stmt.rs
+++ b/src/parse/expr_or_stmt.rs
@@ -16,12 +16,8 @@ pub fn parse_expr_or_stmt(it: &mut LexIterator) -> ParseResult {
                 it.eat(&Token::NL, "expression or statement")?;
                 it.parse(&parse_block, "expression or statement", lex.pos)
             }
-            token =>
-                if is_start_statement(token) {
-                    parse_statement(it)
-                } else {
-                    parse_expression(it)
-                },
+            token if is_start_statement(token) => parse_statement(it),
+            _ => parse_expression(it)
         },
         &[],
         "expression or statement",

--- a/src/parse/expression.rs
+++ b/src/parse/expression.rs
@@ -114,14 +114,11 @@ fn parse_post_expr(pre: &AST, it: &mut LexIterator) -> ParseResult {
                 let res = parse_index(pre, it)?;
                 parse_post_expr(&res, it)
             }
-            _ => {
-                if is_start_expression_exclude_unary(lex) {
-                    let res = parse_call(pre, it)?;
-                    parse_post_expr(&res, it)
-                } else {
-                    Ok(Box::from(pre.clone()))
-                }
+            _ if is_start_expression_exclude_unary(lex) => {
+                let res = parse_call(pre, it)?;
+                parse_post_expr(&res, it)
             }
+            _ => Ok(Box::from(pre.clone()))
         },
         Ok(Box::from(pre.clone())),
     )

--- a/src/parse/operation.rs
+++ b/src/parse/operation.rs
@@ -212,6 +212,8 @@ fn parse_level_1(it: &mut LexIterator) -> ParseResult {
 
 #[cfg(test)]
 mod test {
+    use std::convert::From;
+
     use crate::parse::{parse, parse_direct};
     use crate::parse::ast::Node;
     use crate::parse::lex::token::Token::*;

--- a/src/parse/result.rs
+++ b/src/parse/result.rs
@@ -81,10 +81,9 @@ pub fn expected_one_of(tokens: &[Token], actual: &Lex, parsing: &str) -> ParseEr
     ParseErr {
         position: actual.pos,
         msg: format!(
-            "Expected one of [{}] while parsing {}{}, but found token '{}'",
+            "Expected one of [{}] while parsing {}{parsing}, but found token '{}'",
             comma_delm(tokens),
             an_or_a(parsing),
-            parsing,
             actual.token
         ),
         source: None,
@@ -97,11 +96,9 @@ pub fn expected(expected: &Token, actual: &Lex, parsing: &str) -> ParseErr {
     ParseErr {
         position: actual.pos,
         msg: format!(
-            "Expected {}{} token while parsing {}{}, but found {}",
+            "Expected {}{expected} token while parsing {}{parsing}, but found {}",
             an_or_a(expected),
-            expected,
             an_or_a(parsing),
-            parsing,
             actual.token
         ),
         source: None,
@@ -119,18 +116,16 @@ pub fn eof_expected_one_of(tokens: &[Token], parsing: &str) -> ParseErr {
         position: Position::default(),
         msg: match tokens {
             tokens if tokens.len() > 1 => format!(
-                "Expected one of [{}] tokens while parsing {}{}",
+                "Expected one of [{}] tokens while parsing {}{parsing}",
                 comma_delm(tokens),
                 an_or_a(parsing),
-                parsing
             ),
             tokens if tokens.len() == 1 => format!(
-                "Expected a {} token while parsing {}{}",
+                "Expected a {} token while parsing {}{parsing}",
                 comma_delm(tokens),
                 an_or_a(parsing),
-                parsing
             ),
-            _ => format!("Expected a token while parsing {}{}", an_or_a(parsing), parsing),
+            _ => format!("Expected a token while parsing {}{parsing}", an_or_a(parsing)),
         },
         source: None,
         path: None,
@@ -163,9 +158,8 @@ impl Display for ParseErr {
                 };
 
                 acc + &format!(
-                    "{:3}  |- {}\n     | {}^ in {} ({}:{})\n",
+                    "{:3}  |- {source_line}\n     | {}^ in {} ({}:{})\n",
                     cause.position.start.line,
-                    source_line,
                     String::from_utf8(vec![b' '; cause.position.start.pos]).unwrap(),
                     cause.cause,
                     cause.position.start.line,

--- a/src/parse/statement.rs
+++ b/src/parse/statement.rs
@@ -197,14 +197,13 @@ mod test {
 
         assert_eq!(asts.len(), 1);
         let reassignment = asts.first().expect("reassignment");
-        let (left, right, op) = match &reassignment.node {
-            Node::Reassign { left, right, op } => (left.clone(), right.clone(), op.clone()),
-            other => panic!("Expected reassignment, was {:?}", other),
+        let Node::Reassign { left, right, op } = &reassignment.node else {
+            panic!("Expected reassignment, was {:?}", reassignment)
         };
 
         assert_eq!(left.node, Node::Id { lit: String::from("a") });
         assert_eq!(right.node, Node::Int { lit: String::from("1") });
-        assert_eq!(op, NodeOp::Assign);
+        assert_eq!(*op, NodeOp::Assign);
     }
 
     #[test]
@@ -214,19 +213,18 @@ mod test {
 
         assert_eq!(asts.len(), 1);
         let reassignment = asts.first().expect("reassignment");
-        let (left, right, op) = match &reassignment.node {
-            Node::Reassign { left, right, op } => (left.clone(), right.clone(), op.clone()),
-            other => panic!("Expected reassignment, was {:?}", other),
+        let Node::Reassign { left, right, op } = &reassignment.node else {
+            panic!("Expected reassignment, was {:?}", reassignment)
         };
 
-        let (object, property) = match &left.node {
-            Node::PropertyCall { instance, property } => (instance.clone(), property.clone()),
-            other => panic!("Expected propertycall, was {:?}", other),
+        let Node::PropertyCall { instance, property } = &left.node else {
+            panic!("Expected propertycall, was {:?}", left)
         };
-        assert_eq!(object.node, Node::Id { lit: String::from("a") });
+
+        assert_eq!(instance.node, Node::Id { lit: String::from("a") });
         assert_eq!(property.node, Node::Id { lit: String::from("b") });
 
         assert_eq!(right.node, Node::Int { lit: String::from("1") });
-        assert_eq!(op, NodeOp::Assign);
+        assert_eq!(*op, NodeOp::Assign);
     }
 }


### PR DESCRIPTION
### Summary

- Use let else construct in many unit tests
- Streamline format! macro calls.