### PR TITLE
Prettier error

### DIFF
--- a/src/check/constrain/unify/ty.rs
+++ b/src/check/constrain/unify/ty.rs
@@ -14,6 +14,7 @@ use crate::check::name::{Any, ColType, IsSuperSet, Name, Union};
 use crate::check::name::name_variant::NameVariant;
 use crate::check::result::{TypeErr, TypeResult};
 use crate::common::position::Position;
+use crate::common::result::WithCause;
 
 pub fn unify_type(
     constraint: &Constraint,
@@ -46,11 +47,9 @@ pub fn unify_type(
                 finished.push_ty(right.pos, &l_ty.union(r_ty));
                 unify_link(constraints, finished, ctx, total)
             } else if constraint.superset == ConstrVariant::Left {
-                let msg = format!("Unifying two types within {}: Expected {left}, was {right}", constraint.msg);
-                Err(vec![TypeErr::new(right.pos, &msg)])
+                Err(unify_type_message(&constraint.msg, left, right))
             } else {
-                let msg = format!("Unifying two types within {}: Expected {right}, was {left}", constraint.msg);
-                Err(vec![TypeErr::new(left.pos, &msg)])
+                Err(unify_type_message(&constraint.msg, right, left))
             }
         }
 
@@ -60,11 +59,12 @@ pub fn unify_type(
                     NameVariant::Tuple(names) => {
                         if names.len() != elements.len() {
                             let msg = format!(
-                                "Expected tuple with {} elements, was {}",
+                                "In {}, expected tuple with {} elements, was {}",
+                                constraint.msg,
                                 names.len(),
                                 elements.len()
                             );
-                            return Err(vec![TypeErr::new(left.pos, &msg)]);
+                            return Err(unify_type_message(&msg, left, right));
                         }
 
                         for pair in names.iter().cloned().zip_longest(elements.iter()) {
@@ -76,18 +76,19 @@ pub fn unify_type(
                                 }
                                 _ => {
                                     let msg = format!(
-                                        "Cannot assign {} elements to a tuple of size {}",
+                                        "In {}, Cannot assign {} elements to a tuple of size {}",
+                                        constraint.msg,
                                         elements.len(),
                                         names.len()
                                     );
-                                    return Err(vec![TypeErr::new(left.pos, &msg)]);
+                                    return Err(unify_type_message(&msg, left, right));
                                 }
                             }
                         }
                     }
                     _ => {
                         let msg = format!("Unifying type and tuple: Expected {name}, was {right}");
-                        return Err(vec![TypeErr::new(left.pos, &msg)]);
+                        return Err(unify_type_message(&msg, left, right));
                     }
                 }
             }
@@ -105,11 +106,12 @@ pub fn unify_type(
                     Both(name, exp) => constraints.push("tuple", name, exp),
                     _ => {
                         let msg = format!(
-                            "Tuple sizes differ. Expected {} elements, was {}",
+                            "In {}, Tuple sizes differ. Expected {} elements, was {}",
+                            constraint.msg,
                             l_ty.len(),
                             r_ty.len()
                         );
-                        return Err(vec![TypeErr::new(left.pos, &msg)]);
+                        return Err(unify_type_message(&msg, left, right));
                     }
                 }
             }
@@ -123,8 +125,7 @@ pub fn unify_type(
                     constraints.push("collection type", ty, &Expected::new(left.pos, &expect));
                     unify_link(constraints, finished, ctx, total + 1)
                 } else {
-                    let msg = format!("Unifying type: Expected {left}, was {right}");
-                    Err(vec![TypeErr::new(left.pos, &msg)])
+                    Err(unify_type_message(&constraint.msg, left, right))
                 }
             }
             (Type { name }, Collection { ty }) => {
@@ -133,21 +134,19 @@ pub fn unify_type(
                     constraints.push("collection type", &Expected::new(left.pos, &expect), ty);
                     unify_link(constraints, finished, ctx, total + 1)
                 } else {
-                    let msg = format!("Unifying type: Expected {left}, was {right}");
-                    Err(vec![TypeErr::new(left.pos, &msg)])
+                    Err(unify_type_message(&constraint.msg, left, right))
                 }
             }
 
-            _ => {
-                if l_exp.is_none() && r_exp.is_none() {
-                    unify_link(constraints, finished, ctx, total)
-                } else {
-                    let msg = format!("Unifying type: Expected {left}, was {right}");
-                    Err(vec![TypeErr::new(left.pos, &msg)])
-                }
-            }
+            _ if l_exp.is_none() && r_exp.is_none() => unify_link(constraints, finished, ctx, total),
+            _ => Err(unify_type_message(&constraint.msg, left, right))
         },
     }
+}
+
+pub fn unify_type_message(cause_msg: &str, sup: &Expected, child: &Expected) -> Vec<TypeErr> {
+    let msg = format!("Expected {sup}, was {child}");
+    vec![TypeErr::new(child.pos, &msg).with_cause(&cause_msg, sup.pos)]
 }
 
 fn substitute_ty(

--- a/src/check/result.rs
+++ b/src/check/result.rs
@@ -1,13 +1,13 @@
 use std::fmt;
 use std::fmt::{Display, Formatter};
 use std::hash::{Hash, Hasher};
-use std::path::{MAIN_SEPARATOR, PathBuf};
+use std::path::PathBuf;
 
 use crate::check::ast::ASTTy;
 use crate::common::position::Position;
-use crate::common::result::WithSource;
+use crate::common::result::{Cause, format_err, WithCause, WithSource};
 
-pub type TypeResult<T = ASTTy> = std::result::Result<T, Vec<TypeErr>>;
+pub type TypeResult<T = ASTTy> = Result<T, Vec<TypeErr>>;
 
 pub trait TryFromPos<T>: Sized {
     fn try_from_pos(value: T, pos: Position) -> TypeResult<Self>;
@@ -18,9 +18,21 @@ pub struct TypeErr {
     pub position: Option<Position>,
     pub msg: String,
     pub path: Option<PathBuf>,
-    pub source_before: Option<String>,
-    pub source_after: Option<String>,
-    pub source_line: Option<String>,
+    pub source: Option<String>,
+    causes: Vec<Cause>,
+}
+
+impl WithCause for TypeErr {
+    fn with_cause(self, msg: &str, pos: Position) -> Self {
+        TypeErr {
+            causes: {
+                let mut new_causes = self.causes.clone();
+                new_causes.push(Cause::new(msg, pos));
+                new_causes
+            },
+            ..self.clone()
+        }
+    }
 }
 
 impl Hash for TypeErr {
@@ -44,107 +56,37 @@ impl From<TypeErr> for Vec<TypeErr> {
 }
 
 impl TypeErr {
+    /// New TypeErr with message at given position
     pub fn new(position: Position, msg: &str) -> TypeErr {
         TypeErr {
             position: Some(position),
             msg: String::from(msg),
             path: None,
-            source_before: None,
-            source_after: None,
-            source_line: None,
+            source: None,
+            causes: vec![],
         }
     }
 
+    /// New TypeErr with message at random position
     pub fn new_no_pos(msg: &str) -> TypeErr {
         TypeErr {
             position: None,
             msg: String::from(msg),
             path: None,
-            source_before: None,
-            source_after: None,
-            source_line: None,
+            source: None,
+            causes: vec![],
         }
     }
 }
 
 impl WithSource for TypeErr {
     fn with_source(self, source: &Option<String>, path: &Option<PathBuf>) -> TypeErr {
-        let (source_before, source_line, source_after) = if let Some(position) = &self.position {
-            if let Some(source) = source {
-                (
-                    if position.start.line >= 2 {
-                        source.lines().nth(position.start.line as usize - 2)
-                    } else {
-                        None
-                    },
-                    if position.start.line >= 1 {
-                        source.lines().nth(position.start.line as usize - 1)
-                    } else {
-                        None
-                    },
-                    source.lines().nth(position.start.line as usize),
-                )
-            } else {
-                (None, None, None)
-            }
-        } else {
-            (None, None, None)
-        };
-
-        TypeErr {
-            position: self.position,
-            msg: self.msg,
-            source_before: source_before.map(String::from),
-            source_line: source_line.map(String::from),
-            source_after: source_after.map(String::from),
-            path: path.clone(),
-        }
+        TypeErr { source: source.clone(), path: path.clone(), ..self.clone() }
     }
 }
 
 impl Display for TypeErr {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-        let path = self.path.as_ref().map_or("<unknown>", |p| p.to_str().unwrap_or_default());
-
-        let msg = {
-            let mut string = String::from(self.msg.trim());
-            if string.ends_with('\n') {
-                string.remove(string.len() - 1);
-            }
-            string.replace('\n', "\n   > ")
-        };
-
-        if let Some(position) = self.position {
-            write!(
-                f,
-                "{}\n --> {}:{}:{}\n{}{:4} | {}\n       {}{}{}",
-                msg,
-                path.strip_suffix(MAIN_SEPARATOR).unwrap_or(path),
-                position.start.line,
-                position.start.pos,
-                self.source_before.clone().map_or_else(String::new, |src| if src.is_empty() {
-                    String::new()
-                } else {
-                    format!("{:4} | {}\n", position.start.line - 1, src)
-                }),
-                position.start.line,
-                self.source_line.clone().unwrap_or_else(|| String::from("<unknown>")),
-                String::from_utf8(vec![b' '; position.start.pos as usize - 1]).unwrap(),
-                String::from_utf8(vec![b'^'; position.get_width() as usize]).unwrap(),
-                self.source_after.clone().map_or(String::new(), |src| if src.is_empty() {
-                    String::new()
-                } else {
-                    format!("\n{:4} | {}\n", position.start.line + 1, src)
-                })
-            )
-        } else {
-            let path = if let Some(path) = &self.path {
-                format!("\n --> {}", path.display())
-            } else {
-                String::new()
-            };
-
-            write!(f, "{}{}", msg, path)
-        }
+        format_err(f, &self.msg, &self.path, self.position, &self.source, &self.causes)
     }
 }

--- a/src/common/result.rs
+++ b/src/common/result.rs
@@ -1,8 +1,33 @@
-use std::fmt::Display;
-use std::path::PathBuf;
+use std::cmp::max;
+use std::fmt;
+use std::fmt::{Display, Formatter};
+use std::path::{MAIN_SEPARATOR, PathBuf};
+
+use crate::common::position::Position;
+
+pub const OFFSET_WIDTH: usize = 4;
+
+pub const RIGHT_ARROW: &str = "──→";
+pub const HOOK_ARROW: &str = "└─→";
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct Cause {
+    pub pos: Position,
+    pub msg: String,
+}
+
+impl Cause {
+    pub fn new(msg: &str, position: Position) -> Cause {
+        Cause { pos: position, msg: String::from(msg) }
+    }
+}
 
 pub trait WithSource {
     fn with_source(self, source: &Option<String>, path: &Option<PathBuf>) -> Self;
+}
+
+pub trait WithCause {
+    fn with_cause(self, msg: &str, pos: Position) -> Self;
 }
 
 pub fn an_or_a<D>(parsing: D) -> &'static str where D: Display {
@@ -18,4 +43,89 @@ pub fn an_or_a<D>(parsing: D) -> &'static str where D: Display {
         Some(c) if ['a', 'e', 'i', 'o', 'u'].contains(&c.to_ascii_lowercase()) => "an ",
         _ => "a "
     }
+}
+
+
+pub fn format_err(f: &mut Formatter,
+                  msg: &str,
+                  path: &Option<PathBuf>,
+                  pos: Option<Position>,
+                  source: &Option<String>,
+                  causes: &[Cause]) -> fmt::Result {
+    let path = path.as_ref().map_or("<unknown>", |p| p.to_str().unwrap_or_default());
+
+    if let Some(pos) = pos {
+        write!(f,
+               "{msg}\n {RIGHT_ARROW} {}:{}:{}\n",
+               path.strip_suffix(MAIN_SEPARATOR).unwrap_or(path),
+               pos.start.line,
+               pos.start.pos,
+        )?;
+
+        format_location(f, 0, None, pos, source)
+    } else {
+        write!(f, "{msg}\n {RIGHT_ARROW} {}\n", path.strip_suffix(MAIN_SEPARATOR).unwrap_or(path))
+    }?;
+
+    let mut first = true;
+    for cause in causes {
+        let msg = cause.msg.as_str().clone();
+        if pos.map_or(false, |pos| pos != cause.pos) && first {
+            format_location(f, 1, Some(msg), cause.pos, source)?;
+        } else {
+            let offset_str = String::from_utf8(vec![b' '; OFFSET_WIDTH]).unwrap();
+            write!(f, "{offset_str} {HOOK_ARROW} {msg}\n")?;
+        }
+        first = false;
+    }
+
+    Ok(())
+}
+
+pub fn format_location(f: &mut Formatter,
+                       offset: usize,
+                       msg: Option<&str>,
+                       pos: Position,
+                       source: &Option<String>) -> fmt::Result {
+    let offset_str = String::from_utf8(vec![b' '; OFFSET_WIDTH * offset]).unwrap();
+
+    let msg = if let Some(msg) = msg {
+        format!("{offset_str} {HOOK_ARROW} {msg}\n")
+    } else {
+        String::new()
+    };
+
+    let (before_def, line_def, after_def) = (String::new(), String::from("<unknown>\n"), String::from("\n"));
+    let (source_before, source_line, source_after) = if let Some(source) = source {
+        let before_line_pos = max(pos.start.line as i32 - 2, usize::MAX as i32) as usize;
+        let line_pos = max(pos.start.line as i32 - 1, usize::MAX as i32) as usize;
+        let after_line_pos = max(pos.start.line, usize::MAX);
+
+        let lines = source.lines();
+        let before = lines.clone().nth(before_line_pos).map_or(before_def.clone(), |line| if line.is_empty() {
+            before_def
+        } else {
+            format!("{offset_str}{:4} | {line}\n", pos.start.line - 1)
+        });
+        let line = lines.clone().nth(line_pos).map_or(line_def.clone(), |line| if line.is_empty() {
+            line_def
+        } else {
+            format!("{offset_str}{:4} | {line}\n", pos.start.line)
+        });
+        let after = lines.clone().nth(after_line_pos).map_or(after_def.clone(), |line| if line.is_empty() {
+            after_def
+        } else {
+            format!("\n{offset_str}{:4} | {line}\n", pos.start.line + 1)
+        });
+
+        (before, line, after)
+    } else {
+        (before_def, line_def, after_def)
+    };
+
+    write!(f,
+           "{msg}{source_before}{source_line}       {}{}{source_after}",
+           String::from_utf8(vec![b' '; offset * OFFSET_WIDTH + pos.start.pos as usize - 1]).unwrap(),
+           String::from_utf8(vec![b'^'; pos.get_width() as usize]).unwrap(),
+    )
 }

--- a/src/generate/result.rs
+++ b/src/generate/result.rs
@@ -1,10 +1,10 @@
 use std::fmt;
 use std::fmt::{Display, Formatter};
-use std::path::{MAIN_SEPARATOR, PathBuf};
+use std::path::PathBuf;
 
 use crate::ASTTy;
 use crate::common::position::Position;
-use crate::common::result::WithSource;
+use crate::common::result::{format_err, WithSource};
 use crate::generate::ast::node::Core;
 
 pub type GenResult<T = Core> = Result<T, Box<UnimplementedErr>>;
@@ -15,55 +15,25 @@ const VERSION: &str = env!("CARGO_PKG_VERSION");
 pub struct UnimplementedErr {
     pub position: Position,
     pub msg: String,
-    pub source_line: Option<String>,
+    pub source: Option<String>,
     pub path: Option<PathBuf>,
 }
 
 impl UnimplementedErr {
     pub fn new(ast: &ASTTy, msg: &str) -> UnimplementedErr {
-        UnimplementedErr {
-            position: ast.pos,
-            msg: format!("The {msg} construct has not yet been implemented as of v{VERSION}."),
-            source_line: None,
-            path: None,
-        }
+        let msg = format!("The {msg} construct has not yet been implemented as of v{VERSION}.");
+        UnimplementedErr { position: ast.pos, msg, source: None, path: None }
     }
 }
 
 impl WithSource for UnimplementedErr {
-    fn with_source(
-        self,
-        source: &Option<String>,
-        path: &Option<PathBuf>,
-    ) -> UnimplementedErr {
-        UnimplementedErr {
-            position: self.position,
-            msg: self.msg.clone(),
-            source_line: source.clone().map(|source| {
-                source
-                    .lines()
-                    .nth(self.position.start.line - 1)
-                    .map_or(String::from("unknown"), String::from)
-            }),
-            path: path.clone(),
-        }
+    fn with_source(self, source: &Option<String>, path: &Option<PathBuf>) -> UnimplementedErr {
+        UnimplementedErr { source: source.clone(), path: path.clone(), ..self.clone() }
     }
 }
 
 impl Display for UnimplementedErr {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-        let path = self.path.as_ref().map_or("<unknown>", |p| p.to_str().unwrap_or_default());
-        write!(
-            f,
-            "--> {}:{}:{}\n     | {}\n{:3}  |- {}\n     | {}{}",
-            path.strip_suffix(MAIN_SEPARATOR).unwrap_or(path),
-            self.position.start.line,
-            self.position.start.pos,
-            self.msg,
-            self.position.start.line,
-            self.source_line.clone().unwrap_or_else(|| String::from("<unknown>")),
-            String::from_utf8(vec![b' '; self.position.start.pos]).unwrap(),
-            String::from_utf8(vec![b'^'; self.position.get_width()]).unwrap()
-        )
+        format_err(f, &self.msg, &self.path, Some(self.position), &self.source, &vec![])
     }
 }

--- a/src/parse/iterator.rs
+++ b/src/parse/iterator.rs
@@ -4,6 +4,7 @@ use std::slice::Iter;
 use itertools::multipeek;
 
 use crate::common::position::Position;
+use crate::common::result::WithCause;
 use crate::parse::ast::AST;
 use crate::parse::lex::token::Lex;
 use crate::parse::lex::token::Token;
@@ -85,7 +86,7 @@ impl<'a> LexIterator<'a> {
         cause: &str,
         start: Position,
     ) -> ParseResult<Box<AST>> {
-        parse_fun(self).map_err(|err| Box::from(err.clone_with_cause(cause, start)))
+        parse_fun(self).map_err(|err| Box::from(err.with_cause(cause, start)))
     }
 
     pub fn parse_vec(
@@ -94,7 +95,7 @@ impl<'a> LexIterator<'a> {
         cause: &str,
         start: Position,
     ) -> ParseResult<Vec<AST>> {
-        parse_fun(self).map_err(|err| Box::from(err.clone_with_cause(cause, start)))
+        parse_fun(self).map_err(|err| Box::from(err.with_cause(cause, start)))
     }
 
     pub fn parse_if(

--- a/src/parse/result.rs
+++ b/src/parse/result.rs
@@ -1,11 +1,11 @@
 use std::cmp::min;
 use std::fmt;
 use std::fmt::{Display, Formatter};
-use std::path::{MAIN_SEPARATOR, PathBuf};
+use std::path::PathBuf;
 
 use crate::common::delimit::comma_delm;
 use crate::common::position::Position;
-use crate::common::result::{an_or_a, WithSource};
+use crate::common::result::{an_or_a, Cause, format_err, WithCause, WithSource};
 use crate::parse::ast::AST;
 use crate::parse::lex::result::LexErr;
 use crate::parse::lex::token::Lex;
@@ -24,31 +24,17 @@ pub struct ParseErr {
     pub causes: Vec<Cause>,
 }
 
-#[derive(Debug, Clone)]
-pub struct Cause {
-    pub position: Position,
-    pub cause: String,
-}
-
-impl Cause {
-    pub fn new(cause: &str, position: Position) -> Cause {
-        Cause { position, cause: String::from(cause) }
-    }
-}
-
-impl ParseErr {
-    #[must_use]
-    pub fn clone_with_cause(&self, cause: &str, position: Position) -> ParseErr {
+impl WithCause for ParseErr {
+    fn with_cause(self, msg: &str, pos: Position) -> Self {
         ParseErr {
-            position: self.position,
-            msg: self.msg.clone(),
             causes: {
                 let mut new_causes = self.causes.clone();
-                new_causes.push(Cause::new(cause, position));
+                let msg = format!("While parsing {}{msg}", an_or_a(msg));
+
+                new_causes.push(Cause::new(&msg, pos));
                 new_causes
             },
-            source: self.source.clone(),
-            path: self.path.clone(),
+            ..self.clone()
         }
     }
 }
@@ -56,11 +42,9 @@ impl ParseErr {
 impl WithSource for ParseErr {
     fn with_source(self, source: &Option<String>, path: &Option<PathBuf>) -> ParseErr {
         ParseErr {
-            position: self.position,
-            msg: self.msg,
-            causes: self.causes,
             source: source.clone(),
             path: path.clone(),
+            ..self.clone()
         }
     }
 }
@@ -143,50 +127,7 @@ fn title_case(s: &str) -> String {
 
 impl Display for ParseErr {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-        // The first cause is the error itself
-        let cause_formatter = &self.causes[0..min(self.causes.len(), SYNTAX_ERR_MAX_DEPTH)]
-            .iter()
-            .rev()
-            .skip(1)
-            .fold(String::new(), |acc, cause| {
-                let source_line = match &self.source {
-                    Some(source) => source
-                        .lines()
-                        .nth(cause.position.start.line - 1)
-                        .unwrap_or("<unknown>"),
-                    None => "<unknown>",
-                };
-
-                acc + &format!(
-                    "{:3}  |- {source_line}\n     | {}^ in {} ({}:{})\n",
-                    cause.position.start.line,
-                    String::from_utf8(vec![b' '; cause.position.start.pos]).unwrap(),
-                    cause.cause,
-                    cause.position.start.line,
-                    cause.position.start.pos,
-                )
-            });
-
-        let path = self.path.as_ref().map_or("<unknown>", |path| path.to_str().unwrap_or_default());
-        let source_line = match &self.source {
-            Some(source) => {
-                source.lines().nth(self.position.start.line - 1).unwrap_or("<unknown>")
-            }
-            None => "<unknown>",
-        };
-
-        write!(
-            f,
-            "{}\n --> {}:{}:{}\n {:3} |- {}\n     | {}{}\n{}",
-            self.msg,
-            path.strip_suffix(MAIN_SEPARATOR).unwrap_or(path),
-            self.position.start.line,
-            self.position.start.pos,
-            self.position.start.line,
-            source_line,
-            String::from_utf8(vec![b' '; self.position.start.pos]).unwrap(),
-            String::from_utf8(vec![b'^'; self.position.get_width()]).unwrap(),
-            cause_formatter,
-        )
+        let causes = &self.causes[0..min(self.causes.len() - 1, SYNTAX_ERR_MAX_DEPTH)];
+        format_err(f, &self.msg, &self.path, Some(self.position), &self.source, causes)
     }
 }

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -126,7 +126,7 @@ fn err_output_relative_path_from_src() -> Result<(), Box<dyn std::error::Error>>
     cmd.arg("-v");
     let res = String::from_utf8(cmd.output()?.stderr)?;
 
-    let path_res_str = format!("--> {}", Path::new("src").join(Path::new("hello_world.mamba")).to_str().unwrap());
+    let path_res_str = format!("─→ {}", Path::new("src").join(Path::new("hello_world.mamba")).to_str().unwrap());
     assert!(res.contains(&path_res_str), "err msg did not contain: \"{}\"\nerr:\n{}\n\n", path_res_str, res);
     Ok(())
 }
@@ -139,7 +139,7 @@ fn err_output_relative_path_from_custom_src() -> Result<(), Box<dyn std::error::
     cmd.arg("-v").arg("--input").arg("custom_src");
     let res = String::from_utf8(cmd.output()?.stderr)?;
 
-    let path_res_str = format!("--> {}", Path::new("custom_src").join(Path::new("hello_world.mamba")).to_str().unwrap());
+    let path_res_str = format!("─→ {}", Path::new("custom_src").join(Path::new("hello_world.mamba")).to_str().unwrap());
     assert!(res.contains(&path_res_str), "err msg did not contain: \"{}\"\nerr:\n{}\n\n", path_res_str, res);
     Ok(())
 }


### PR DESCRIPTION
### Relevant issues

- Should make it easier to implement #168 
- Should make it easier to implement #167 

### Summary

For Type error messages, print the cause of an error as well.
We point to the location with which we're trying to unify for:
- Field and function access.
- Unifying two types.

Streamline print error logic so that it is stored in a single location.
Both simpler logic, and less chance of inconsistent error messages.

