### PR TITLE
Remove unused ConstrVariant

### DIFF
--- a/src/check/constrain/constraint/builder.rs
+++ b/src/check/constrain/constraint/builder.rs
@@ -136,7 +136,7 @@ impl ConstrBuilder {
         }
 
         let lvls = comma_delm(lvls);
-        trace!("Constr[{}]: {} == {}, {}: {}", lvls, constraint.left.pos, constraint.right.pos, constraint.msg, constraint);
+        trace!("Constr[{}]: {} == {}, {}: {}", lvls, constraint.parent.pos, constraint.child.pos, constraint.msg, constraint);
     }
 
     pub fn all_constr(self) -> Vec<Constraints> {

--- a/src/check/constrain/constraint/iterator.rs
+++ b/src/check/constrain/constraint/iterator.rs
@@ -42,9 +42,9 @@ impl Constraints {
             // Can only reinsert constraint once
             let msg = format!(
                 "Cannot infer type within {}. Expected a {}, was {}",
-                constraint.msg, &constraint.left.expect, &constraint.right.expect
+                constraint.msg, &constraint.parent.expect, &constraint.child.expect
             );
-            return Err(vec![TypeErr::new(constraint.left.pos, &msg)]);
+            return Err(vec![TypeErr::new(constraint.parent.pos, &msg)]);
         }
 
         self.constraints.push_back(constraint.flag());

--- a/src/check/constrain/unify/expression/mod.rs
+++ b/src/check/constrain/unify/expression/mod.rs
@@ -1,7 +1,7 @@
 use EitherOrBoth::Both;
 use itertools::{EitherOrBoth, Itertools};
 
-use crate::check::constrain::constraint::{Constraint, ConstrVariant};
+use crate::check::constrain::constraint::Constraint;
 use crate::check::constrain::constraint::expected::Expect::{Expression, Tuple};
 use crate::check::constrain::constraint::expected::Expected;
 use crate::check::constrain::constraint::iterator::Constraints;
@@ -16,7 +16,7 @@ use crate::parse::ast::{AST, Node};
 pub mod substitute;
 
 pub fn unify_expression(constraint: &Constraint, constraints: &mut Constraints, finished: &mut Finished, ctx: &Context, count: usize, total: usize) -> Unified {
-    let (left, right) = (&constraint.left, &constraint.right);
+    let (left, right) = (&constraint.parent, &constraint.child);
     match (&left.expect, &right.expect) {
         // Not sure if necessary, but exception made for tuple
         (Tuple { elements }, Expression { ast: AST { node: Node::Tuple { elements: ast_elements }, .. } }) |
@@ -37,8 +37,7 @@ pub fn unify_expression(constraint: &Constraint, constraints: &mut Constraints, 
             }
         }
 
-        (Expression { .. }, _) if constraint.superset == ConstrVariant::Left =>
-            substitute(constraints, right, left, count, total)?,
+        (Expression { .. }, _) => substitute(constraints, right, left, count, total)?,
         _ => substitute(constraints, left, right, count, total)?
     }
 

--- a/src/check/constrain/unify/expression/substitute.rs
+++ b/src/check/constrain/unify/expression/substitute.rs
@@ -27,7 +27,7 @@ pub fn substitute(
         constraint_pos += 1;
         macro_rules! replace {
             ($left:expr, $new:expr) => {{
-                let pos = format!("({}={}) ", constr.left.pos, constr.right.pos);
+                let pos = format!("({}={}) ", constr.parent.pos, constr.child.pos);
                 let side = if $left { "l" } else { "r" };
                 trace!(
                     "{:width$} [subbed {}\\{} {}]  {}  =>  {}",
@@ -42,11 +42,11 @@ pub fn substitute(
             }};
         }
 
-        let (sub_l, left) = recursive_substitute("l", &constr.left, old, new);
-        let (sub_r, right) = recursive_substitute("r", &constr.right, old, new);
+        let (sub_l, left) = recursive_substitute("l", &constr.parent, old, new);
+        let (sub_r, right) = recursive_substitute("r", &constr.child, old, new);
 
-        constr.left = left;
-        constr.right = right;
+        constr.parent = left;
+        constr.child = right;
         if sub_l || sub_r {
             replace!(sub_l, constr)
         }

--- a/src/check/constrain/unify/function.rs
+++ b/src/check/constrain/unify/function.rs
@@ -3,7 +3,7 @@ use std::collections::HashSet;
 
 use itertools::{EitherOrBoth, enumerate, Itertools};
 
-use crate::check::constrain::constraint::{Constraint, ConstrVariant};
+use crate::check::constrain::constraint::Constraint;
 use crate::check::constrain::constraint::expected::Expect::{Access, Field, Function, Type};
 use crate::check::constrain::constraint::expected::Expected;
 use crate::check::constrain::constraint::iterator::Constraints;
@@ -29,7 +29,7 @@ pub fn unify_function(
     ctx: &Context,
     total: usize,
 ) -> Unified {
-    let (left, right) = (&constraint.left, &constraint.right);
+    let (left, right) = (&constraint.parent, &constraint.child);
     match (&left.expect, &right.expect) {
         (Function { args, .. }, Type { name }) | (Type { name }, Function { args, .. }) => {
             let arguments_union: Vec<Vec<Name>> = name
@@ -75,8 +75,7 @@ pub fn unify_function(
         (_, Access { entity, name }) =>
             access(constraints, finished, ctx, constraint, entity, name, false, total),
 
-        _ if constraint.superset == ConstrVariant::Left => Err(unify_type_message(&constraint.msg, left, right)),
-        _ => Err(unify_type_message(&constraint.msg, right, left))
+        _ => Err(unify_type_message(&constraint.msg, left, right))
     }
 }
 
@@ -91,7 +90,7 @@ fn access(
     access_left: bool,
     total: usize,
 ) -> Unified {
-    let (left, right) = (&constraint.left, &constraint.right);
+    let (left, right) = (&constraint.parent, &constraint.child);
     let (left, right) = if access_left { (left, right) } else { (right, left) };
 
     if let Type { name: entity_name } = &entity.expect {

--- a/src/check/constrain/unify/link.rs
+++ b/src/check/constrain/unify/link.rs
@@ -17,7 +17,7 @@ use crate::check::context::Context;
 /// constraints each time we do a recursive call to unify link.
 pub fn unify_link(constraints: &mut Constraints, finished: &mut Finished, ctx: &Context, total: usize) -> Unified {
     if let Some(constraint) = &constraints.pop_constr() {
-        let (left, right) = (&constraint.left, &constraint.right);
+        let (left, right) = (&constraint.parent, &constraint.child);
 
         let pos = format!("{}={} ", left.pos, right.pos);
         let count = if constraints.len() <= total { total - constraints.len() } else { 0 };
@@ -70,7 +70,7 @@ pub fn unify_link(constraints: &mut Constraints, finished: &mut Finished, ctx: &
 /// The amount of attempts is a counter which states how often we allow
 /// reinserts.
 pub fn reinsert(constr: &mut Constraints, constraint: &Constraint, total: usize) -> Unified<()> {
-    let pos = format!("({}={}) ", constraint.left.pos.start, constraint.right.pos.start);
+    let pos = format!("({}={}) ", constraint.parent.pos.start, constraint.child.pos.start);
     let count = format!("[reinserting {}\\{}] ", total - constr.len(), total);
     trace!("{:width$}{}{}", pos, count, constraint, width = 17);
 


### PR DESCRIPTION
### Relevant issues

- Streamlines #439 

### Summary

Instead commit to the parent-child heuristic we have used anyway up until this point.
Turns out that we don't need to switch around parent child in constraints, we just need better substitution rules, such as in #438 .

