### PR TITLE
Use variables directly in `format!` macro

### DIFF
--- a/src/check/context/arg/mod.rs
+++ b/src/check/context/arg/mod.rs
@@ -32,7 +32,7 @@ impl Display for FunctionArg {
             f,
             "{}{}{}",
             self.name,
-            if let Some(ty) = &self.ty { format!(": {}", ty) } else { String::new() },
+            if let Some(ty) = &self.ty { format!(": {ty}") } else { String::new() },
             if self.has_default { "?" } else { "" }
         )
     }

--- a/src/check/context/clss/mod.rs
+++ b/src/check/context/clss/mod.rs
@@ -165,8 +165,8 @@ impl LookupClass<&StringName, Class> for Context {
                 // Tuple and collection exception, variable generic count
                 let mut generic_keys: Vec<Name> = vec![];
                 for (i, gen) in enumerate(&class.generics) {
-                    generic_keys.push(Name::from(format!("G{}", i).as_str()));
-                    generics.insert(Name::from(format!("G{}", i).as_str()), gen.clone());
+                    generic_keys.push(Name::from(format!("G{i}").as_str()));
+                    generics.insert(Name::from(format!("G{i}").as_str()), gen.clone());
                 }
 
                 let name = StringName::new(class.name.as_str(), &generic_keys);
@@ -183,11 +183,11 @@ impl LookupClass<&StringName, Class> for Context {
                         generics.insert(placeholder.clone(), name.clone());
                     }
                     EitherOrBoth::Left(placeholder) => {
-                        let msg = format!("No argument for generic {} in {}", placeholder, class);
+                        let msg = format!("No argument for generic {placeholder} in {class}");
                         return Err(vec![TypeErr::new(pos, &msg)]);
                     }
                     EitherOrBoth::Right(placeholder) => {
-                        let msg = format!("Gave unexpected generic {} to {}", placeholder, class);
+                        let msg = format!("Gave unexpected generic {placeholder} to {class}");
                         return Err(vec![TypeErr::new(pos, &msg)]);
                     }
                 }
@@ -195,7 +195,7 @@ impl LookupClass<&StringName, Class> for Context {
 
             Class::try_from((generic_class, &generics, pos))
         } else {
-            let msg = format!("Type '{}' is undefined.", class);
+            let msg = format!("Type '{class}' is undefined.");
             Err(vec![TypeErr::new(pos, &msg)])
         }
     }
@@ -272,7 +272,7 @@ impl GetField<Field> for Class {
                 return Ok(ok);
             }
         }
-        Err(vec![TypeErr::new(pos, &format!("'{}' does not define '{}'", self, name))])
+        Err(vec![TypeErr::new(pos, &format!("'{self}' does not define '{name}'"))])
     }
 }
 
@@ -291,7 +291,7 @@ impl GetFun<Function> for Class {
                 return Ok(function);
             }
         }
-        Err(vec![TypeErr::new(pos, &format!("'{}' does not define '{}'", self, name))])
+        Err(vec![TypeErr::new(pos, &format!("'{self}' does not define '{name}'"))])
     }
 }
 

--- a/src/check/context/function/mod.rs
+++ b/src/check/context/function/mod.rs
@@ -6,7 +6,7 @@ use std::hash::{Hash, Hasher};
 
 use itertools::{EitherOrBoth, Itertools};
 
-use crate::check::context::{arg, Context, function, LookupFunction};
+use crate::check::context::{arg, Context, LookupFunction};
 use crate::check::context::arg::FunctionArg;
 use crate::check::context::clss::Class;
 use crate::check::context::function::generic::GenericFunction;
@@ -35,10 +35,10 @@ pub const POW: &str = "^";
 pub const SUB: &str = "-";
 pub const SQRT: &str = "sqrt";
 
-pub const STR: &str = function::python::STR;
-pub const TRUTHY: &str = function::python::TRUTHY;
-pub const NEXT: &str = function::python::NEXT;
-pub const ITER: &str = function::python::ITER;
+pub const STR: &str = python::STR;
+pub const TRUTHY: &str = python::TRUTHY;
+pub const NEXT: &str = python::NEXT;
+pub const ITER: &str = python::ITER;
 
 pub mod union;
 pub mod generic;
@@ -74,7 +74,7 @@ impl LookupFunction<&StringName, Function> for Context {
             let class = Class::try_from((generic_class, &generics, pos))?;
             Ok(class.constructor(true))
         } else {
-            let msg = format!("Function {} is undefined.", function);
+            let msg = format!("Function {function} is undefined.");
             Err(vec![TypeErr::new(pos, &msg)])
         }
     }
@@ -103,7 +103,7 @@ impl Display for Function {
         } else {
             format!(" raises [{}]", &self.raises)
         };
-        write!(f, "{: >8} : ({}){}{}", self.name, comma_delm(&self.arguments), ret, raises)
+        write!(f, "{: >8} : ({}){ret}{raises}", self.name, comma_delm(&self.arguments))
     }
 }
 
@@ -160,18 +160,17 @@ impl Function {
                     if let Some(arg_ty) = &fun_param.ty {
                         if !arg_ty.is_superset_of(arg, ctx, pos)? {
                             let msg = format!(
-                                "'{}' given to argument {}, which expected a '{}'",
-                                arg, fun_param, arg_ty
+                                "'{arg}' given to argument {fun_param}, which expected a '{arg_ty}'"
                             );
                             return Err(vec![TypeErr::new(pos, &msg)]);
                         }
                     } else {
-                        let msg = format!("Type of function parameter {} unknown.", fun_param);
+                        let msg = format!("Type of function parameter {fun_param} unknown.");
                         return Err(vec![TypeErr::new(pos, &msg)]);
                     },
                 EitherOrBoth::Left(fun_param) =>
                     if !fun_param.has_default {
-                        let msg = format!("Expected an argument for {}.", fun_param);
+                        let msg = format!("Expected an argument for {fun_param}.");
                         return Err(vec![TypeErr::new(pos, &msg)]);
                     },
                 EitherOrBoth::Right(_) => {

--- a/src/common/delimit.rs
+++ b/src/common/delimit.rs
@@ -10,7 +10,7 @@ pub fn custom_delimited<I, D>(iterable: I, delimiter: &str, prepend: &str) -> St
     }
 
     let mut s = String::from(prepend);
-    iterable.into_iter().for_each(|item| write!(&mut s, "{}{}", item, delimiter).unwrap());
+    iterable.into_iter().for_each(|item| write!(&mut s, "{item}{delimiter}").unwrap());
     String::from(s.trim_end_matches(delimiter))
 }
 

--- a/src/io.rs
+++ b/src/io.rs
@@ -50,7 +50,7 @@ pub fn relative_files(in_path: &Path) -> Result<Vec<OsString>, String> {
     let pattern_path = in_path.to_owned().join("**").join("*.mamba");
     let pattern = pattern_path.as_os_str().to_string_lossy();
     let glob = glob(pattern.as_ref())
-        .map_err(|e| format!("Unable to recursively find files: {}", e))?;
+        .map_err(|e| format!("Unable to recursively find files: {e}"))?;
 
     let mut relative_paths = vec![];
     for absolute_result in glob {

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,7 +15,7 @@ const VERSION: &str = env!("CARGO_PKG_VERSION");
 
 pub fn main() -> Result<(), String> {
     #[cfg(windows)]
-        ansi_term::enable_ansi_support().unwrap();
+    ansi_term::enable_ansi_support().unwrap();
 
     let yaml = load_yaml!("cli.yml");
     let matches = App::from_yaml(yaml).version(VERSION).get_matches();
@@ -37,13 +37,13 @@ pub fn main() -> Result<(), String> {
 
     info!("Mamba 🐍 {}", VERSION);
     let current_dir = std::env::current_dir().map_err(|err| {
-        error!("Error while finding current directory: {}", err);
-        format!("Error while finding current directory: {}", err)
+        error!("Error while finding current directory: {err}");
+        format!("Error while finding current directory: {err}")
     })?;
 
     transpile_dir(&current_dir, in_path, out_path, &arguments)
         .map_err(|errors| {
-            errors.iter().unique().for_each(|msg| eprintln!("{}", msg));
+            errors.iter().unique().for_each(|msg| eprintln!("{msg}"));
             match errors.first() {
                 Some(msg) => msg.clone(),
                 None => String::new()

--- a/src/parse/lex/tokenize.rs
+++ b/src/parse/lex/tokenize.rs
@@ -224,7 +224,7 @@ pub fn into_tokens(c: char, it: &mut Peekable<Chars>, state: &mut State) -> LexR
             state.space();
             Ok(vec![])
         }
-        c => Err(LexErr::new(state.pos, None, &format!("unrecognized character: {}", c))),
+        c => Err(LexErr::new(state.pos, None, &format!("unrecognized character: {c}"))),
     }
 }
 


### PR DESCRIPTION
### Summary

Gets rid of last nightly clippy errors.
