### PR TITLE
Check assigned to in if and match branches

### DIFF
--- a/src/check/constrain/generate/control_flow.rs
+++ b/src/check/constrain/generate/control_flow.rs
@@ -61,7 +61,7 @@ pub fn gen_flow(
             }
 
             constr.reset_branches();
-            Ok(then_env.union(&else_env))
+            Ok(env.intersection(&then_env.union(&else_env)))
         }
         Node::IfElse { cond, then, .. } => {
             constr.add_constr(&Constraint::truthy("if condition", &Expected::from(cond)), env);

--- a/src/check/constrain/generate/env.rs
+++ b/src/check/constrain/generate/env.rs
@@ -141,4 +141,39 @@ impl Environment {
         unassigned.remove(var);
         Environment { unassigned, ..self.clone() }
     }
+
+    /// Union with unassigned of other.
+    pub fn union(&self, other: &Environment) -> Environment {
+        let unassigned = self.unassigned.union(&other.unassigned);
+        Environment { unassigned: unassigned.cloned().collect(), ..self.clone() }
+    }
+
+    /// Intersection with unassigned of other.
+    pub fn intersection(&self, other: &Environment) -> Environment {
+        let unassigned = self.unassigned.intersection(&other.unassigned);
+        Environment { unassigned: unassigned.cloned().collect(), ..self.clone() }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashSet;
+
+    use crate::check::constrain::generate::env::Environment;
+
+    #[test]
+    fn union_unassigned() {
+        let (env1, env2) = (Environment::default(), Environment::default());
+        let env1 = env1.with_unassigned(HashSet::from([String::from("a")]));
+        let env2 = env2.with_unassigned(HashSet::from([String::from("a")]));
+        assert_eq!(env1.unassigned.len(), 1);
+
+        let env1 = env1.assigned_to(&String::from("a"));
+        assert_eq!(env1.unassigned.len(), 0);
+        assert_eq!(env2.unassigned.len(), 1);
+
+        let env3 = env1.union(&env2);
+        assert!(env3.unassigned.contains(&String::from("a")));
+        assert_eq!(env3.unassigned.len(), 1);
+    }
 }

--- a/src/parse/ast/node.rs
+++ b/src/parse/ast/node.rs
@@ -36,7 +36,9 @@ impl Display for Node {
                 format!("{}", id.node)
             },
             Node::Parent { .. } => String::from("parent"),
-            Node::Reassign { .. } => String::from("reassign"),
+            Node::Reassign { left, right, op } => {
+                format!("{} {} {}", left.node, op, right.node)
+            }
             Node::VariableDef { .. } => String::from("variable definition"),
             Node::FunDef { .. } => String::from("function definition"),
             Node::AnonFun { .. } => String::from("anonymous function"),

--- a/tests/check/invalid/control_flow.rs
+++ b/tests/check/invalid/control_flow.rs
@@ -74,3 +74,15 @@ fn undefined_var_in_match_arm() {
     let source = resource_content(false, &["type", "control_flow"], "undefined_var_in_match_arm.mamba");
     check_all(&[*parse(&source).unwrap()]).unwrap_err();
 }
+
+#[test]
+fn variable_defined_in_then() {
+    let source = resource_content(false, &["type", "control_flow"], "variable_defined_in_then.mamba");
+    check_all(&[*parse(&source).unwrap()]).unwrap_err();
+}
+
+#[test]
+fn variable_defined_in_else() {
+    let source = resource_content(false, &["type", "control_flow"], "variable_defined_in_else.mamba");
+    check_all(&[*parse(&source).unwrap()]).unwrap_err();
+}

--- a/tests/check/invalid/control_flow.rs
+++ b/tests/check/invalid/control_flow.rs
@@ -10,6 +10,24 @@ fn access_match_arms_variable() {
 }
 
 #[test]
+fn class_field_assigned_to_only_one_arm_match() {
+    let source = resource_content(false, &["type", "control_flow"], "class_field_assigned_to_only_one_arm_match.mamba");
+    check_all(&[*parse(&source).unwrap()]).unwrap_err();
+}
+
+#[test]
+fn class_field_assigned_to_only_then() {
+    let source = resource_content(false, &["type", "control_flow"], "class_field_assigned_to_only_then.mamba");
+    check_all(&[*parse(&source).unwrap()]).unwrap_err();
+}
+
+#[test]
+fn class_field_assigned_to_only_else() {
+    let source = resource_content(false, &["type", "control_flow"], "class_field_assigned_to_only_else.mamba");
+    check_all(&[*parse(&source).unwrap()]).unwrap_err();
+}
+
+#[test]
 fn float_and() {
     let source = resource_content(false, &["type", "control_flow"], "float_and.mamba");
     check_all(&[*parse(&source).unwrap()]).unwrap_err();

--- a/tests/resource/invalid/type/control_flow/class_field_assigned_to_only_else.mamba
+++ b/tests/resource/invalid/type/control_flow/class_field_assigned_to_only_else.mamba
@@ -1,0 +1,8 @@
+class MyClass
+    def x: Int
+
+    def __init__(self) =>
+        if False then
+            print("something")
+        else
+            self.x := 10

--- a/tests/resource/invalid/type/control_flow/class_field_assigned_to_only_one_arm_match.mamba
+++ b/tests/resource/invalid/type/control_flow/class_field_assigned_to_only_one_arm_match.mamba
@@ -1,0 +1,10 @@
+class MyClass
+    def x: Int
+
+    def __init__(self) =>
+        match 10
+            2 => self.x := 2
+            3 => self.x := 3
+            4 => print("o")
+            5 => print("o")
+            _ => print("p")

--- a/tests/resource/invalid/type/control_flow/class_field_assigned_to_only_then.mamba
+++ b/tests/resource/invalid/type/control_flow/class_field_assigned_to_only_then.mamba
@@ -1,0 +1,8 @@
+class MyClass
+    def x: Int
+
+    def __init__(self) =>
+        if False then
+            self.x := 10
+        else
+            print("something")

--- a/tests/resource/invalid/type/control_flow/variable_defined_in_else.mamba
+++ b/tests/resource/invalid/type/control_flow/variable_defined_in_else.mamba
@@ -1,0 +1,6 @@
+if False then
+    print("something")
+else
+    def x := 10
+
+x + 10

--- a/tests/resource/invalid/type/control_flow/variable_defined_in_then.mamba
+++ b/tests/resource/invalid/type/control_flow/variable_defined_in_then.mamba
@@ -1,0 +1,6 @@
+if False then
+    def x := 10
+else
+    print("something")
+
+x + 10

--- a/tests/resource/valid/control_flow/class_field_assigned_to_both_branches_if.mamba
+++ b/tests/resource/valid/control_flow/class_field_assigned_to_both_branches_if.mamba
@@ -1,0 +1,8 @@
+class MyClass
+    def x: Int
+
+    def __init__(self) =>
+        if False then
+            self.x := 10
+        else
+            self.x := 20

--- a/tests/resource/valid/control_flow/class_field_assigned_to_both_branches_if_check.py
+++ b/tests/resource/valid/control_flow/class_field_assigned_to_both_branches_if_check.py
@@ -1,0 +1,8 @@
+class MyClass:
+    x: int = None
+
+    def __init__(self):
+        if False:
+            self.x = 10
+        else:
+            self.x = 20

--- a/tests/resource/valid/control_flow/class_field_assigned_to_exhaustive_match.mamba
+++ b/tests/resource/valid/control_flow/class_field_assigned_to_exhaustive_match.mamba
@@ -1,0 +1,8 @@
+class MyClass
+    def x: Int
+
+    def __init__(self) =>
+        match 10
+            2 => self.x := 2
+            3 => self.x := 3
+            _ => self.x := 3

--- a/tests/resource/valid/control_flow/class_field_assigned_to_exhaustive_match_check.py
+++ b/tests/resource/valid/control_flow/class_field_assigned_to_exhaustive_match_check.py
@@ -1,0 +1,11 @@
+class MyClass:
+    x: int = None
+
+    def __init__(self):
+        match 10:
+            case 2:
+                self.x = 2
+            case 3:
+                self.x = 3
+            case _:
+                self.x = 3

--- a/tests/system/valid/control_flow.rs
+++ b/tests/system/valid/control_flow.rs
@@ -11,6 +11,16 @@ fn assign_match() -> OutTestRet {
 }
 
 #[test]
+fn class_field_assigned_to_both_branches_if() -> OutTestRet {
+    test_directory(true, &["control_flow"], &["control_flow", "target"], "class_field_assigned_to_both_branches_if")
+}
+
+#[test]
+fn class_field_assigned_to_exhaustive_match() -> OutTestRet {
+    test_directory(true, &["control_flow"], &["control_flow", "target"], "class_field_assigned_to_exhaustive_match")
+}
+
+#[test]
 fn double_assign_if() -> OutTestRet {
     test_directory(true, &["control_flow"], &["control_flow", "target"], "double_assign_if")
 }


### PR DESCRIPTION
## Relevant issues

- Resolves #449 

In future we can perhaps use this logic to also de-nullify types (i.e. `Str? -> Str`) as we move towards implementing type refinement
- #96 

## Summary

If we assign to a variable of a class in all possible execution paths of the constructor, we consider it to be assigned to.

`Environment` intersection and union functions only perform operations on the "must be assigned to" set.
All other items in the `Environment` are left untouched.
That is because
- Shadowing logic is partially implemented in the constraint builder
- We don't want full unions of environments because we don't consider a variable to be declared even if it is declared in all branches (even if this is valid in Python).
  We only consider a variable to be declared if it is declared _in scope_.

## Added Tests

**Happy**
- Assing to class var in all branches of match
- Assign to class var in all branches of if

**Sad**
- Definition does not leak out of then branch...
- ...And else branch of if
- Assign to clas var in only then branch...
- ...And else branch of if
- Assigng to class var in only some branches of match