### PR TITLE
Feat: Simplify, with token becomes where token in match

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -106,7 +106,7 @@ has its own README worth reading before making non-trivial changes there (`src/p
 
 ## Block syntax (post indent/dedent removal)
 
-`for`/`while`/`with` bodies always require an explicit `do ... end` block — there is no single-statement
+`for`/`while`/`where` (resource) bodies always require an explicit `do ... end` block — there is no single-statement
 shorthand for these three (`for a in b do c` is a parse error; it must be `for a in b do c end`). `if`/`then`/
 `else` branches are the exception: each branch is parsed as one `parse_expr_or_stmt`, which accepts either a
 bare single statement/expression or an explicit `do ... end` block (`if a then do ... end else c` is valid).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -106,7 +106,7 @@ has its own README worth reading before making non-trivial changes there (`src/p
 
 ## Block syntax (post indent/dedent removal)
 
-`for`/`while`/`where` (resource) bodies always require an explicit `do ... end` block — there is no single-statement
+`for`/`while`/`using` bodies always require an explicit `do ... end` block — there is no single-statement
 shorthand for these three (`for a in b do c` is a parse error; it must be `for a in b do c end`). `if`/`then`/
 `else` branches are the exception: each branch is parsed as one `parse_expr_or_stmt`, which accepts either a
 bare single statement/expression or an explicit `do ... end` block (`if a then do ... end else c` is valid).

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ We can write a simple script that computes the factorial of a value given by the
 
 ```mamba
 # Factorial of x
-def factorial(x: Int) -> Int := match x with
+def factorial(x: Int) -> Int := match x where
     0 => 1
     n => n * factorial(n - 1)
 end
@@ -98,13 +98,13 @@ This means that the compiler will check for us that factorial is only used with 
 Also note that:
 
 - Code blocks are denoted using `do` and `end` because this is a list of statements and expressions that gets executed _in order_.
-- For a match expression or statement we denote cases starting with `with` and ending with `end`, as this is a _set_ of cases which we match on.
-  You can read `match x with ... end`, where we read this as "match `x` on this set of conditions in `with ... end`".
+- For a match expression or statement we denote cases starting with `where` and ending with `end`, as this is a _set_ of cases which we match on.
+  You can read `match x where ... end`, where we read this as "match `x` on this set of conditions in `where ... end`".
 
 _Note_ One could use [dynamic programming](https://en.wikipedia.org/wiki/Dynamic_programming) in the above example so that we consume less memory:
 
 ```mamba
-def factorial(x: Int) -> Int := match x with
+def factorial(x: Int) -> Int := match x where
     0 => 1
     n => do
         def ans := 1
@@ -392,7 +392,7 @@ Take for instance this naive implementation of the Fibonacci sequence:
 
 ```mamba
 ## Fibonacci, implemented using recursion and not dynamic programming
-def total pure fibonacci(x: PosInt) -> Int := match x with
+def total pure fibonacci(x: PosInt) -> Int := match x where
     0 => 0
     1 => 1
     n => fibonacci(n - 1) + fibonacci(n - 2)
@@ -549,7 +549,7 @@ This also prevents us from wrapping large code blocks in a `try`, where it might
 Under the hood, `<call> ! where <cases> end` desugars to a plain `match` on the call's result:
 
 ```mamba
-match m.last_op() with
+match m.last_op() where
     err: MatrixErr(message) => print("Error when getting last op: \"{message}\"")
 end
 ```

--- a/docs/features/control_flow/control_flow_expression.md
+++ b/docs/features/control_flow/control_flow_expression.md
@@ -43,18 +43,18 @@ We can even match based on the type of the returned expression.
 
 A `match` has the form:
 
-    match <expression> with { <expression> => <expression or statement> }
+    match <expression> where { <expression> => <expression or statement> }
 
 An example would be (if `b` is a number):
 
-    match b with
+    match b where
         1 => print "one"
         4 => print "four"
         5 => print "five"
 
 We can also add a default case if:
 
-    match b with
+    match b where
         1 => print "one"
         4 => print "four"
         5 => print "five"
@@ -69,6 +69,6 @@ This can be achieved by either exhaustively covering every possible value, or by
 
 So, a `match` _expression_ has the form:
 
-    match <expression> with { <expression> => <expression> }
+    match <expression> where { <expression> => <expression> }
 
 With the additional requirement that we have an arm for every possible value of a given input type.

--- a/docs/spec/grammar.md
+++ b/docs/spec/grammar.md
@@ -34,6 +34,7 @@ The grammar of the language in Extended Backus-Naur Form (EBNF).
                       | trait-def
                       | class-def
                       | import
+                      | using-block
                       | "return" [ expression ]
                       | code-set
     expression       ::= control-flow-expr 
@@ -101,14 +102,17 @@ The grammar of the language in Extended Backus-Naur Form (EBNF).
     
     code-block       ::= "do" expr-or-stmt { newline expr-or-stmt } "end" 
     code-set         ::= "where" expr-or-stmt { newline expr-or-stmt } "end"
+    using-block      ::= "using" expression { "as" expression } code-block
     
     control-flow-expr::= if | match
     if               ::= "if" expression "then" expression [ "else" expression ]
-    match            ::= "match" expression "where" map
+    match            ::= "match" expression "where" match-cases
+    match-cases      ::= "where" { match-case } "end"
+    match-case       ::= expression "=>" expression
     
     control-flow-stmt::= while | foreach | "break" | "continue"
-    while            ::= "while" expression "do" expression
-    foreach          ::= "for" expression "in" expression "do" expression
+    while            ::= "while" expression code-block
+    foreach          ::= "for" expression "in" expression code-block
     
     newline          ::= <platform dependent>
 ```

--- a/docs/spec/grammar.md
+++ b/docs/spec/grammar.md
@@ -104,7 +104,7 @@ The grammar of the language in Extended Backus-Naur Form (EBNF).
     
     control-flow-expr::= if | match
     if               ::= "if" expression "then" expression [ "else" expression ]
-    match            ::= "match" expression "with" map
+    match            ::= "match" expression "where" map
     
     control-flow-stmt::= while | foreach | "break" | "continue"
     while            ::= "while" expression "do" expression

--- a/docs/spec/reserved.md
+++ b/docs/spec/reserved.md
@@ -87,8 +87,10 @@ Keyword | Use
 ## Blocks
 
 Keyword | Use
+---|---
 `end`   | Denote end of code block or set
 `where` | Denote start of code set
+`using` | Denote start of a resource block, binding an alias for the duration of its body
 
 ## 3.2.2 Special Characters
 

--- a/src/backend/python/convert/mod.rs
+++ b/src/backend/python/convert/mod.rs
@@ -247,7 +247,7 @@ pub fn convert_node(ast: &ASTTy, imp: &mut Imports, state: &State, ctx: &Context
 
         NodeTy::Condition { .. } => return Err(Box::from(UnimplementedErr::new(ast, "condition"))),
 
-        NodeTy::With {
+        NodeTy::Using {
             resource,
             alias: Some((alias, ..)),
             expr,
@@ -266,7 +266,7 @@ pub fn convert_node(ast: &ASTTy, imp: &mut Imports, state: &State, ctx: &Context
                 expr: Box::from(scope_guarded(expr, expr_core)),
             }
         }
-        NodeTy::With { resource, expr, .. } => {
+        NodeTy::Using { resource, expr, .. } => {
             let expr_core = convert_node(expr, imp, state, ctx)?;
             PythonCore::With {
                 resource: Box::from(convert_node(resource, imp, state, ctx)?),
@@ -803,7 +803,7 @@ mod tests {
     }
 
     #[test]
-    fn with_verify() {
+    fn using_verify() {
         let resource = to_pos!(Node::Id {
             lit: String::from("my_resource")
         });
@@ -817,7 +817,7 @@ mod tests {
         let expr = to_pos!(Node::Int {
             lit: String::from("9")
         });
-        let with = to_pos!(Node::With {
+        let using = to_pos!(Node::Using {
             resource,
             alias,
             expr
@@ -827,9 +827,9 @@ mod tests {
             resource,
             alias,
             expr,
-        }) = gen(&ASTTy::from(&with))
+        }) = gen(&ASTTy::from(&using))
         else {
-            panic!("Expected with as but was {:?}", gen(&ASTTy::from(&with)))
+            panic!("Expected with as but was {:?}", gen(&ASTTy::from(&using)))
         };
 
         assert_eq!(
@@ -909,20 +909,20 @@ mod tests {
     }
 
     #[test]
-    fn with_no_as_verify() {
+    fn using_no_as_verify() {
         let resource = to_pos!(Node::Id {
             lit: String::from("other")
         });
         let expr = to_pos!(Node::Int {
             lit: String::from("2341")
         });
-        let with = to_pos!(Node::With {
+        let using = to_pos!(Node::Using {
             resource,
             alias: None,
             expr
         });
 
-        let (resource, expr) = match gen(&ASTTy::from(&with)) {
+        let (resource, expr) = match gen(&ASTTy::from(&using)) {
             Ok(PythonCore::With { resource, expr }) => (resource, expr),
             other => panic!("Expected with but was {other:?}"),
         };

--- a/src/check/ast/mod.rs
+++ b/src/check/ast/mod.rs
@@ -128,7 +128,7 @@ pub enum NodeTy {
         expr_or_stmt: Box<ASTTy>,
         cases: Vec<ASTTy>,
     },
-    With {
+    Using {
         resource: Box<ASTTy>,
         alias: Option<(Box<ASTTy>, bool, OptName)>,
         expr: Box<ASTTy>,

--- a/src/check/ast/node.rs
+++ b/src/check/ast/node.rs
@@ -130,11 +130,11 @@ impl From<(&Node, &Finished)> for NodeTy {
                     .map(|ast| ASTTy::from((ast, finished)))
                     .collect(),
             },
-            Node::With {
+            Node::Using {
                 resource,
                 alias,
                 expr,
-            } => NodeTy::With {
+            } => NodeTy::Using {
                 resource: Box::from(ASTTy::from((resource, finished))),
                 alias: alias.clone().map(|(resource, alias, expr)| {
                     let resource = Box::from(ASTTy::from((resource, finished)));

--- a/src/check/constrain/generate/mod.rs
+++ b/src/check/constrain/generate/mod.rs
@@ -65,7 +65,7 @@ pub fn generate(
         AnonFun { .. } => gen_expr(ast, env, ctx, constr),
         Pass => gen_expr(ast, env, ctx, constr),
 
-        With { .. } => gen_resources(ast, env, ctx, constr),
+        Using { .. } => gen_resources(ast, env, ctx, constr),
 
         SetBuilder { .. } | ListBuilder { .. } | DictBuilder { .. } => {
             gen_coll(ast, env, ctx, constr)

--- a/src/check/constrain/generate/resources.rs
+++ b/src/check/constrain/generate/resources.rs
@@ -18,19 +18,19 @@ pub fn gen_resources(
     constr: &mut ConstrBuilder,
 ) -> Constrained {
     match &ast.node {
-        Node::With {
+        Node::Using {
             resource,
             alias: Some((alias, mutable, ty)),
             expr,
         } => {
             constr.add(
-                "with alias",
+                "using alias",
                 &Expected::from(resource),
                 &Expected::from(alias),
                 env,
             );
             constr.add(
-                "with resource",
+                "using resource",
                 &Expected::from(resource),
                 &Expected::any(resource.pos),
                 env,
@@ -41,7 +41,7 @@ pub fn gen_resources(
                     name: Name::try_from(ty)?,
                 };
                 constr.add(
-                    "with alias type",
+                    "using alias type",
                     &Expected::from(resource),
                     &Expected::new(ty.pos, &ty_exp),
                     env,
@@ -71,9 +71,9 @@ pub fn gen_resources(
 
             Ok(env.clone())
         }
-        Node::With { resource, expr, .. } => {
+        Node::Using { resource, expr, .. } => {
             constr.add(
-                "with",
+                "using",
                 &Expected::from(resource),
                 &Expected::any(resource.pos),
                 env,

--- a/src/parse/ast/mod.rs
+++ b/src/parse/ast/mod.rs
@@ -96,7 +96,7 @@ pub enum Node {
         expr_or_stmt: Box<AST>,
         cases: Vec<AST>,
     },
-    With {
+    Using {
         resource: Box<AST>,
         alias: Option<(Box<AST>, bool, Option<Box<AST>>)>,
         expr: Box<AST>,

--- a/src/parse/ast/node.rs
+++ b/src/parse/ast/node.rs
@@ -46,7 +46,7 @@ impl Display for Node {
             Node::AnonFun { .. } => String::from("anonymous function"),
             Node::Raise { .. } => String::from("raise"),
             Node::Handle { .. } => String::from("handle"),
-            Node::With { .. } => String::from("with"),
+            Node::Using { .. } => String::from("using"),
             Node::FunctionCall { name, args } => {
                 format!(
                     "{}({})",
@@ -240,11 +240,11 @@ impl Node {
                 expr_or_stmt: Box::from(expr_or_stmt.map(mapping)),
                 cases: cases.iter().map(|c| c.map(mapping)).collect(),
             },
-            Node::With {
+            Node::Using {
                 resource,
                 alias,
                 expr,
-            } => Node::With {
+            } => Node::Using {
                 resource: Box::from(resource.map(mapping)),
                 alias: alias.map(|(resource, alias, expr)| {
                     (
@@ -561,12 +561,12 @@ impl Node {
                 },
             ) => les.same_value(res) && equal_vec(lc, rc),
             (
-                Node::With {
+                Node::Using {
                     resource: lr,
                     alias: Some((la, lmut, lty)),
                     expr: le,
                 },
-                Node::With {
+                Node::Using {
                     resource: rr,
                     alias: Some((ra, rmut, rty)),
                     expr: re,
@@ -579,12 +579,12 @@ impl Node {
                     && le.same_value(re)
             }
             (
-                Node::With {
+                Node::Using {
                     resource: lr,
                     alias: None,
                     expr: le,
                 },
-                Node::With {
+                Node::Using {
                     resource: rr,
                     alias: None,
                     expr: re,
@@ -1382,7 +1382,7 @@ mod test {
             cases: vec![*first.clone()],
             expr_or_stmt: second.clone()
         });
-        two_ast!(Node::With {
+        two_ast!(Node::Using {
             resource: first.clone(),
             alias: Some((second.clone(), false, Some(third.clone()))),
             expr: Box::from(AST::new(Position::invisible(), Node::Pass))

--- a/src/parse/control_flow_expr.rs
+++ b/src/parse/control_flow_expr.rs
@@ -52,7 +52,7 @@ fn parse_match(it: &mut LexIterator) -> ParseResult {
     it.eat(&Token::Match, "match")?;
     let cond = it.parse(&parse_expression, "match", start)?;
     it.eat_while(&Token::NL);
-    it.eat(&Token::With, "match")?;
+    it.eat(&Token::Where, "match")?;
     it.eat_while(&Token::NL);
     let cases = it.parse_vec(&parse_match_cases, "match", start)?;
     let end = cases.last().cloned().map_or(cond.pos, |case| case.pos);
@@ -145,7 +145,7 @@ mod test {
 
     #[test]
     fn match_verify() {
-        let source = String::from("match a with\n    a => b\n    c => d\nend");
+        let source = String::from("match a where\n    a => b\n    c => d\nend");
         let statements = parse_direct(&source).unwrap();
 
         let Node::Match { cond, cases } = &statements.first().expect("script empty.").node else {
@@ -285,7 +285,7 @@ mod test {
 
     #[test]
     fn match_missing_arms() {
-        let source = String::from("match a with\n    ");
+        let source = String::from("match a where\n    ");
         parse_direct(&source).unwrap_err();
     }
 

--- a/src/parse/lex/token.rs
+++ b/src/parse/lex/token.rs
@@ -109,7 +109,6 @@ pub enum Token {
     Continue,
     Break,
     Ret,
-    With,
 
     Question,
 
@@ -235,7 +234,6 @@ impl fmt::Display for Token {
             Token::Break => write!(f, "break"),
             Token::Ret => write!(f, "return"),
             Token::Do => write!(f, "do"),
-            Token::With => write!(f, "with"),
 
             Token::Question => write!(f, "?"),
 

--- a/src/parse/lex/token.rs
+++ b/src/parse/lex/token.rs
@@ -109,6 +109,7 @@ pub enum Token {
     Continue,
     Break,
     Ret,
+    Using,
 
     Question,
 
@@ -234,6 +235,7 @@ impl fmt::Display for Token {
             Token::Break => write!(f, "break"),
             Token::Ret => write!(f, "return"),
             Token::Do => write!(f, "do"),
+            Token::Using => write!(f, "using"),
 
             Token::Question => write!(f, "?"),
 

--- a/src/parse/lex/tokenize.rs
+++ b/src/parse/lex/tokenize.rs
@@ -260,6 +260,7 @@ fn as_op_or_id(string: String) -> Token {
         "return" => Token::Ret,
         "then" => Token::Then,
         "do" => Token::Do,
+        "using" => Token::Using,
 
         "in" => Token::In,
         "when" => Token::When,

--- a/src/parse/lex/tokenize.rs
+++ b/src/parse/lex/tokenize.rs
@@ -260,7 +260,6 @@ fn as_op_or_id(string: String) -> Token {
         "return" => Token::Ret,
         "then" => Token::Then,
         "do" => Token::Do,
-        "with" => Token::With,
 
         "in" => Token::In,
         "when" => Token::When,

--- a/src/parse/statement.rs
+++ b/src/parse/statement.rs
@@ -27,7 +27,7 @@ pub fn parse_statement(it: &mut LexIterator) -> ParseResult {
                 Ok(Box::from(AST::new(lex.pos.union(error.pos), node)))
             }
             Token::Def => parse_definition(it),
-            Token::With => parse_with(it),
+            Token::Where => parse_with(it),
             Token::For | Token::While => parse_cntrl_flow_stmt(it),
             Token::Ret => parse_return(it),
             _ => Err(Box::from(expected_one_of(
@@ -35,7 +35,7 @@ pub fn parse_statement(it: &mut LexIterator) -> ParseResult {
                     Token::Pass,
                     Token::Raise,
                     Token::Def,
-                    Token::With,
+                    Token::Where,
                     Token::For,
                     Token::While,
                     Token::Ret,
@@ -48,7 +48,7 @@ pub fn parse_statement(it: &mut LexIterator) -> ParseResult {
             Token::Pass,
             Token::Raise,
             Token::Def,
-            Token::With,
+            Token::Where,
             Token::For,
             Token::While,
             Token::Ret,
@@ -161,7 +161,7 @@ pub fn parse_reassignment(pre: &AST, it: &mut LexIterator) -> ParseResult {
 
 pub fn parse_with(it: &mut LexIterator) -> ParseResult {
     let start = it.start_pos("with")?;
-    it.eat(&Token::With, "with")?;
+    it.eat(&Token::Where, "with")?;
     let resource = it.parse(&parse_expression, "with", start)?;
 
     let alias = it.parse_if(&Token::As, &parse_expression_type, "with id", start)?;
@@ -212,7 +212,7 @@ pub fn is_start_statement(tp: &Token) -> bool {
             | Token::While
             | Token::Pass
             | Token::Raise
-            | Token::With
+            | Token::Where
             | Token::Ret
     )
 }

--- a/src/parse/statement.rs
+++ b/src/parse/statement.rs
@@ -27,7 +27,7 @@ pub fn parse_statement(it: &mut LexIterator) -> ParseResult {
                 Ok(Box::from(AST::new(lex.pos.union(error.pos), node)))
             }
             Token::Def => parse_definition(it),
-            Token::Where => parse_with(it),
+            Token::Using => parse_using(it),
             Token::For | Token::While => parse_cntrl_flow_stmt(it),
             Token::Ret => parse_return(it),
             _ => Err(Box::from(expected_one_of(
@@ -35,7 +35,7 @@ pub fn parse_statement(it: &mut LexIterator) -> ParseResult {
                     Token::Pass,
                     Token::Raise,
                     Token::Def,
-                    Token::Where,
+                    Token::Using,
                     Token::For,
                     Token::While,
                     Token::Ret,
@@ -48,7 +48,7 @@ pub fn parse_statement(it: &mut LexIterator) -> ParseResult {
             Token::Pass,
             Token::Raise,
             Token::Def,
-            Token::Where,
+            Token::Using,
             Token::For,
             Token::While,
             Token::Ret,
@@ -159,12 +159,12 @@ pub fn parse_reassignment(pre: &AST, it: &mut LexIterator) -> ParseResult {
     Ok(Box::from(AST::new(start.union(right.pos), node)))
 }
 
-pub fn parse_with(it: &mut LexIterator) -> ParseResult {
-    let start = it.start_pos("with")?;
-    it.eat(&Token::Where, "with")?;
-    let resource = it.parse(&parse_expression, "with", start)?;
+pub fn parse_using(it: &mut LexIterator) -> ParseResult {
+    let start = it.start_pos("using")?;
+    it.eat(&Token::Using, "using")?;
+    let resource = it.parse(&parse_expression, "using", start)?;
 
-    let alias = it.parse_if(&Token::As, &parse_expression_type, "with id", start)?;
+    let alias = it.parse_if(&Token::As, &parse_expression_type, "using id", start)?;
     let alias = if let Some(alias) = &alias {
         match alias.node.clone() {
             Node::ExpressionType { expr, mutable, ty } => Some((expr, mutable, ty)),
@@ -174,9 +174,9 @@ pub fn parse_with(it: &mut LexIterator) -> ParseResult {
         None
     };
 
-    let expr = it.parse(&parse_block, "with", start)?;
+    let expr = it.parse(&parse_block, "using", start)?;
 
-    let node = Node::With {
+    let node = Node::Using {
         resource,
         alias,
         expr: expr.clone(),
@@ -212,7 +212,7 @@ pub fn is_start_statement(tp: &Token) -> bool {
             | Token::While
             | Token::Pass
             | Token::Raise
-            | Token::Where
+            | Token::Using
             | Token::Ret
     )
 }

--- a/tests/resource/invalid/type/control_flow/access_match_arms_variable.mamba
+++ b/tests/resource/invalid/type/control_flow/access_match_arms_variable.mamba
@@ -1,4 +1,4 @@
-match 10 with
+match 10 where
     n => print("10")
 end
 

--- a/tests/resource/invalid/type/control_flow/class_field_assigned_to_only_one_arm_match.mamba
+++ b/tests/resource/invalid/type/control_flow/class_field_assigned_to_only_one_arm_match.mamba
@@ -1,7 +1,7 @@
 class MyClass where
     def x: Int
 
-    def __init__(self) := match 10 with
+    def __init__(self) := match 10 where
         2 => self.x := 2
         3 => self.x := 3
         4 => print("o")

--- a/tests/resource/invalid/type/control_flow/different_type_shadow.mamba
+++ b/tests/resource/invalid/type/control_flow/different_type_shadow.mamba
@@ -1,4 +1,4 @@
-match 10 with
+match 10 where
     n =>
         print(x)
 end

--- a/tests/resource/invalid/type/control_flow/undefined_var_in_match_arm.mamba
+++ b/tests/resource/invalid/type/control_flow/undefined_var_in_match_arm.mamba
@@ -1,4 +1,4 @@
-match 10 with
+match 10 where
     n =>
         print(x)
 end

--- a/tests/resource/invalid/type/error/unhandled_exception.mamba
+++ b/tests/resource/invalid/type/error/unhandled_exception.mamba
@@ -1,7 +1,7 @@
 class MyException1(msg: String): Exception(msg)
 class MyException2(msg: String): Exception(msg)
 
-def f(x: Int) -> Int ! { MyException1, MyException2 } := match x with
+def f(x: Int) -> Int ! { MyException1, MyException2 } := match x where
     0 => 20
     1 => ! MyException1()
     2 => ! MyException2()

--- a/tests/resource/invalid/type/error/using_old_resource_in_with.mamba
+++ b/tests/resource/invalid/type/error/using_old_resource_in_with.mamba
@@ -1,5 +1,5 @@
 def old := 10
 
-with old as new do
+where old as new do
     print(old + 10)
 end

--- a/tests/resource/invalid/type/error/using_old_resource_in_with.mamba
+++ b/tests/resource/invalid/type/error/using_old_resource_in_with.mamba
@@ -1,5 +1,5 @@
 def old := 10
 
-where old as new do
+using old as new do
     print(old + 10)
 end

--- a/tests/resource/invalid/type/error/with_not_expression.mamba
+++ b/tests/resource/invalid/type/error/with_not_expression.mamba
@@ -1,5 +1,5 @@
 def not_an_expression() := print("not an expression")
 
-where not_an_expression() as my_expression do
+using not_an_expression() as my_expression do
     print("not an expression!")
 end

--- a/tests/resource/invalid/type/error/with_not_expression.mamba
+++ b/tests/resource/invalid/type/error/with_not_expression.mamba
@@ -1,5 +1,5 @@
 def not_an_expression() := print("not an expression")
 
-with not_an_expression() as my_expression do
+where not_an_expression() as my_expression do
     print("not an expression!")
 end

--- a/tests/resource/invalid/type/error/with_wrong_type.mamba
+++ b/tests/resource/invalid/type/error/with_wrong_type.mamba
@@ -1,5 +1,5 @@
 def my_string := "my string"
 
-with my_string as my_int: Int do
+where my_string as my_int: Int do
     print("error")
 end

--- a/tests/resource/invalid/type/error/with_wrong_type.mamba
+++ b/tests/resource/invalid/type/error/with_wrong_type.mamba
@@ -1,5 +1,5 @@
 def my_string := "my string"
 
-where my_string as my_int: Int do
+using my_string as my_int: Int do
     print("error")
 end

--- a/tests/resource/valid/control_flow/assign_match.mamba
+++ b/tests/resource/valid/control_flow/assign_match.mamba
@@ -1,5 +1,5 @@
 def c := True
-def my_var := match c with
+def my_var := match c where
     True => 10
     False => 20
 end

--- a/tests/resource/valid/control_flow/class_field_assigned_to_exhaustive_match.mamba
+++ b/tests/resource/valid/control_flow/class_field_assigned_to_exhaustive_match.mamba
@@ -2,7 +2,7 @@ class MyClass where
     def x: Int
 
     def __init__(self) :=
-        match 10 with
+        match 10 where
             2 => self.x := 2
             3 => self.x := 3
             _ => self.x := 3

--- a/tests/resource/valid/control_flow/match_dont_remove_shadowed.mamba
+++ b/tests/resource/valid/control_flow/match_dont_remove_shadowed.mamba
@@ -1,6 +1,6 @@
 def n := 10
 
-match 10 with
+match 10 where
     n =>
         print("10")
 end

--- a/tests/resource/valid/control_flow/match_stmt.mamba
+++ b/tests/resource/valid/control_flow/match_stmt.mamba
@@ -2,18 +2,18 @@ def a := "d"
 
 def (b, bb, bbb) := (0, 1, 2)
 
-match (b, bb, bbb) with
+match (b, bb, bbb) where
     (0, 1, 2) => print("hello world")
 end
 
 def nested := "other"
 
-match nested with
+match nested where
     "a" => do
         "b"
         "c"
     end
-    "c" => match nested with
+    "c" => match nested where
         "other" => "even_other"
         "other_one" => "better_one"
         _ => "default"

--- a/tests/resource/valid/control_flow/matches_in_if.mamba
+++ b/tests/resource/valid/control_flow/matches_in_if.mamba
@@ -1,9 +1,9 @@
 def x:= if True then
-    match 10 with
+    match 10 where
         2 => 3
         _ => 4
     end
 else
-    match 20 with
+    match 20 where
         _ => 2
     end

--- a/tests/resource/valid/definition/assign_with_match.mamba
+++ b/tests/resource/valid/definition/assign_with_match.mamba
@@ -1,4 +1,4 @@
-def a := match 40 with
+def a := match 40 where
     2 => 3
     4 => 30
     _ => 300

--- a/tests/resource/valid/definition/assign_with_match_different_types.mamba
+++ b/tests/resource/valid/definition/assign_with_match_different_types.mamba
@@ -2,7 +2,7 @@ class MyClass
 class MyClass1
 class MyClass2
 
-def a:= match 40 with
+def a:= match 40 where
     2 => MyClass()
     4 => MyClass1()
     _ => MyClass2()

--- a/tests/resource/valid/definition/assign_with_match_type_annotation.mamba
+++ b/tests/resource/valid/definition/assign_with_match_type_annotation.mamba
@@ -1,4 +1,4 @@
-def a: Int := match 40 with
+def a: Int := match 40 where
     2 => 3
     4 => 30
     _ => 300

--- a/tests/resource/valid/definition/function_with_match.mamba
+++ b/tests/resource/valid/definition/function_with_match.mamba
@@ -1,5 +1,5 @@
 def f(x: Int) -> Int :=
-    match x with
+    match x where
         2 => 3
         4 => 30
         _ => 300

--- a/tests/resource/valid/error/nested_exception.mamba
+++ b/tests/resource/valid/error/nested_exception.mamba
@@ -2,7 +2,7 @@ class MyException1(msg: Str): Exception(msg)
 class MyException2(msg: Str): Exception(msg)
 
 def f(x: Int) -> Int ! { MyException1, MyException2 } :=
-    match x with
+    match x where
         0 => 20
         1 => ! MyException1()
         2 => ! MyException2()

--- a/tests/resource/valid/error/with.mamba
+++ b/tests/resource/valid/error/with.mamba
@@ -2,14 +2,14 @@ def do_something(x: Int) := print("hello world {x}")
 
 def my_resource := 10
 
-where my_resource as other do
+using my_resource as other do
     do_something(other)
 end
 
-where my_resource as yet_another: Int do
+using my_resource as yet_another: Int do
     do_something(yet_another)
 end
 
-where my_resource do
+using my_resource do
     do_something(my_resource)
 end

--- a/tests/resource/valid/error/with.mamba
+++ b/tests/resource/valid/error/with.mamba
@@ -2,14 +2,14 @@ def do_something(x: Int) := print("hello world {x}")
 
 def my_resource := 10
 
-with my_resource as other do
+where my_resource as other do
     do_something(other)
 end
 
-with my_resource as yet_another: Int do
+where my_resource as yet_another: Int do
     do_something(yet_another)
 end
 
-with my_resource do
+where my_resource do
     do_something(my_resource)
 end

--- a/tests/resource/valid/function/match_function.mamba
+++ b/tests/resource/valid/function/match_function.mamba
@@ -1,4 +1,4 @@
-def f(x: Int) -> Str := match x with
+def f(x: Int) -> Str := match x where
     1 => "One"
     2 => "Two"
     _ => "Three"

--- a/tests/resource/valid/readme_example/error_handling_desyntax_sugared.mamba
+++ b/tests/resource/valid/readme_example/error_handling_desyntax_sugared.mamba
@@ -1,3 +1,3 @@
-match m.last_op() with
+match m.last_op() where
     err: MatrixErr(message) => print("Error when getting last op: \"{message}\"")
 end

--- a/tests/resource/valid/readme_example/factorial.mamba
+++ b/tests/resource/valid/readme_example/factorial.mamba
@@ -1,5 +1,5 @@
 # Factorial of x
-def factorial(x: Int) -> Int := match x with
+def factorial(x: Int) -> Int := match x where
     0 => 1
     n => n * factorial(n - 1)
 end

--- a/tests/resource/valid/readme_example/factorial_dynamic.mamba
+++ b/tests/resource/valid/readme_example/factorial_dynamic.mamba
@@ -1,4 +1,4 @@
-def factorial(x: Int) -> Int := match x with
+def factorial(x: Int) -> Int := match x where
     0 => 1
     n => do
         def ans := 1

--- a/tests/resource/valid/readme_example/pure_functions.mamba
+++ b/tests/resource/valid/readme_example/pure_functions.mamba
@@ -1,4 +1,4 @@
-def factorial(x: Int) -> Int := match x with
+def factorial(x: Int) -> Int := match x where
     0 => 1
     n => n * factorial(n - 1)
 end

--- a/tests/resource/valid/readme_example/total_functions.mamba
+++ b/tests/resource/valid/readme_example/total_functions.mamba
@@ -1,5 +1,5 @@
 ## Fibonacci, implemented using recursion and not dynamic programming
-def total pure fibonacci(x: PosInt) -> Int := match x with
+def total pure fibonacci(x: PosInt) -> Int := match x where
     0 => 0
     1 => 1
     n => fibonacci(n - 1) + fibonacci(n - 2)


### PR DESCRIPTION
### Summary

With did almost the same, lets simplify the language. This makes more clear that 'do' is for imperative, and where is for those places where the order does not matter.

### Added Tests

Tests update to reflect the change.

